### PR TITLE
fix(api): bound data explorer name resolution

### DIFF
--- a/src/api/routes/data_explorer.py
+++ b/src/api/routes/data_explorer.py
@@ -592,6 +592,9 @@ def _find_dataset_path(name: str) -> Path:
     ``name`` is matched as a *literal* filename, never as a glob pattern. Names
     containing glob metacharacters (``* ? [ ]``) are rejected outright so a
     client cannot enumerate the output tree via wildcard expansion (#7740 F).
+    Resolution uses the same bounded scan policy as ``GET /datasets`` so
+    preview/stats/filter cannot recursively walk and sort the whole output tree
+    for one client-supplied filename (#8172).
     """
     if any(ch in _GLOB_METACHARACTERS for ch in name):
         raise HTTPException(
@@ -599,9 +602,21 @@ def _find_dataset_path(name: str) -> Path:
             detail="Dataset name must not contain glob metacharacters (* ? [ ])",
         )
     output_dir = _get_output_dir()
-    matches = sorted(
-        path for path in output_dir.rglob("*") if path.name == name and path.is_file()
-    )
+    matches: list[Path] = []
+    truncated = False
+    if output_dir.exists():
+        candidates, truncated = _scan_dataset_files(output_dir, MAX_DATASET_LIST_SCAN)
+        matches = [path for path in candidates if path.name == name]
+
+    if truncated:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Dataset name '{name}' could not be resolved within the bounded "
+                f"scan cap ({MAX_DATASET_LIST_SCAN} files); narrow the output "
+                "tree or use an imported dataset ID"
+            ),
+        )
     if not matches:
         raise HTTPException(status_code=404, detail=f"Dataset '{name}' not found")
     if len(matches) > 1:

--- a/tests/unit/api/test_routes_data_explorer.py
+++ b/tests/unit/api/test_routes_data_explorer.py
@@ -535,6 +535,29 @@ def test_find_dataset_path_matches_exact_filename_only(
     assert resolved.name == "swing.csv"
 
 
+def test_find_dataset_path_uses_bounded_scan_not_rglob(
+    temp_dataset_dir, monkeypatch
+) -> None:
+    """Single-dataset resolution must share the bounded scan policy (#8172)."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from src.api.routes.data_explorer import _find_dataset_path
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "swing.csv").write_text("a\n1\n", encoding="utf-8")
+
+    def fail_rglob(*_: object, **__: object) -> None:
+        raise AssertionError("_find_dataset_path must not use Path.rglob")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resolved = _find_dataset_path("swing.csv")
+
+    assert resolved == output_dir / "swing.csv"
+
+
 def test_find_dataset_path_ambiguous_name_409(temp_dataset_dir) -> None:
     """Two files with the same name in different subdirs yield a 409."""
     from pathlib import Path
@@ -573,6 +596,63 @@ def test_stats_ambiguous_name_returns_409(client: TestClient, temp_dataset_dir) 
     with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
         resp = no_raise.get("/tools/data-explorer/datasets/dup.csv/stats")
     assert resp.status_code == 409
+
+
+def test_preview_returns_409_when_name_resolution_scan_is_truncated(
+    client: TestClient, temp_dataset_dir, monkeypatch
+) -> None:
+    """Preview must not trust a partial scan when uniqueness is unproven."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import src.api.routes.data_explorer as de
+
+    output_dir = Path(temp_dataset_dir)
+    target = output_dir / "target.csv"
+    target.write_text("a\n1\n", encoding="utf-8")
+    monkeypatch.setattr(de, "MAX_DATASET_LIST_SCAN", 1)
+
+    def truncated_scan(scan_dir: Path, scan_cap: int) -> tuple[list[Path], bool]:
+        assert scan_dir == output_dir
+        assert scan_cap == 1
+        return [target], True
+
+    monkeypatch.setattr(de, "_scan_dataset_files", truncated_scan)
+
+    no_raise = TestClient(client.app, raise_server_exceptions=False)
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        resp = no_raise.get("/tools/data-explorer/datasets/target.csv/preview")
+
+    assert resp.status_code == 409
+    assert "bounded scan cap" in resp.json()["detail"]
+
+
+def test_stats_and_filter_resolve_names_with_bounded_scan(
+    client: TestClient, temp_dataset_dir, monkeypatch
+) -> None:
+    """Stats/filter should resolve on-disk names without falling back to rglob."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    output_dir = Path(temp_dataset_dir)
+    (output_dir / "values.csv").write_text("a\n1\n3\n", encoding="utf-8")
+
+    def fail_rglob(*_: object, **__: object) -> None:
+        raise AssertionError("stats/filter name resolution must not use Path.rglob")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    with patch("src.api.routes.data_explorer._get_output_dir", return_value=output_dir):
+        stats_resp = client.get("/tools/data-explorer/datasets/values.csv/stats")
+        filter_resp = client.post(
+            "/tools/data-explorer/datasets/values.csv/filter",
+            json={"column": "a", "operator": "gt", "value": "1"},
+        )
+
+    assert stats_resp.status_code == 200
+    assert stats_resp.json()["stats"]["a"]["max"] == 3.0
+    assert filter_resp.status_code == 200
+    assert filter_resp.json()["rows"] == [{"a": "3"}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route Data Explorer single-name resolution through the existing bounded dataset scan helper
- return 409 when the scan cap is reached before uniqueness can be proven
- add regressions for no Path.rglob usage, truncated preview resolution, and stats/filter bounded resolution

Closes #8172

## Validation
- py -3.13 -m pytest -q tests\\unit\\api\\test_routes_data_explorer.py tests\\unit\\api\\test_data_explorer_perf.py
- py -3.13 -m ruff check src\\api\\routes\\data_explorer.py tests\\unit\\api\\test_routes_data_explorer.py tests\\unit\\api\\test_data_explorer_perf.py
- py -3.13 -m ruff format src\\api\\routes\\data_explorer.py tests\\unit\\api\\test_routes_data_explorer.py
- git diff --check
- pre-push hook: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print(), mypy, bandit, pytest