### PR TITLE
fix(launcher): detect failed package app startup

### DIFF
--- a/src/launchers/launcher_model_handlers.py
+++ b/src/launchers/launcher_model_handlers.py
@@ -330,6 +330,7 @@ class SpecialAppHandler:
                 module_name=package_module,
                 cwd=working_directory,
                 extra_python_paths=python_paths,
+                confirm_startup=True,
             )
         else:
             process = process_manager.launch_script(

--- a/src/launchers/launcher_process_manager.py
+++ b/src/launchers/launcher_process_manager.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 OutputCallback = Callable[[str, str], None]  # (engine_name, line) -> None
+STARTUP_FAILURE_GRACE_SECONDS = 0.5
 
 # Windows-specific subprocess constants
 CREATE_NO_WINDOW: int
@@ -460,6 +461,30 @@ class ProcessManager:
         t.start()
         self._output_threads[name] = t
 
+    def _process_survives_startup(
+        self,
+        name: str,
+        process: subprocess.Popen[bytes],
+        startup_timeout_seconds: float,
+    ) -> bool:
+        """Return whether ``process`` stays alive through the startup grace."""
+        if startup_timeout_seconds < 0:
+            raise ValueError("startup_timeout_seconds must be non-negative")
+        if startup_timeout_seconds == 0:
+            return True
+
+        try:
+            return_code = process.wait(timeout=startup_timeout_seconds)
+        except subprocess.TimeoutExpired:
+            return True
+        except (OSError, ValueError) as exc:
+            logger.debug("Could not confirm startup state for %s: %s", name, exc)
+            return True
+
+        logger.error("%s exited during startup with code %s", name, return_code)
+        self._stream_output(name, process)
+        return False
+
     def _stream_output(self, name: str, process: subprocess.Popen[bytes]) -> None:
         """Read stdout/stderr from *process* and emit lines until EOF.
 
@@ -494,6 +519,8 @@ class ProcessManager:
         env: dict[str, str] | None = None,
         extra_python_paths: tuple[Path, ...] = (),
         keep_terminal_open: bool = False,
+        confirm_startup: bool = False,
+        startup_timeout_seconds: float = STARTUP_FAILURE_GRACE_SECONDS,
     ) -> subprocess.Popen[bytes] | None:
         """Launch a Python script as a subprocess.
 
@@ -568,6 +595,16 @@ class ProcessManager:
                     creationflags=CREATE_NO_WINDOW if os.name == "nt" else 0,
                     preexec_fn=_preexec_fn,
                 )
+            _assign_to_job(process)
+
+            if confirm_startup and not self._process_survives_startup(
+                name,
+                process,
+                startup_timeout_seconds,
+            ):
+                return None
+
+            if not self.use_separate_terminals:
                 # Stream output in a background thread
                 t = threading.Thread(
                     target=self._stream_output,
@@ -576,8 +613,6 @@ class ProcessManager:
                 )
                 t.start()
                 self._output_threads[name] = t
-
-            _assign_to_job(process)
 
             # Guard running_processes dict with lock (issue #2715)
             self._add_to_running_processes(name, process)
@@ -602,6 +637,8 @@ class ProcessManager:
         env: dict[str, str] | None = None,
         extra_python_paths: tuple[Path, ...] = (),
         keep_terminal_open: bool = False,
+        confirm_startup: bool = False,
+        startup_timeout_seconds: float = STARTUP_FAILURE_GRACE_SECONDS,
     ) -> subprocess.Popen[bytes] | None:
         """Launch a Python module as a subprocess.
 
@@ -701,6 +738,16 @@ class ProcessManager:
                     creationflags=CREATE_NO_WINDOW if os.name == "nt" else 0,
                     preexec_fn=_preexec_fn,
                 )
+            _assign_to_job(process)
+
+            if confirm_startup and not self._process_survives_startup(
+                name,
+                process,
+                startup_timeout_seconds,
+            ):
+                return None
+
+            if not self.use_separate_terminals:
                 t = threading.Thread(
                     target=self._stream_output,
                     args=(name, process),
@@ -708,8 +755,6 @@ class ProcessManager:
                 )
                 t.start()
                 self._output_threads[name] = t
-
-            _assign_to_job(process)
 
             # Guard running_processes dict with lock (issue #2715)
             self._add_to_running_processes(name, process)

--- a/tests/launchers/test_model_handlers.py
+++ b/tests/launchers/test_model_handlers.py
@@ -237,6 +237,7 @@ class TestSpecialAppHandler:
             module_name="movement_optimizer",
             cwd=optimizer_root.resolve(),
             extra_python_paths=((optimizer_root / "src").resolve(),),
+            confirm_startup=True,
         )
         process_manager.launch_script.assert_not_called()
 

--- a/tests/launchers/test_motion_match_preview_launch.py
+++ b/tests/launchers/test_motion_match_preview_launch.py
@@ -72,5 +72,6 @@ def test_motion_match_preview_uses_local_source_package_module(
         module_name="src.tools.starting_pose_matcher",
         cwd=tmp_path.resolve(),
         extra_python_paths=(),
+        confirm_startup=True,
     )
     process_manager.launch_script.assert_not_called()

--- a/tests/launchers/test_pendulum_simulator_entrypoint.py
+++ b/tests/launchers/test_pendulum_simulator_entrypoint.py
@@ -69,5 +69,38 @@ def test_pendulum_tile_uses_module_launch_not_script_launch(tmp_path: Path) -> N
         module_name="shared.python.pendulum_simulator",
         cwd=tmp_path,
         extra_python_paths=(),
+        confirm_startup=True,
+    )
+    process_manager.launch_script.assert_not_called()
+
+
+@pytest.mark.unit
+def test_pendulum_tile_reports_fast_module_startup_failure(tmp_path: Path) -> None:
+    """A child process that dies during startup must not produce a success toast."""
+    entrypoint = (
+        tmp_path / "src" / "shared" / "python" / "pendulum_simulator" / "__main__.py"
+    )
+    entrypoint.parent.mkdir(parents=True)
+    entrypoint.write_text("raise SystemExit(1)\n", encoding="utf-8")
+    model = SimpleNamespace(
+        id="pendulum_simulator",
+        name="Pendulum Simulator",
+        path="src/shared/python/pendulum_simulator/__main__.py",
+        type="special_app",
+        source_root=None,
+        working_dir=None,
+        python_paths=(),
+    )
+    process_manager = MagicMock()
+    process_manager.launch_module.return_value = None
+
+    assert SpecialAppHandler().launch(model, tmp_path, process_manager) is False
+
+    process_manager.launch_module.assert_called_once_with(
+        name="Pendulum Simulator",
+        module_name="shared.python.pendulum_simulator",
+        cwd=tmp_path,
+        extra_python_paths=(),
+        confirm_startup=True,
     )
     process_manager.launch_script.assert_not_called()

--- a/tests/launchers/test_pose_studio_launch_containment.py
+++ b/tests/launchers/test_pose_studio_launch_containment.py
@@ -64,5 +64,6 @@ def test_pose_studio_uses_a_child_package_module(
         module_name="src.tools.pose_studio",
         cwd=tmp_path.resolve(),
         extra_python_paths=(),
+        confirm_startup=True,
     )
     process_manager.launch_script.assert_not_called()

--- a/tests/unit/launchers/test_launch_regressions.py
+++ b/tests/unit/launchers/test_launch_regressions.py
@@ -437,3 +437,41 @@ class TestProcessImmediateDeathDetection:
             calls = [str(c) for c in mock_emit.call_args_list]
             exit_logged = any("exited with code" in c for c in calls)
             assert exit_logged, f"Expected exit code in output, got: {calls}"
+
+    def test_launch_module_confirm_startup_rejects_fast_exit(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #8065: package app startup failure must not look launched."""
+        from src.launchers.launcher_process_manager import ProcessManager
+
+        mod_dir = tmp_path / "failing_mod"
+        mod_dir.mkdir()
+        (mod_dir / "__main__.py").write_text(
+            "import sys; print('startup failed', file=sys.stderr); sys.exit(2)\n",
+            encoding="utf-8",
+        )
+
+        pm = ProcessManager(REPO_ROOT)
+        with (
+            patch(
+                "src.launchers.launcher_process_manager.secure_popen",
+                side_effect=lambda cmd, cwd=None, suite_root=None, **kw: __import__(
+                    "subprocess"
+                ).Popen(cmd, cwd=str(cwd) if cwd else None, **kw),
+            ),
+            patch.object(pm, "_emit_output") as mock_emit,
+        ):
+            process = pm.launch_module(
+                "test_bad_mod",
+                "failing_mod",
+                tmp_path,
+                confirm_startup=True,
+                startup_timeout_seconds=2.0,
+            )
+
+        assert process is None
+        assert "test_bad_mod" not in pm.running_processes
+        calls = [str(c) for c in mock_emit.call_args_list]
+        assert any("startup failed" in c for c in calls)
+        assert any("exited with code 2" in c for c in calls)


### PR DESCRIPTION
## Summary
- Add an opt-in startup health check to ProcessManager module/script launches
- Use startup confirmation for package __main__ special-app tiles so fast child exits return launch failure
- Pin Pendulum Simulator false-success behavior plus adjacent package-entry launch contracts

Closes #8065.

## Validation
- py -3.13 -m pytest -q tests\\launchers\\test_pendulum_simulator_entrypoint.py tests\\unit\\launchers\\test_launch_regressions.py::TestProcessImmediateDeathDetection
- py -3.13 -m pytest -q tests\\launchers\\test_pendulum_simulator_entrypoint.py tests\\launchers\\test_pose_studio_launch_containment.py tests\\launchers\\test_motion_match_preview_launch.py tests\\launchers\\test_model_handlers.py tests\\launchers\\test_launcher_model_handlers.py tests\\launchers\\test_launcher_process_manager.py tests\\unit\\launchers\\test_launch_regressions.py::TestProcessImmediateDeathDetection
- py -3.13 -m pytest -q tests\\launchers\\test_launcher_simulation.py
- py -3.13 -m ruff check src\\launchers\\launcher_process_manager.py src\\launchers\\launcher_model_handlers.py tests\\launchers\\test_pendulum_simulator_entrypoint.py tests\\launchers\\test_pose_studio_launch_containment.py tests\\launchers\\test_motion_match_preview_launch.py tests\\launchers\\test_model_handlers.py tests\\unit\\launchers\\test_launch_regressions.py
- py -3.13 -m ruff format --check src\\launchers\\launcher_process_manager.py src\\launchers\\launcher_model_handlers.py tests\\launchers\\test_pendulum_simulator_entrypoint.py tests\\launchers\\test_pose_studio_launch_containment.py tests\\launchers\\test_motion_match_preview_launch.py tests\\launchers\\test_model_handlers.py tests\\unit\\launchers\\test_launch_regressions.py
- py -3.13 scripts\\ci\\check_file_size_budget.py --base-ref origin/main
- git diff --check
- pre-push hooks: ruff, format, formatter guidance, no wildcard imports, no debug statements, no print() in src, mypy, bandit, pytest