### PR TITLE
fix(ai): terminate skipped workflow failures

### DIFF
--- a/src/shared/python/ai/workflow_engine.py
+++ b/src/shared/python/ai/workflow_engine.py
@@ -415,19 +415,21 @@ class WorkflowEngine:
 
         skipped = self._check_step_condition(step, execution, start_time)
         if skipped is not None:
-            if execution.current_step_index >= len(workflow.steps):
-                execution.status = StepStatus.COMPLETED
-                logger.info(
-                    "Workflow completed (final step skipped): %s", execution.workflow_id
-                )
+            self._mark_completed_if_past_end(
+                execution,
+                workflow,
+                "Workflow completed (final step skipped): %s",
+            )
             return skipped
 
-        tool_result, failure = self._execute_step_tool(step, execution, start_time)
+        tool_result, failure = self._execute_step_tool(
+            step, execution, workflow, start_time
+        )
         if failure is not None:
             return failure
 
         validation_failure = self._validate_step_result(
-            step, execution, tool_result, start_time
+            step, execution, workflow, tool_result, start_time
         )
         if validation_failure is not None:
             return validation_failure
@@ -468,6 +470,7 @@ class WorkflowEngine:
         self,
         step: WorkflowStep,
         execution: WorkflowExecution,
+        workflow: Workflow,
         start_time: float,
     ) -> tuple[ToolResult | None, StepResult | None]:
         if step is None:
@@ -492,7 +495,7 @@ class WorkflowEngine:
                     duration=time.perf_counter() - start_time,
                 )
                 execution.step_results.append(result)
-                return None, self._handle_failure(execution, step, result)
+                return None, self._handle_failure(execution, step, result, workflow)
 
             if not tool_result.success:
                 result = StepResult(
@@ -502,7 +505,7 @@ class WorkflowEngine:
                     duration=time.perf_counter() - start_time,
                 )
                 execution.step_results.append(result)
-                return None, self._handle_failure(execution, step, result)
+                return None, self._handle_failure(execution, step, result, workflow)
 
         return tool_result, None
 
@@ -510,6 +513,7 @@ class WorkflowEngine:
         self,
         step: WorkflowStep,
         execution: WorkflowExecution,
+        workflow: Workflow,
         tool_result: ToolResult | None,
         start_time: float,
     ) -> StepResult | None:
@@ -533,9 +537,28 @@ class WorkflowEngine:
                         duration=time.perf_counter() - start_time,
                     )
                     execution.step_results.append(result)
-                    return self._handle_failure(execution, step, result)
+                    return self._handle_failure(execution, step, result, workflow)
             except (RuntimeError, ValueError, OSError) as e:
-                logger.warning("Validation failed for step %s: %s", step.id, e)
+                message = f"Validation failed for step {step.id}: {e}"
+                logger.warning(
+                    "Validation failed for step %s: %s",
+                    step.id,
+                    e,
+                )
+                validation = ValidationResult(
+                    passed=False,
+                    message=message,
+                    details={"exception_type": type(e).__name__},
+                )
+                result = StepResult(
+                    step_id=step.id,
+                    status=StepStatus.FAILED,
+                    error=message,
+                    validation=validation,
+                    duration=time.perf_counter() - start_time,
+                )
+                execution.step_results.append(result)
+                return self._handle_failure(execution, step, result, workflow)
         return None
 
     def _finalize_step_success(
@@ -565,17 +588,30 @@ class WorkflowEngine:
 
         execution.current_step_index += 1
 
-        if execution.current_step_index >= len(workflow.steps):
-            execution.status = StepStatus.COMPLETED
-            logger.info("Workflow completed: %s", execution.workflow_id)
+        self._mark_completed_if_past_end(
+            execution,
+            workflow,
+            "Workflow completed: %s",
+        )
 
         return result
+
+    def _mark_completed_if_past_end(
+        self,
+        execution: WorkflowExecution,
+        workflow: Workflow,
+        message: str,
+    ) -> None:
+        if execution.current_step_index >= len(workflow.steps):
+            execution.status = StepStatus.COMPLETED
+            logger.info(message, execution.workflow_id)
 
     def _handle_failure(
         self,
         execution: WorkflowExecution,
         step: WorkflowStep,
         result: StepResult,
+        workflow: Workflow,
     ) -> StepResult:
         """Handle a step failure based on recovery strategy.
 
@@ -601,6 +637,11 @@ class WorkflowEngine:
         elif step.on_failure == RecoveryStrategy.SKIP:
             result.status = StepStatus.SKIPPED
             execution.current_step_index += 1
+            self._mark_completed_if_past_end(
+                execution,
+                workflow,
+                "Workflow completed (final failed step skipped): %s",
+            )
             logger.warning("Skipped failed step: %s", step.id)
         # For RETRY, ASK_USER, FALLBACK - return result for caller to handle
 

--- a/tests/unit/shared_python/test_ai_workflow_engine.py
+++ b/tests/unit/shared_python/test_ai_workflow_engine.py
@@ -439,6 +439,56 @@ class TestExecuteNextStep:
         result = engine.execute_next_step(exe)
         assert result.status == StepStatus.SKIPPED
 
+    def test_final_validation_failure_skip_completes_execution(
+        self, engine: WorkflowEngine, context: ConversationContext
+    ) -> None:
+        wf = Workflow(id="wf-final-skip", name="WF", description="D")
+        wf.add_step(
+            WorkflowStep(
+                id="s1",
+                name="S1",
+                description="D",
+                validation=lambda _: ValidationResult(passed=False, message="Bad"),
+                on_failure=RecoveryStrategy.SKIP,
+            )
+        )
+        engine.register_workflow(wf)
+        exe = engine.start_workflow("wf-final-skip", context)
+        result = engine.execute_next_step(exe)
+        progress = engine.get_progress(exe)
+
+        assert result.status == StepStatus.SKIPPED
+        assert exe.current_step_index == len(wf.steps)
+        assert engine.is_complete(exe)
+        assert exe.status == StepStatus.COMPLETED
+        assert progress["status"] == StepStatus.COMPLETED.name
+
+    def test_validation_exception_aborts_workflow(
+        self, engine: WorkflowEngine, context: ConversationContext
+    ) -> None:
+        def raise_validation_error(_result: object) -> ValidationResult:
+            raise ValueError("bad validation")
+
+        wf = Workflow(id="wf-validation-exception", name="WF", description="D")
+        wf.add_step(
+            WorkflowStep(
+                id="s1",
+                name="S1",
+                description="D",
+                validation=raise_validation_error,
+                on_failure=RecoveryStrategy.ABORT,
+            )
+        )
+        engine.register_workflow(wf)
+        exe = engine.start_workflow("wf-validation-exception", context)
+        result = engine.execute_next_step(exe)
+
+        assert result.status == StepStatus.FAILED
+        assert result.validation is not None
+        assert result.validation.passed is False
+        assert "bad validation" in (result.error or "")
+        assert exe.status == StepStatus.FAILED
+
 
 # ---------------------------------------------------------------------------
 # WorkflowEngine — get_progress


### PR DESCRIPTION
## Summary
- Fail closed when workflow step validation raises a runtime validation exception.
- Mark executions completed when a final failed step is skipped by recovery.
- Add regression coverage for terminal skip status and validation exception handling.

## Validation
- `py -3.13 -m pytest -q tests\unit\shared_python\test_ai_workflow_engine.py tests\ai\test_ai_workflow.py tests\ai\test_workflow_engine.py`
- `py -3.13 -m ruff check src\shared\python\ai\workflow_engine.py tests\unit\shared_python\test_ai_workflow_engine.py`
- `py -3.13 -m ruff format --check src\shared\python\ai\workflow_engine.py tests\unit\shared_python\test_ai_workflow_engine.py`
- `git push` pre-push hooks: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, mypy, bandit, pytest

Notes: an earlier manual `pre_commit run --hook-stage pre-push --all-files` was stopped after it hit pre-existing unrelated repo-wide wildcard/no-print/prettier failures and began a broad type-check run. Its hook-generated unrelated formatting changes were restored before push.

Closes #8178
Closes #8179