### PR TITLE
fix(api): reject invalid cross-engine timing grid

### DIFF
--- a/src/api/routes/cross_engine.py
+++ b/src/api/routes/cross_engine.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.shared.python.analysis.cross_engine import ENGINE_NAMES
 from src.shared.python.logging_pkg.logging_config import get_logger
@@ -60,6 +60,15 @@ class CrossEnginePerturbationConfig(BaseModel):
         default=10, ge=1, le=200, description="Number of perturbation trials"
     )
     seed: int = Field(default=42, description="Random seed for reproducibility")
+
+    @model_validator(mode="after")
+    def timing_grid_must_have_at_least_one_step(self) -> CrossEnginePerturbationConfig:
+        """Pre: service-layer config requires ``t_end > dt > 0``."""
+        if self.t_end <= self.dt:
+            raise ValueError(
+                f"t_end ({self.t_end}) must be greater than dt ({self.dt})"
+            )
+        return self
 
 
 class CrossEngineStudyRequest(BaseModel):

--- a/tests/unit/api/test_routes_cross_engine.py
+++ b/tests/unit/api/test_routes_cross_engine.py
@@ -137,6 +137,18 @@ class TestStartCrossEngineStudy:
         response = client.post("/analysis/cross-engine", json=payload)
         assert response.status_code == 422, response.text
 
+    def test_invalid_config_dt_not_less_than_t_end_rejected_before_task_creation(
+        self, client: TestClient, task_manager: TaskManager
+    ) -> None:
+        payload = {
+            "engines": ["pendulum_stub"],
+            "config": {"t_end": 0.01, "dt": 0.01},
+        }
+        response = client.post("/analysis/cross-engine", json=payload)
+        assert response.status_code == 422, response.text
+        assert "must be greater than dt" in response.text
+        assert len(task_manager) == 0
+
     def test_invalid_config_n_trials_zero_rejected(self, client: TestClient) -> None:
         payload = {"engines": ["pendulum_stub"], "config": {"n_trials": 0}}
         response = client.post("/analysis/cross-engine", json=payload)


### PR DESCRIPTION
Closes #8174.

Summary:
- Enforce the service-layer t_end > dt invariant in CrossEnginePerturbationConfig before task creation.
- Return FastAPI/Pydantic 422 for invalid timing grids instead of creating a doomed background task.
- Add a route regression that asserts no TaskManager entry is created when dt >= t_end.

Validation:
- py -3.13 -m pytest -q tests/unit/api/test_routes_cross_engine.py
- py -3.13 -m ruff check src/api/routes/cross_engine.py tests/unit/api/test_routes_cross_engine.py
- py -3.13 -m ruff format --check src/api/routes/cross_engine.py tests/unit/api/test_routes_cross_engine.py
- git diff --check
- pre-push hook passed: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print, prettier, mypy, bandit, pytest