### PR TITLE
fix(c3d): default missing point units

### DIFF
--- a/src/shared/python/sidekick/lab/bio/_c3d_io.py
+++ b/src/shared/python/sidekick/lab/bio/_c3d_io.py
@@ -30,6 +30,7 @@ from ._c3d_models import (
 logger = get_logger(__name__)
 
 C3DMapping = dict[str, Any]
+DEFAULT_POINT_UNITS = "mm"
 
 
 def load_c3d(file_path: Path) -> C3DMapping:
@@ -93,6 +94,15 @@ def get_analog_details(
         units = units[: len(labels)]
 
     return labels, analog_rate, units
+
+
+def get_point_units(point_parameters: dict[str, Any]) -> str:
+    """Return POINT units, defaulting malformed legacy C3D metadata to mm."""
+    values = point_parameters.get("UNITS", {}).get("value", [])
+    if not values:
+        return DEFAULT_POINT_UNITS
+    units = str(values[0]).strip()
+    return units or DEFAULT_POINT_UNITS
 
 
 def get_events(c3d_data: C3DMapping) -> list[C3DEvent]:
@@ -380,7 +390,7 @@ def build_metadata(c3d_data: C3DMapping, file_path: Path) -> C3DMetadata:
     marker_labels = [label.strip() for label in point_parameters["LABELS"]["value"]]
     frame_count = int(point_parameters["FRAMES"]["value"][0])
     frame_rate = float(point_parameters["RATE"]["value"][0])
-    units = str(point_parameters["UNITS"]["value"][0])
+    units = get_point_units(point_parameters)
     analog_labels, analog_rate, analog_units = get_analog_details(c3d_data)
     events = get_events(c3d_data)
     force_plates = get_force_platforms(c3d_data, len(analog_labels))

--- a/src/shared/python/sidekick/lab/bio/c3d_reader.py
+++ b/src/shared/python/sidekick/lab/bio/c3d_reader.py
@@ -72,6 +72,8 @@ class C3DDataReader:
 
     def __init__(self, file_path: Path | str) -> None:
         """Initialize the C3D data reader with a file path."""
+        if not str(file_path):
+            raise ValueError("file_path must be provided")
         self.file_path = Path(file_path)
         self._c3d_data: C3DMapping | None = None
         self._metadata: C3DMetadata | None = None

--- a/src/shared/python/sidekick/tests/lab/bio/test_c3d_edge_cases.py
+++ b/src/shared/python/sidekick/tests/lab/bio/test_c3d_edge_cases.py
@@ -26,6 +26,7 @@ from sidekick.lab.bio.c3d_reader import (
     C3DEvent,
     C3DMetadata,
 )
+from sidekick.lab.bio._c3d_io import build_metadata
 
 # ---------------------------------------------------------------------------
 # C3DEvent validation
@@ -87,6 +88,47 @@ class TestC3DMetadataValidation:
             events=[],
         )
         assert meta.duration == 0.0
+
+    @pytest.fixture()
+    def c3d_point_metadata(self) -> dict:
+        return {
+            "parameters": {
+                "POINT": {
+                    "LABELS": {"value": ["M1"]},
+                    "FRAMES": {"value": [10]},
+                    "RATE": {"value": [100.0]},
+                    "UNITS": {"value": ["cm"]},
+                },
+                "ANALOG": {
+                    "LABELS": {"value": []},
+                    "UNITS": {"value": []},
+                    "RATE": {"value": [0.0]},
+                },
+            },
+            "data": {
+                "analogs": np.empty((1, 0, 0)),
+            },
+        }
+
+    def test_metadata_defaults_absent_point_units_to_mm(
+        self, c3d_point_metadata: dict
+    ) -> None:
+        """C3D files without POINT:UNITS still build actionable metadata."""
+        del c3d_point_metadata["parameters"]["POINT"]["UNITS"]
+
+        metadata = build_metadata(c3d_point_metadata, Path("missing-units.c3d"))
+
+        assert metadata.units == "mm"
+
+    def test_metadata_defaults_empty_point_units_to_mm(
+        self, c3d_point_metadata: dict
+    ) -> None:
+        """Empty POINT:UNITS values use the same default as absent units."""
+        c3d_point_metadata["parameters"]["POINT"]["UNITS"]["value"] = []
+
+        metadata = build_metadata(c3d_point_metadata, Path("empty-units.c3d"))
+
+        assert metadata.units == "mm"
 
     def test_duration_correct(self) -> None:
         """Duration = frame_count / frame_rate."""
@@ -157,7 +199,7 @@ class TestAnalogEdgeCases:
 
     @pytest.fixture()
     def mock_ezc3d(self):
-        with patch("sidekick.lab.bio.c3d_reader.ezc3d") as mock:
+        with patch("sidekick.lab.bio._c3d_io.ezc3d") as mock:
             yield mock
 
     @pytest.fixture()

--- a/src/shared/python/sidekick/tests/lab/bio/test_c3d_reader_fixed.py
+++ b/src/shared/python/sidekick/tests/lab/bio/test_c3d_reader_fixed.py
@@ -22,7 +22,7 @@ from sidekick.lab.bio.c3d_reader import C3DDataReader
 class TestC3DDataReader:
     @pytest.fixture
     def mock_ezc3d(self) -> Generator[MagicMock, None, None]:
-        with patch("sidekick.lab.bio.c3d_reader.ezc3d") as mock:
+        with patch("sidekick.lab.bio._c3d_io.ezc3d") as mock:
             yield mock
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
- Default missing, empty, or blank C3D `POINT:UNITS` metadata to `mm` instead of crashing metadata extraction.
- Add direct regressions for absent and empty `POINT:UNITS` values.
- Restore adjacent C3D reader tests by patching the actual `_c3d_io.ezc3d` backend and enforcing the existing empty-path precondition.

## Validation
- `py -3.13 -m pytest -q src\shared\python\sidekick\tests\lab\bio\test_c3d_reader_fixed.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- Golden fixture smoke: `C3DDataReader("tests/data/motion_pipeline/golden/sample.c3d").get_metadata()` returns units `mm`, 30 frames, 6 markers.
- `py -3.13 -m ruff check src\shared\python\sidekick\lab\bio\_c3d_io.py src\shared\python\sidekick\lab\bio\c3d_reader.py src\shared\python\sidekick\tests\lab\bio\test_c3d_reader_fixed.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- `py -3.13 -m ruff format --check src\shared\python\sidekick\lab\bio\_c3d_io.py src\shared\python\sidekick\lab\bio\c3d_reader.py src\shared\python\sidekick\tests\lab\bio\test_c3d_reader_fixed.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- `py -3.13 scripts\ci\check_file_size_budget.py --base-ref origin/main`
- `git diff --check`
- `git push` pre-push hooks: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, mypy, bandit, pytest

Note: these sidekick files are child copies of the Tools source. I am mirroring the same change into Tools separately so the canonical source is retained.

Closes #8082