### PR TITLE
test(ai): isolate adapter sdk mocks

### DIFF
--- a/tests/ai/test_ai_adapters.py
+++ b/tests/ai/test_ai_adapters.py
@@ -14,6 +14,12 @@ mock_openai_module = MagicMock()
 mock_anthropic_module = MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def reset_sdk_module_mocks() -> None:
+    mock_openai_module.reset_mock(return_value=True, side_effect=True)
+    mock_anthropic_module.reset_mock(return_value=True, side_effect=True)
+
+
 @pytest.fixture
 def mock_openai_adapter() -> Generator[Any, None, None]:
     with patch.dict(sys.modules, {"openai": mock_openai_module}):

--- a/tests/unit/shared_python/ai/adapters/test_anthropic_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_anthropic_adapter.py
@@ -33,6 +33,11 @@ from src.shared.python.ai.types import (  # noqa: E402
 )
 
 
+@pytest.fixture(autouse=True)
+def reset_anthropic_mock() -> None:
+    anthropic_mock.reset_mock(return_value=True, side_effect=True)
+
+
 @pytest.fixture
 def adapter() -> AnthropicAdapter:
     """Provide a configured AnthropicAdapter."""

--- a/tests/unit/shared_python/ai/adapters/test_gemini_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_gemini_adapter.py
@@ -17,7 +17,7 @@ import pytest  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def reset_mocks() -> None:
-    sys.modules["google.generativeai"].reset_mock()
+    sys.modules["google.generativeai"].reset_mock(return_value=True, side_effect=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/shared_python/ai/adapters/test_ollama_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_ollama_adapter.py
@@ -34,7 +34,7 @@ import pytest  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def reset_mocks() -> None:
-    sys.modules["httpx"].reset_mock()
+    sys.modules["httpx"].reset_mock(return_value=True, side_effect=True)
 
 
 from src.shared.python.ai.adapters.base import ToolDeclaration  # noqa: E402

--- a/tests/unit/shared_python/ai/adapters/test_openai_adapter.py
+++ b/tests/unit/shared_python/ai/adapters/test_openai_adapter.py
@@ -31,6 +31,11 @@ from src.shared.python.ai.types import (  # noqa: E402
 )
 
 
+@pytest.fixture(autouse=True)
+def reset_openai_mock() -> None:
+    openai_mock.reset_mock(return_value=True, side_effect=True)
+
+
 @pytest.fixture
 def adapter() -> OpenAIAdapter:
     """Provide a configured OpenAIAdapter."""


### PR DESCRIPTION
## Summary
- Reset module-level OpenAI, Anthropic, Gemini, and Ollama SDK mocks before each adapter test.
- Clear nested mock return values and side effects so test order cannot leak provider state.
- Keep the fix test-only; no adapter runtime code changed.

## Validation
- `py -3.13 -m pytest -q tests\ai\test_ai_adapters.py tests\unit\shared_python\ai\adapters\test_openai_adapter.py tests\unit\shared_python\ai\adapters\test_anthropic_adapter.py tests\unit\shared_python\ai\adapters\test_gemini_adapter.py tests\unit\shared_python\ai\adapters\test_ollama_adapter.py`
- `py -3.13 -m ruff check tests\ai\test_ai_adapters.py tests\unit\shared_python\ai\adapters\test_openai_adapter.py tests\unit\shared_python\ai\adapters\test_anthropic_adapter.py tests\unit\shared_python\ai\adapters\test_gemini_adapter.py tests\unit\shared_python\ai\adapters\test_ollama_adapter.py`
- `py -3.13 -m ruff format --check tests\ai\test_ai_adapters.py tests\unit\shared_python\ai\adapters\test_openai_adapter.py tests\unit\shared_python\ai\adapters\test_anthropic_adapter.py tests\unit\shared_python\ai\adapters\test_gemini_adapter.py tests\unit\shared_python\ai\adapters\test_ollama_adapter.py`
- `git push` pre-push hooks: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, mypy, bandit, pytest

Closes #8180