### PR TITLE
fix(chat): pass launcher token to Sidekick websocket

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -38,6 +38,7 @@ from typing import Any, cast
 
 from PyQt6.QtCore import Qt, QTimer, QUrl, pyqtSignal
 from PyQt6.QtGui import QKeySequence, QShortcut
+from PyQt6.QtNetwork import QNetworkRequest
 from PyQt6.QtWebSockets import QWebSocket
 from PyQt6.QtWidgets import (
     QApplication,
@@ -61,8 +62,12 @@ from ._theme_protocol import ThemeProviderProtocol, _DefaultDarkTheme
 from ._workspace_protocol import WorkspaceContextProtocol, WorkspaceVariableInfo
 from .chat_dock_widget import (
     _DEFAULT_SERVER,
+    _chat_disconnect_status,
+    _chat_websocket_url,
+    _fetch_launcher_capability_token,
     _read_shared_session_id,
     _session_file_path,
+    _websocket_origin_for_server,
     _write_shared_session_id,
 )
 from .cli_provider_availability import list_available_cli_providers
@@ -331,6 +336,9 @@ class ChatDockWidget(QDockWidget):
         self._voice_manager = VoiceInputManager()
         self._terminal_start_pending = False
         self._socket: QWebSocket | None = None
+        self._connection_failures = 0
+        self._last_connection_error: str | None = None
+        self._last_connection_url: str | None = None
         self._session_file = _session_file_path(app_name)
         # Tools issue #2872: conversation-management state.
         self._loaded_context_sessions: list[str] = []
@@ -696,14 +704,31 @@ class ChatDockWidget(QDockWidget):
         self._socket.connected.connect(self._on_connected)
         self._socket.disconnected.connect(self._on_disconnected)
         self._socket.textMessageReceived.connect(self._on_message)
+        self._socket.errorOccurred.connect(self._on_socket_error)
 
         sid = ChatDockWidget._get_shared_session_id() or "new"
-        path = self._ws_path_template.replace("{session_id}", sid)
-        url = QUrl(f"{self._server_url}{path}")
+        token = _fetch_launcher_capability_token(self._server_url)
+        url_text = _chat_websocket_url(
+            self._server_url,
+            self._ws_path_template,
+            sid,
+            token,
+        )
+        self._last_connection_url = url_text
+        if token is None:
+            self._last_connection_error = "launcher capability token was unavailable"
+        url = QUrl(url_text)
+        request = QNetworkRequest(url)
+        request.setRawHeader(
+            b"Origin",
+            _websocket_origin_for_server(self._server_url).encode("utf-8"),
+        )
         self._status_label.setText("Connecting...")
-        self._socket.open(url)
+        self._socket.open(request)
 
     def _on_connected(self) -> None:
+        self._connection_failures = 0
+        self._last_connection_error = None
         self._status_label.setText("Connected")
         self._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
         self.refresh_models()
@@ -757,8 +782,19 @@ class ChatDockWidget(QDockWidget):
         panel.show()
         self._memory_panel_window = panel
 
+    def _on_socket_error(self, _error: object) -> None:
+        if self._socket is not None:
+            self._last_connection_error = self._socket.errorString()
+
     def _on_disconnected(self) -> None:
-        self._status_label.setText("Disconnected - retrying in 3s...")
+        self._connection_failures += 1
+        self._status_label.setText(
+            _chat_disconnect_status(
+                self._connection_failures,
+                self._last_connection_url,
+                self._last_connection_error,
+            )
+        )
         self._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
         self._is_streaming = False
         self._send_btn.setEnabled(True)

--- a/src/shared/python/chat/chat_dock_widget.py
+++ b/src/shared/python/chat/chat_dock_widget.py
@@ -25,10 +25,16 @@ from __future__ import annotations
 
 import os
 import threading
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 from typing import Any
 
 _DEFAULT_SERVER = "ws://127.0.0.1:8000"
+_LAUNCHER_MANIFEST_PATH = "/api/launcher/manifest"
+_LAUNCHER_TOKEN_QUERY = "launcher_token"
 
 
 def _resolve_default_server() -> str:
@@ -105,6 +111,101 @@ def _write_shared_session_id(session_id: str, path: Path) -> None:
             pass
 
 
+def _http_base_for_ws_server(server_url: str) -> str:
+    """Return the HTTP(S) origin matching a ws:// or wss:// server URL."""
+    parsed = urllib.parse.urlsplit(server_url.rstrip("/"))
+    if parsed.scheme == "ws":
+        scheme = "http"
+    elif parsed.scheme == "wss":
+        scheme = "https"
+    elif parsed.scheme in {"http", "https"}:
+        scheme = parsed.scheme
+    else:
+        raise ValueError(f"Unsupported chat server URL scheme: {parsed.scheme!r}")
+    return urllib.parse.urlunsplit((scheme, parsed.netloc, "", "", ""))
+
+
+def _launcher_manifest_url(server_url: str) -> str:
+    """Return the launcher manifest URL for a chat WebSocket server."""
+    return f"{_http_base_for_ws_server(server_url)}{_LAUNCHER_MANIFEST_PATH}"
+
+
+def _websocket_origin_for_server(server_url: str) -> str:
+    """Return the loopback Origin header expected by local WS auth guards."""
+    return _http_base_for_ws_server(server_url)
+
+
+def _chat_websocket_url(
+    server_url: str,
+    ws_path_template: str,
+    session_id: str,
+    launcher_token: str | None = None,
+) -> str:
+    """Build the chat WebSocket URL, appending the launcher token when present."""
+    path = ws_path_template.replace("{session_id}", session_id)
+    url = f"{server_url.rstrip('/')}{path}"
+    if not launcher_token:
+        return url
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append((_LAUNCHER_TOKEN_QUERY, launcher_token))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            urllib.parse.urlencode(query),
+            parsed.fragment,
+        )
+    )
+
+
+def _fetch_launcher_capability_token(
+    server_url: str,
+    timeout_seconds: float = 2.0,
+) -> str | None:
+    """Fetch the launcher capability token used by local WebSocket auth."""
+    try:
+        request = urllib.request.Request(
+            _launcher_manifest_url(server_url),
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            if getattr(response, "status", 200) >= 400:
+                return None
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        OSError,
+        TimeoutError,
+        ValueError,
+        json.JSONDecodeError,
+        urllib.error.URLError,
+    ):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    token = payload.get("launcher_csrf_token")
+    return token if isinstance(token, str) and token else None
+
+
+def _chat_disconnect_status(
+    failure_count: int,
+    websocket_url: str | None,
+    last_error: str | None,
+) -> str:
+    """Return the connection status text after a failed chat WS attempt."""
+    if failure_count < 3:
+        return "Disconnected - retrying in 3s..."
+    detail = (last_error or "").strip() or (
+        "launcher capability token is missing or stale"
+    )
+    target = websocket_url or "unknown WebSocket URL"
+    return (
+        "Chat unavailable: "
+        f"{detail}. URL: {target}. Check /api/launcher/manifest and retrying in 3s..."
+    )
+
+
 def _load_qt_module() -> Any:
     from . import _chat_dock_widget_qt
 
@@ -121,7 +222,12 @@ __all__ = [
     "ChatDockWidget",
     "ChatMessageBubble",
     "_DEFAULT_SERVER",
+    "_chat_disconnect_status",
+    "_chat_websocket_url",
+    "_fetch_launcher_capability_token",
+    "_launcher_manifest_url",
     "_session_file_path",
+    "_websocket_origin_for_server",
     "_read_shared_session_id",
     "_write_shared_session_id",
 ]

--- a/src/shared/python/chat/tests/test_chat.py
+++ b/src/shared/python/chat/tests/test_chat.py
@@ -201,3 +201,113 @@ class TestSessionFileFunctions:
         _write_shared_session_id("roundtrip-id-999", f)
         result = _read_shared_session_id(f)
         assert result == "roundtrip-id-999"
+
+
+class TestLauncherWebSocketAuthHelpers:
+    def test_manifest_url_uses_http_origin_for_ws_server(self):
+        from chat.chat_dock_widget import _launcher_manifest_url
+
+        assert (
+            _launcher_manifest_url("ws://127.0.0.1:8000")
+            == "http://127.0.0.1:8000/api/launcher/manifest"
+        )
+        assert (
+            _launcher_manifest_url("wss://example.test")
+            == "https://example.test/api/launcher/manifest"
+        )
+
+    def test_chat_websocket_url_appends_launcher_token(self):
+        from chat.chat_dock_widget import _chat_websocket_url
+
+        url = _chat_websocket_url(
+            "ws://127.0.0.1:8000",
+            "/api/ws/chat/{session_id}",
+            "abc",
+            "tok-123",
+        )
+
+        assert url == "ws://127.0.0.1:8000/api/ws/chat/abc?launcher_token=tok-123"
+
+    def test_chat_websocket_url_preserves_existing_query(self):
+        from chat.chat_dock_widget import _chat_websocket_url
+
+        url = _chat_websocket_url(
+            "ws://127.0.0.1:8000",
+            "/api/ws/chat/{session_id}?mode=local",
+            "abc",
+            "tok-123",
+        )
+
+        assert (
+            url
+            == "ws://127.0.0.1:8000/api/ws/chat/abc?mode=local&launcher_token=tok-123"
+        )
+
+    def test_websocket_origin_matches_http_origin(self):
+        from chat.chat_dock_widget import _websocket_origin_for_server
+
+        assert _websocket_origin_for_server("ws://127.0.0.1:8000") == (
+            "http://127.0.0.1:8000"
+        )
+
+    def test_fetch_launcher_capability_token_reads_manifest(self):
+        from chat.chat_dock_widget import _fetch_launcher_capability_token
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"launcher_csrf_token": "tok-abc"}'
+
+        with patch("urllib.request.urlopen", return_value=Response()) as urlopen:
+            token = _fetch_launcher_capability_token("ws://127.0.0.1:8000")
+
+        assert token == "tok-abc"
+        request = urlopen.call_args.args[0]
+        assert request.full_url == "http://127.0.0.1:8000/api/launcher/manifest"
+
+    def test_fetch_launcher_capability_token_returns_none_for_missing_token(self):
+        from chat.chat_dock_widget import _fetch_launcher_capability_token
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"tiles": []}'
+
+        with patch("urllib.request.urlopen", return_value=Response()):
+            assert _fetch_launcher_capability_token("ws://127.0.0.1:8000") is None
+
+    def test_disconnect_status_becomes_actionable_after_repeated_failures(self):
+        from chat.chat_dock_widget import _chat_disconnect_status
+
+        assert (
+            _chat_disconnect_status(
+                2,
+                "ws://127.0.0.1:8000/api/ws/chat/new",
+                "403 Forbidden",
+            )
+            == "Disconnected - retrying in 3s..."
+        )
+
+        status = _chat_disconnect_status(
+            3,
+            "ws://127.0.0.1:8000/api/ws/chat/new",
+            "403 Forbidden",
+        )
+
+        assert "403 Forbidden" in status
+        assert "ws://127.0.0.1:8000/api/ws/chat/new" in status
+        assert "/api/launcher/manifest" in status


### PR DESCRIPTION
Closes #8075.

Summary:
- Fetch /api/launcher/manifest from the chat dock HTTP origin before opening the WebSocket.
- Append launcher_token and send the loopback Origin header required by local WebSocket auth.
- Show an actionable retry state after repeated failures.
- Add pure regression tests for token, URL, origin, and retry-status helpers.

Validation:
- py -3.13 -m pytest -q src/shared/python/chat/tests/test_chat.py
- py -3.13 -m ruff check src/shared/python/chat/chat_dock_widget.py src/shared/python/chat/_chat_dock_widget_qt.py src/shared/python/chat/tests/test_chat.py
- py -3.13 -m ruff format --check src/shared/python/chat/chat_dock_widget.py src/shared/python/chat/_chat_dock_widget_qt.py src/shared/python/chat/tests/test_chat.py
- git diff --check
- PyQt6 QWebSocket.open(QNetworkRequest) sanity check
- pre-push hook passed: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print, prettier, mypy, bandit, pytest