### PR TITLE
fix: open Shot Tracer in launcher tab

### DIFF
--- a/src/launchers/launcher_simulation.py
+++ b/src/launchers/launcher_simulation.py
@@ -1061,6 +1061,25 @@ except (RuntimeError, TypeError, AttributeError) as e:
 
     def _launch_shot_tracer(self) -> None:
         """Launch the Shot Tracer ball flight visualization."""
+        if hasattr(self, "dock_widget_as_tab"):
+            try:
+                from src.launchers import _shot_tracer_gui
+
+                ui_widget = _shot_tracer_gui.get_dockable_ui()
+                if ui_widget is None:
+                    raise RuntimeError("Shot Tracer UI factory returned no widget")
+                self.dock_widget_as_tab(ui_widget, "Shot Tracer")
+                self.show_toast("Shot Tracer loaded as tab.", "success")
+                self.lbl_status.setText("> Shot Tracer Running")
+                self.lbl_status.setStyleSheet(Styles.STATUS_SUCCESS)
+                return
+            except (ImportError, OSError, RuntimeError, ValueError) as e:
+                logger.exception("Failed to load Shot Tracer UI")
+                self.show_toast(f"Shot Tracer unavailable: {e}", "error")
+                self.lbl_status.setText("! Launch Error")
+                self.lbl_status.setStyleSheet(Styles.STATUS_ERROR)
+                return
+
         shot_tracer_script = REPOS_ROOT / "src" / "launchers" / "shot_tracer.py"
 
         if not shot_tracer_script.exists():

--- a/tests/launchers/test_launcher_simulation.py
+++ b/tests/launchers/test_launcher_simulation.py
@@ -556,6 +556,38 @@ def test_launch_shot_tracer(launcher) -> None:
         launcher.show_toast.assert_called_with("Shot Tracer script not found.", "error")
 
 
+@pytest.mark.unit
+def test_launch_shot_tracer_prefers_registered_dockable_ui(launcher) -> None:
+    ui_widget = MagicMock()
+    launcher.dock_widget_as_tab = MagicMock()
+
+    with patch(
+        "src.launchers._shot_tracer_gui.get_dockable_ui", return_value=ui_widget
+    ):
+        launcher._launch_shot_tracer()
+
+    launcher.dock_widget_as_tab.assert_called_once_with(ui_widget, "Shot Tracer")
+    launcher.process_manager.launch_script.assert_not_called()
+    launcher.show_toast.assert_called_with("Shot Tracer loaded as tab.", "success")
+
+
+@pytest.mark.unit
+def test_launch_shot_tracer_reports_embedded_ui_failure(launcher) -> None:
+    launcher.dock_widget_as_tab = MagicMock()
+
+    with patch(
+        "src.launchers._shot_tracer_gui.get_dockable_ui",
+        side_effect=RuntimeError("missing OpenGL support"),
+    ):
+        launcher._launch_shot_tracer()
+
+    launcher.dock_widget_as_tab.assert_not_called()
+    launcher.process_manager.launch_script.assert_not_called()
+    launcher.show_toast.assert_called_once_with(
+        "Shot Tracer unavailable: missing OpenGL support", "error"
+    )
+
+
 @patch("src.launchers.launcher_simulation.secure_popen")
 def test_launch_matlab_app(mock_popen, launcher) -> None:
     model = DummyModel("m2", "M2", "matlab_app", path="test.slx")


### PR DESCRIPTION
## Summary
- open Shot Tracer through its dockable PyQt UI when the launcher supports tabs
- report embedded UI creation failures with an error toast instead of falling back to a silent subprocess
- add focused launcher regressions for the tab path and visible failure path

## Validation
- python -m pytest tests\launchers\test_launcher_simulation.py -k "shot_tracer" -q
- python -m pytest tests\launchers\test_shot_tracer.py tests\launchers\test_launcher_simulation.py -k "shot_tracer" -q
- python -m ruff check src\launchers\launcher_simulation.py tests\launchers\test_launcher_simulation.py
- python -m ruff format --check src\launchers\launcher_simulation.py tests\launchers\test_launcher_simulation.py

Closes #8069