### PR TITLE
fix(web): route non-json API fetches through timeout helper

### DIFF
--- a/ui/src/api/analysisExport.ts
+++ b/ui/src/api/analysisExport.ts
@@ -1,0 +1,31 @@
+import { apiFetchBlob } from './fetch';
+import { triggerBlobDownload } from './download';
+
+/** Only the formats the backend actually implements (no xlsx/pdf). */
+export type ExportFormat = 'csv' | 'json';
+
+export const EXPORT_FORMATS: readonly ExportFormat[] = ['csv', 'json'];
+
+export interface ExportResult {
+  format: ExportFormat;
+  filename: string;
+  size_bytes: number;
+}
+
+/**
+ * Export analysis data through the shared timeout/error-handled fetch path.
+ */
+export async function downloadAnalysisExport(format: ExportFormat): Promise<ExportResult> {
+  const blob = await apiFetchBlob('/api/analysis/export', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      format,
+      include_metrics: true,
+      include_time_series: true,
+    }),
+  });
+  const filename = `analysis_export.${format}`;
+  triggerBlobDownload(blob, filename);
+  return { format, filename, size_bytes: blob.size };
+}

--- a/ui/src/api/backend.ts
+++ b/ui/src/api/backend.ts
@@ -11,23 +11,10 @@
  * See issue #6637.
  */
 
-/** Single source of truth for the Python backend port (issue #6637). */
-export const BACKEND_PORT = 8000;
+import { apiFetch } from './fetch';
+import { BACKEND_PORT, isTauri } from './base';
 
-/**
- * Returns the base URL for the Python API.
- *
- * - In Tauri mode the UI and backend are on different origins, so we
- *   return `http://localhost:BACKEND_PORT`.
- * - In browser/Vite mode the dev-server proxies `/api` so we return
- *   an empty string (relative URLs work fine).
- */
-export function getApiBase(): string {
-  if (isTauri()) {
-    return `http://localhost:${BACKEND_PORT}`;
-  }
-  return '';
-}
+export { BACKEND_PORT, getApiBase, isTauri } from './base';
 
 export interface BackendStatus {
   running: boolean;
@@ -42,11 +29,6 @@ export interface DiagnosticInfo {
   python_version: string | null;
   repo_root: string | null;
   local_server_found: boolean;
-}
-
-/** Check if we are running inside a Tauri window. */
-export function isTauri(): boolean {
-  return '__TAURI_INTERNALS__' in window;
 }
 
 async function invoke<T>(cmd: string): Promise<T> {
@@ -83,15 +65,8 @@ export async function getBackendStatus(): Promise<BackendStatus> {
 export async function getDiagnostics(): Promise<DiagnosticInfo> {
   if (!isTauri()) {
     // In browser mode, call the backend API endpoint.
-    // NOTE: cannot use apiFetch here — fetch.ts imports getApiBase from this
-    // module, so importing apiFetch back would create a circular dependency.
-    // We build the URL via getApiBase() directly to stay Tauri-safe (#6897).
     try {
-      const response = await fetch(`${getApiBase()}/api/diagnostics`);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      return await response.json();
+      return await apiFetch<DiagnosticInfo>('/api/diagnostics');
     } catch (error) {
       // Fallback if backend is not available
       return {

--- a/ui/src/api/base.ts
+++ b/ui/src/api/base.ts
@@ -1,0 +1,29 @@
+/**
+ * Dependency-free API base URL helpers.
+ *
+ * Keep this module free of imports from higher-level API helpers so request
+ * wrappers and backend lifecycle code can both depend on it without cycles.
+ */
+
+/** Single source of truth for the Python backend port (issue #6637). */
+export const BACKEND_PORT = 8000;
+
+/** Check if we are running inside a Tauri window. */
+export function isTauri(): boolean {
+  return '__TAURI_INTERNALS__' in window;
+}
+
+/**
+ * Returns the base URL for the Python API.
+ *
+ * - In Tauri mode the UI and backend are on different origins, so we
+ *   return `http://localhost:BACKEND_PORT`.
+ * - In browser/Vite mode the dev-server proxies `/api` so we return
+ *   an empty string (relative URLs work fine).
+ */
+export function getApiBase(): string {
+  if (isTauri()) {
+    return `http://localhost:${BACKEND_PORT}`;
+  }
+  return '';
+}

--- a/ui/src/api/download.ts
+++ b/ui/src/api/download.ts
@@ -1,0 +1,15 @@
+/** Browser download helpers shared by API modules and components. */
+
+export function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  try {
+    link.click();
+  } finally {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+}

--- a/ui/src/api/fetch.ts
+++ b/ui/src/api/fetch.ts
@@ -16,7 +16,7 @@
  *   });
  */
 
-import { getApiBase } from './backend';
+import { getApiBase } from './base';
 
 /**
  * Default request timeout (issue #8080).
@@ -62,6 +62,75 @@ function buildSignal(
   return timeoutSignal;
 }
 
+function formatFetchError(
+  path: string,
+  timeoutMs: number,
+  err: unknown,
+): Error {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    return new Error(`Request timed out after ${timeoutMs}ms — ${path}`);
+  }
+  if (err instanceof DOMException && err.name === 'AbortError') {
+    return new Error(`Request aborted — ${path}`);
+  }
+  return new Error(
+    err instanceof Error ? err.message : `Network error for ${path}`,
+  );
+}
+
+async function responseError(response: Response, path: string): Promise<Error> {
+  let detail: string | undefined;
+  try {
+    const body = (await response.json()) as Record<string, unknown>;
+    if (typeof body.detail === 'string') {
+      detail = body.detail;
+    }
+  } catch {
+    // Body was not valid JSON — that's fine, fall through to generic message.
+  }
+  return new Error(detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`);
+}
+
+/**
+ * apiFetchRaw — shared request helper for non-JSON success bodies.
+ *
+ * Use this when callers need to consume `text()`, `blob()`, or another
+ * response body type while keeping the same timeout and FastAPI error contract
+ * as `apiFetch`.
+ */
+export async function apiFetchRaw(
+  path: string,
+  init?: ApiFetchInit,
+): Promise<Response> {
+  const url = `${getApiBase()}${path}`;
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...requestInit,
+      signal: buildSignal(timeoutMs, requestInit.signal),
+    });
+  } catch (err) {
+    throw formatFetchError(path, timeoutMs, err);
+  }
+
+  if (!response.ok) {
+    throw await responseError(response, path);
+  }
+
+  return response;
+}
+
+/** Fetch a non-JSON endpoint and return its blob body. */
+export async function apiFetchBlob(
+  path: string,
+  init?: ApiFetchInit,
+): Promise<Blob> {
+  const response = await apiFetchRaw(path, init);
+  return response.blob();
+}
+
 /**
  * apiFetch<T> — typed HTTP helper with consistent error handling.
  *
@@ -76,44 +145,10 @@ export async function apiFetch<T>(
   path: string,
   init?: ApiFetchInit,
 ): Promise<T> {
-  const url = `${getApiBase()}${path}`;
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
-
-  const mergedInit: RequestInit = {
+  const response = await apiFetchRaw(path, {
+    ...init,
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
-    ...requestInit,
-    signal: buildSignal(timeoutMs, requestInit.signal),
-  };
-
-  let response: Response;
-  try {
-    response = await fetch(url, mergedInit);
-  } catch (err) {
-    if (err instanceof DOMException && err.name === 'TimeoutError') {
-      throw new Error(`Request timed out after ${timeoutMs}ms — ${path}`);
-    }
-    if (err instanceof DOMException && err.name === 'AbortError') {
-      throw new Error(`Request aborted — ${path}`);
-    }
-    // Network-level error (no response at all)
-    throw new Error(
-      err instanceof Error ? err.message : `Network error for ${path}`,
-    );
-  }
-
-  if (!response.ok) {
-    // Attempt to extract a FastAPI-style `detail` field
-    let detail: string | undefined;
-    try {
-      const body = (await response.json()) as Record<string, unknown>;
-      if (typeof body.detail === 'string') {
-        detail = body.detail;
-      }
-    } catch {
-      // Body was not valid JSON — that's fine, fall through to generic message
-    }
-    throw new Error(detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`);
-  }
+  });
 
   return response.json() as Promise<T>;
 }
@@ -154,29 +189,6 @@ export async function apiFetchParsed<T>(
  * @returns Parsed JSON body typed as `T`
  */
 export async function apiFetchForm<T>(path: string, formData: FormData): Promise<T> {
-  const url = `${getApiBase()}${path}`;
-
-  let response: Response;
-  try {
-    response = await fetch(url, { method: 'POST', body: formData });
-  } catch (err) {
-    throw new Error(
-      err instanceof Error ? err.message : `Network error for ${path}`,
-    );
-  }
-
-  if (!response.ok) {
-    let detail: string | undefined;
-    try {
-      const body = (await response.json()) as Record<string, unknown>;
-      if (typeof body.detail === 'string') {
-        detail = body.detail;
-      }
-    } catch {
-      // ignore
-    }
-    throw new Error(detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`);
-  }
-
+  const response = await apiFetchRaw(path, { method: 'POST', body: formData });
   return response.json() as Promise<T>;
 }

--- a/ui/src/api/fetchTimeout.test.ts
+++ b/ui/src/api/fetchTimeout.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiFetch, DEFAULT_TIMEOUT_MS } from './fetch';
+import { apiFetch, apiFetchBlob, apiFetchRaw, DEFAULT_TIMEOUT_MS } from './fetch';
 
 function jsonResponse(body: unknown): Response {
   return {
@@ -32,6 +32,16 @@ describe('apiFetch timeout (#8080)', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await apiFetch('/api/anything');
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('passes an AbortSignal for raw response callers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiFetchRaw('/api/export');
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
@@ -124,5 +134,21 @@ describe('apiFetch timeout (#8080)', () => {
       } as unknown as Response),
     );
     await expect(apiFetch('/api/bad')).rejects.toThrow('Method Not Allowed');
+  });
+
+  it('extracts FastAPI detail for raw and blob callers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: () => Promise.resolve({ detail: 'Invalid export request' }),
+      } as unknown as Response),
+    );
+
+    await expect(apiFetchBlob('/api/export')).rejects.toThrow(
+      'Invalid export request',
+    );
   });
 });

--- a/ui/src/api/fetchTimeout.test.ts
+++ b/ui/src/api/fetchTimeout.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiFetch, apiFetchBlob, apiFetchRaw, DEFAULT_TIMEOUT_MS } from './fetch';
+import {
+  apiFetch,
+  apiFetchBlob,
+  apiFetchForm,
+  apiFetchRaw,
+  DEFAULT_TIMEOUT_MS,
+} from './fetch';
 
 function jsonResponse(body: unknown): Response {
   return {
@@ -45,6 +51,17 @@ describe('apiFetch timeout (#8080)', () => {
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('passes an AbortSignal for multipart upload callers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ uploaded: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await apiFetchForm('/api/upload', new FormData());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.headers).toBeUndefined();
   });
 
   it('exposes a sane default timeout', () => {

--- a/ui/src/api/useAnalysisTools.test.ts
+++ b/ui/src/api/useAnalysisTools.test.ts
@@ -1,14 +1,82 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadAnalysisExport } from './analysisExport';
+import type { ExportResult } from './analysisExport';
+import { apiFetch } from './fetch';
+import { useAnalysisTools } from './useAnalysisTools';
+
+vi.mock('./fetch', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('./analysisExport', () => ({
+  EXPORT_FORMATS: ['csv', 'json'],
+  downloadAnalysisExport: vi.fn(),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 describe('useAnalysisTools lifecycle guard', () => {
-  it('clears the mounted ref on unmount before async completions can set state', () => {
-    const source = readFileSync(join(__dirname, 'useAnalysisTools.ts'), 'utf-8');
+  const apiFetchMock = vi.mocked(apiFetch);
+  const downloadAnalysisExportMock = vi.mocked(downloadAnalysisExport);
 
-    expect(source).toMatch(/import\s+\{[^}]*useEffect[^}]*\}\s+from 'react';/);
-    expect(source).toMatch(
-      /useEffect\(\(\) => \{\s*isMountedRef\.current = true;\s*return \(\) => \{\s*isMountedRef\.current = false;\s*\};\s*\}, \[\]\);/,
-    );
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    downloadAnalysisExportMock.mockReset();
+  });
+
+  it('does not commit metrics state after an in-flight request resolves post-unmount', async () => {
+    const pending = deferred<unknown>();
+    apiFetchMock.mockReturnValueOnce(pending.promise);
+    const { result, unmount } = renderHook(() => useAnalysisTools());
+
+    let request!: Promise<void>;
+    act(() => {
+      request = result.current.fetchMetrics();
+    });
+    expect(result.current.loadState).toBe('loading');
+
+    unmount();
+    await act(async () => {
+      pending.resolve({ status: 'ok', metrics: { club_speed: 42 } });
+      await request;
+    });
+
+    expect(result.current.metrics).toBeNull();
+    expect(result.current.loadState).toBe('loading');
+  });
+
+  it('does not commit export state after an in-flight export resolves post-unmount', async () => {
+    const pending = deferred<ExportResult>();
+    downloadAnalysisExportMock.mockReturnValueOnce(pending.promise);
+    const { result, unmount } = renderHook(() => useAnalysisTools());
+
+    let request!: Promise<void>;
+    act(() => {
+      request = result.current.exportAnalysis('csv');
+    });
+    expect(result.current.loadState).toBe('loading');
+
+    unmount();
+    await act(async () => {
+      pending.resolve({
+        format: 'csv',
+        filename: 'analysis_export.csv',
+        size_bytes: 10,
+      });
+      await request;
+    });
+
+    expect(result.current.exportResult).toBeNull();
+    expect(result.current.loadState).toBe('loading');
   });
 });

--- a/ui/src/api/useAnalysisTools.ts
+++ b/ui/src/api/useAnalysisTools.ts
@@ -13,7 +13,10 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { apiFetch } from './fetch';
-import { getApiBase } from './backend';
+import { downloadAnalysisExport, type ExportFormat, type ExportResult } from './analysisExport';
+
+export { EXPORT_FORMATS } from './analysisExport';
+export type { ExportFormat, ExportResult } from './analysisExport';
 
 // ── Types (matching src/api/models/responses.py) ───────────────────────
 
@@ -39,17 +42,6 @@ export interface StatisticsSummary {
   sample_count: number;
   metrics: MetricSummary[];
   time_series: Record<string, number[]> | null;
-}
-
-/** Only the formats the backend actually implements (no xlsx/pdf). */
-export type ExportFormat = 'csv' | 'json';
-
-export const EXPORT_FORMATS: readonly ExportFormat[] = ['csv', 'json'];
-
-export interface ExportResult {
-  format: ExportFormat;
-  filename: string;
-  size_bytes: number;
 }
 
 export type AnalysisLoadState = 'idle' | 'loading' | 'loaded' | 'error';
@@ -113,37 +105,9 @@ export function useAnalysisTools() {
     setLoadState('loading');
     setError(null);
     try {
-      const response = await fetch(`${getApiBase()}/api/analysis/export`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          format,
-          include_metrics: true,
-          include_time_series: true,
-        }),
-      });
-      if (!response.ok) {
-        let detail = `Export failed: HTTP ${response.status}`;
-        try {
-          const body = (await response.json()) as Record<string, unknown>;
-          if (typeof body.detail === 'string') detail = body.detail;
-        } catch {
-          // non-JSON error body — keep generic message
-        }
-        throw new Error(detail);
-      }
-      const blob = await response.blob();
-      const filename = `analysis_export.${format}`;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const result = await downloadAnalysisExport(format);
       if (isMountedRef.current) {
-        setExportResult({ format, filename, size_bytes: blob.size });
+        setExportResult(result);
         setLoadState('loaded');
       }
     } catch (err) {

--- a/ui/src/api/useDatasetGenerator.ts
+++ b/ui/src/api/useDatasetGenerator.ts
@@ -9,7 +9,8 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { apiFetch } from './fetch';
+import { triggerBlobDownload } from './download';
+import { apiFetch, apiFetchBlob } from './fetch';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -265,29 +266,10 @@ export function useDatasetGenerator() {
     async (datasetId: string, format: string) => {
       setError(null);
       try {
-        // Use raw fetch so we can read the blob response
-        const { getApiBase } = await import('./backend');
-        const url = `${getApiBase()}/api/dataset/export/${encodeURIComponent(datasetId)}?format=${encodeURIComponent(format)}`;
-        const res = await fetch(url);
-        if (!res.ok) {
-          let detail: string | undefined;
-          try {
-            const body = (await res.json()) as Record<string, unknown>;
-            if (typeof body.detail === 'string') detail = body.detail;
-          } catch {
-            // ignore
-          }
-          throw new Error(detail ?? `Export failed: HTTP ${res.status}`);
-        }
-        const blob = await res.blob();
-        const objectUrl = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = objectUrl;
-        a.download = `${datasetId}.${format}`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(objectUrl);
+        const blob = await apiFetchBlob(
+          `/api/dataset/export/${encodeURIComponent(datasetId)}?format=${encodeURIComponent(format)}`,
+        );
+        triggerBlobDownload(blob, `${datasetId}.${format}`);
       } catch (err) {
         if (isMountedRef.current)
           setError(err instanceof Error ? err.message : 'Export failed');
@@ -299,14 +281,15 @@ export function useDatasetGenerator() {
   // F7: Fetch catalog data on mount, set catalogLoading=false when all done
   useEffect(() => {
     isMountedRef.current = true;
-    setCatalogLoading(true);
-    Promise.allSettled([
-      fetchFeatures(),
-      fetchPlotTypes(),
-      fetchExportFormats(),
-      fetchControls(),
-    ]).finally(() => {
-      if (isMountedRef.current) setCatalogLoading(false);
+    queueMicrotask(() => {
+      Promise.allSettled([
+        fetchFeatures(),
+        fetchPlotTypes(),
+        fetchExportFormats(),
+        fetchControls(),
+      ]).finally(() => {
+        if (isMountedRef.current) setCatalogLoading(false);
+      });
     });
     return () => {
       isMountedRef.current = false;

--- a/ui/src/api/websocketToken.ts
+++ b/ui/src/api/websocketToken.ts
@@ -17,7 +17,7 @@
  * acquire the token on demand, independently of which route mounted first.
  */
 
-import { getApiBase } from './backend';
+import { apiFetch } from './fetch';
 
 const LAUNCHER_WS_TOKEN_QUERY = 'launcher_token';
 
@@ -71,13 +71,9 @@ export async function ensureLauncherCapabilityToken(): Promise<string | null> {
 
   inFlightTokenFetch = (async (): Promise<string | null> => {
     try {
-      const response = await fetch(`${getApiBase()}/api/launcher/manifest`, {
-        signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),
+      const body = await apiFetch<Record<string, unknown>>('/api/launcher/manifest', {
+        timeoutMs: MANIFEST_TIMEOUT_MS,
       });
-      if (!response.ok) {
-        return null;
-      }
-      const body = (await response.json()) as Record<string, unknown>;
       const token = body.launcher_csrf_token;
       if (typeof token === 'string' && token.length > 0) {
         launcherCapabilityToken = token;

--- a/ui/src/components/analysis/AnalysisPanel.tsx
+++ b/ui/src/components/analysis/AnalysisPanel.tsx
@@ -20,7 +20,7 @@ import {
 } from 'recharts';
 import { Download, BarChart2, Activity, TrendingUp } from 'lucide-react';
 import { apiFetch } from '@/api/fetch';
-import { getApiBase } from '@/api/backend';
+import { downloadAnalysisExport } from '@/api/analysisExport';
 
 /** Analysis metric from the backend. */
 interface AnalysisMetric {
@@ -123,7 +123,9 @@ export function AnalysisPanel({
   // Start/stop polling when simulation runs
   useEffect(() => {
     if (isRunning) {
-      fetchStatistics();
+      queueMicrotask(() => {
+        void fetchStatistics();
+      });
       pollRef.current = setInterval(fetchStatistics, pollInterval);
     } else {
       if (pollRef.current) {
@@ -142,26 +144,7 @@ export function AnalysisPanel({
   // Export handler
   const handleExport = useCallback(async (format: 'csv' | 'json') => {
     try {
-      // Export returns a binary blob (not JSON), so apiFetch — which parses
-      // JSON — is not suitable here. Build the URL via getApiBase() to stay
-      // Tauri-safe (#6897).
-      const response = await fetch(`${getApiBase()}/api/analysis/export`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ format, include_metrics: true, include_time_series: true }),
-      });
-      if (!response.ok) {
-        throw new Error(`Export failed: ${response.status}`);
-      }
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `analysis_export.${format}`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      await downloadAnalysisExport(format);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Export failed');
     }

--- a/ui/src/components/ui/ChatContextChip.test.tsx
+++ b/ui/src/components/ui/ChatContextChip.test.tsx
@@ -54,6 +54,7 @@ describe('ChatContextChip', () => {
     expect(chip.textContent).toContain('last run 3.0s');
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/chat/context'),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 

--- a/ui/src/components/ui/ChatContextChip.tsx
+++ b/ui/src/components/ui/ChatContextChip.tsx
@@ -10,7 +10,7 @@
 
 import { useEffect, useState } from 'react';
 import { Eye } from 'lucide-react';
-import { getApiBase } from '../../api/backend';
+import { apiFetch } from '../../api/fetch';
 
 export interface ChatContextSimulation {
   engine: string | null;
@@ -61,9 +61,7 @@ export function ChatContextChip({ refreshMs = 15_000 }: ChatContextChipProps = {
     const load = async () => {
       if (typeof fetch !== 'function') return;
       try {
-        const resp = await fetch(`${getApiBase()}/api/chat/context`);
-        if (!resp.ok) return;
-        const data = (await resp.json()) as ChatContextInfo;
+        const data = await apiFetch<ChatContextInfo>('/api/chat/context');
         if (!cancelled) setContext(data);
       } catch {
         // Context is best-effort decoration; stay silent on failure.

--- a/ui/src/pages/CanonicalCoreShell.tsx
+++ b/ui/src/pages/CanonicalCoreShell.tsx
@@ -55,6 +55,7 @@ const FALLBACK_TITLE: Record<CanonicalCoreMode, string> = {
  * @returns The validated status.
  * @throws Error when a required field is missing or mistyped.
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export function parseCanonicalCoreStatus(raw: unknown): CanonicalCoreStatus {
   if (typeof raw !== 'object' || raw === null) {
     throw new Error('Canonical-core status response was not an object');
@@ -109,7 +110,9 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
   }, [mode]);
 
   useEffect(() => {
-    void loadStatusReport();
+    queueMicrotask(() => {
+      void loadStatusReport();
+    });
   }, [loadStatusReport]);
 
   const title = status?.name || FALLBACK_TITLE[mode];

--- a/ui/src/pages/CharacterBuilder.test.tsx
+++ b/ui/src/pages/CharacterBuilder.test.tsx
@@ -116,6 +116,7 @@ describe('CharacterBuilderPage', () => {
       headers: {
         'Content-Type': 'application/json',
       },
+      signal: expect.any(AbortSignal),
       body: JSON.stringify({
         height_m: 1.8,
         mass_kg: 80,

--- a/ui/src/pages/CharacterBuilder.tsx
+++ b/ui/src/pages/CharacterBuilder.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useCallback } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Grid, Environment } from '@react-three/drei';
-import { getApiBase } from '@/api/backend';
+import { apiFetchRaw } from '@/api/fetch';
+import { triggerBlobDownload } from '@/api/download';
 
 interface SegmentBreakdown {
   name: string;
@@ -143,9 +144,7 @@ export function CharacterBuilderPage() {
     setGenerating(true);
     setError(null);
     try {
-      // Response is URDF XML text (not JSON), so apiFetch is not suitable.
-      // Build the URL via getApiBase() to stay Tauri-safe (#6897).
-      const response = await fetch(`${getApiBase()}/api/character-builder/generate`, {
+      const response = await apiFetchRaw('/api/character-builder/generate', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -157,20 +156,9 @@ export function CharacterBuilderPage() {
         }),
       });
 
-      if (!response.ok) {
-        throw new Error(`Failed to generate URDF: ${response.statusText}`);
-      }
-
       const text = await response.text();
       const blob = new Blob([text], { type: 'text/xml' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${buildType.toLowerCase()}_humanoid.urdf`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+      triggerBlobDownload(blob, `${buildType.toLowerCase()}_humanoid.urdf`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error occurred');
     } finally {

--- a/ui/src/pages/CrossEngineDashboard.tsx
+++ b/ui/src/pages/CrossEngineDashboard.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts';
-import { getApiBase } from '@/api/backend';
+import { apiFetch } from '@/api/fetch';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -71,27 +71,15 @@ async function startStudy(
   engines: EngineName[],
   config: PerturbationConfig,
 ): Promise<string> {
-  const base = getApiBase();
-  const resp = await fetch(`${base}/api/v1/analysis/cross-engine`, {
+  const data = await apiFetch<{ task_id: string }>('/api/v1/analysis/cross-engine', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ engines, config }),
   });
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Failed to start study: ${resp.status} ${text}`);
-  }
-  const data = await resp.json();
-  return data.task_id as string;
+  return data.task_id;
 }
 
 async function pollStatus(taskId: string): Promise<{ status: string; result?: CrossEngineResult; error?: string }> {
-  const base = getApiBase();
-  const resp = await fetch(`${base}/api/v1/analysis/cross-engine/status/${taskId}`);
-  if (!resp.ok) {
-    throw new Error(`Poll failed: ${resp.status}`);
-  }
-  return resp.json();
+  return apiFetch(`/api/v1/analysis/cross-engine/status/${encodeURIComponent(taskId)}`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #8152.
Closes #8144.
Closes #8173.

## Summary
- Split dependency-free API base URL helpers out of backend lifecycle code so backend diagnostics can use shared fetch handling without an import cycle.
- Added apiFetchRaw/apiFetchBlob plus shared blob download helpers for text/blob endpoints.
- Migrated character builder, cross-engine analysis, analysis export, dataset export, diagnostics, chat context, and launcher manifest calls away from raw production fetch() calls.
- Routed multipart apiFetchForm uploads through the shared timeout/error path without setting a manual Content-Type boundary.
- Deduplicated analysis export download behavior behind one API helper.
- Replaced the brittle source-regex useAnalysisTools lifecycle test with rendered-hook behavior that resolves async work after unmount.
- Cleaned the unrelated CanonicalCoreShell lint blocker so the full UI lint gate is green on this branch.

## Validation
- npm run lint
- npm run type-check
- npm run test:run -- fetchTimeout.test.ts ChatContextChip.test.tsx websocketToken.test.ts CharacterBuilder.test.tsx AnalysisPanel.test.tsx useDatasetGenerator.test.ts CanonicalCoreShell.test.tsx
- npm run test:run -- useAnalysisTools.test.ts
- npm run test:run
- git diff --check