### PR TITLE
fix(mocap): canonicalize C3D launcher imports

### DIFF
--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/_embed_adapter.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/_embed_adapter.py
@@ -52,6 +52,7 @@ class _C3DViewerEmbedAdapter:
             import matplotlib.pyplot as plt
 
             if not hasattr(self, "_widget") or self._widget is None:
+                plt.close("all")
                 return
 
             w = self._widget

--- a/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
+++ b/src/engines/Simscape_Multibody_Models/3D_Golf_Model/python/src/apps/c3d_viewer.py
@@ -319,7 +319,7 @@ class MainWidget(QtWidgets.QWidget):
         # shared module import must be available
         if not (path is not None):
             raise ValueError("path must be provided")
-        from shared.python.security.security_utils import validate_path
+        from src.shared.python.security.security_utils import validate_path
 
         suite_root = Path(__file__).parents[6]
         allowed = [

--- a/src/shared/python/motion_matching/loaders/c3d.py
+++ b/src/shared/python/motion_matching/loaders/c3d.py
@@ -1,7 +1,7 @@
 """C3D loader for cluster-marker mocap files.
 
 Reuses the canonical ``C3DDataReader`` from
-``shared.python.sidekick.lab.bio.c3d_reader``.
+``src.shared.python.sidekick.lab.bio.c3d_reader``.
 Marker-name discovery is heuristic because the cluster-marker set is not
 documented in this repo (issue #013 is the verification pass).
 """
@@ -16,12 +16,12 @@ import numpy as np
 import pandas as pd
 
 from src.shared.python.core.contracts import postcondition, precondition
-from shared.python.sidekick.lab.bio.c3d_reader import C3DDataReader
-from shared.python.sidekick.lab.bio._c3d_marker_set import (
+from src.shared.python.sidekick.lab.bio.c3d_reader import C3DDataReader
+from src.shared.python.sidekick.lab.bio._c3d_marker_set import (
     MarkerSet,
     MarkerSetMismatchError,
 )
-from shared.python.sidekick.lab.bio._c3d_models import C3DEvent
+from src.shared.python.sidekick.lab.bio._c3d_models import C3DEvent
 
 from ..club_target import AlignOptions, ClubTarget, SourceProvenance
 from ._align import detect_impact_index, resample_target

--- a/src/shared/python/motion_matching/loaders/c3d_body.py
+++ b/src/shared/python/motion_matching/loaders/c3d_body.py
@@ -116,7 +116,7 @@ def _sha256_of(path: Path) -> str:
 
 def _import_c3d_reader_class():
     """Import :class:`C3DDataReader` from the canonical bio module."""
-    from shared.python.sidekick.lab.bio.c3d_reader import (
+    from src.shared.python.sidekick.lab.bio.c3d_reader import (
         C3DDataReader,
     )
 

--- a/tests/tools/starting_pose_matcher/test_skeleton_extractor_and_adapter.py
+++ b/tests/tools/starting_pose_matcher/test_skeleton_extractor_and_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from pathlib import Path
@@ -158,6 +159,16 @@ def test_embed_adapter_create_main_widget_lazy_imports():
         w = a.create_main_widget(parent="P")
     assert w is fake_widget
     assert a._widgets == [fake_widget]
+
+
+def test_motion_match_preview_gui_imports_without_short_shared_alias():
+    """The GUI import path must not depend on the stale ``shared.python`` alias."""
+    sys.modules.pop("shared", None)
+    sys.modules.pop("shared.python", None)
+
+    module = importlib.import_module("src.tools.starting_pose_matcher.gui_main_widget")
+
+    assert hasattr(module, "MainWidget")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/c3d_viewer/test_embed_adapter.py
+++ b/tests/ui/c3d_viewer/test_embed_adapter.py
@@ -103,6 +103,49 @@ def test_create_main_widget_returns_qwidget(qapp, adapter) -> None:
 
 
 @pytest.mark.unit
+def test_load_c3d_file_uses_canonical_security_import(
+    qapp, tmp_path, monkeypatch
+) -> None:
+    """Loading a local C3D path must not use the stale ``shared.python`` import."""
+    c3d_mod = importlib.import_module(f"{_APPS_PKG_NAME}.c3d_viewer")
+    c3d_path = tmp_path / "sample.c3d"
+    c3d_path.write_bytes(b"not a real c3d; loader is stubbed")
+    started_paths: list[str] = []
+    warnings: list[str] = []
+
+    class _Signal:
+        def connect(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    class _FakeLoaderThread:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            self.loaded = _Signal()
+            self.failed = _Signal()
+            self.finished = _Signal()
+
+        def start(self) -> None:
+            started_paths.append(self.path)
+
+    monkeypatch.setattr(c3d_mod, "C3DLoaderThread", _FakeLoaderThread)
+    monkeypatch.setattr(
+        c3d_mod.QtWidgets.QMessageBox,
+        "warning",
+        lambda *_args: warnings.append(str(_args[-1])),
+    )
+
+    widget = c3d_mod.MainWidget()
+    try:
+        widget.load_c3d_file_from_path(str(c3d_path))
+    finally:
+        c3d_mod.QtWidgets.QApplication.restoreOverrideCursor()
+        widget.deleteLater()
+
+    assert warnings == []
+    assert started_paths == [str(c3d_path.resolve())]
+
+
+@pytest.mark.unit
 def test_cleanup_closes_all_matplotlib_figures(adapter) -> None:
     """``cleanup`` releases every open matplotlib figure."""
     import matplotlib


### PR DESCRIPTION
## Summary
- replace stale `shared.python` imports in the C3D viewer and motion-matching C3D loaders with canonical `src.shared.python` imports
- add a behavioral C3D viewer regression that reaches the loader without `ModuleNotFoundError`
- add a Motion-Match Preview regression that imports `gui_main_widget` without the stale short-path alias
- make C3D embed cleanup close matplotlib figures even before a widget is created

Closes #8073
Closes #8066

## Validation
- `py -3.13 -m pytest -q tests\ui\c3d_viewer\test_embed_adapter.py`
- `py -3.13 -m pytest -q tests\ui\c3d_viewer\test_embed_adapter.py tests\unit\config\test_setup_wizard.py tests\unit\launcher\test_bootstrap_manifest_coverage.py`
- `py -3.13 -m pytest -q tests\tools\starting_pose_matcher\test_skeleton_extractor_and_adapter.py tests\unit\launchers\test_embed_adapter_backgrounding_rollout.py::test_cleanup_is_idempotent[_MotionMatchPreviewEmbedAdapter]`
- direct import probe for `src.tools.starting_pose_matcher.gui_main_widget`, `src.tools.starting_pose_matcher.gui`, and the two C3D loaders
- `py -3.13 -m ruff check` on touched files
- `py -3.13 -m ruff format` on touched files
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print(), mypy, bandit, pytest