### PR TITLE
fix(launcher): pass parent to embeddable tools

### DIFF
--- a/src/launchers/launcher_model_handlers.py
+++ b/src/launchers/launcher_model_handlers.py
@@ -351,7 +351,7 @@ class SpecialAppHandler:
 
             tool = get_embeddable_tool(tool_id)
             if tool is not None:
-                return tool.create_main_widget()
+                return tool.create_main_widget(None)
 
         embed_adapter = getattr(model, "embed_adapter", None)
         if embed_adapter and "::" in embed_adapter:

--- a/tests/launchers/test_model_handlers.py
+++ b/tests/launchers/test_model_handlers.py
@@ -20,6 +20,11 @@ from src.launchers.launcher_model_handlers import (  # noqa: E402
     _package_main_module_name,
 )
 from src.launchers.launcher_process_manager import ProcessManager  # noqa: E402
+from src.shared.python.launcher_embed import (  # noqa: E402
+    EmbedCapabilities,
+    register_embeddable_tool,
+    unregister_embeddable_tool,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -289,7 +294,49 @@ class TestSpecialAppHandler:
             result = SpecialAppHandler().get_dockable_ui(model, tmp_path)
 
         assert result is widget
-        tool.create_main_widget.assert_called_once_with()
+        tool.create_main_widget.assert_called_once_with(None)
+
+    def test_registered_embeddable_tool_receives_parent_argument(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Special-app docking must honor the EmbeddableTool parent contract."""
+
+        class ParentRecordingTool:
+            tool_id = "registered_parent_tool"
+
+            def __init__(self) -> None:
+                self.parent_seen = object()
+                self.widget = object()
+
+            def embed_capabilities(self) -> EmbedCapabilities:
+                return EmbedCapabilities(supports_embedded=True)
+
+            def create_main_widget(self, parent: object | None) -> object:
+                self.parent_seen = parent
+                return self.widget
+
+            def cleanup(self) -> None:
+                pass
+
+            def is_dirty(self) -> bool:
+                return False
+
+        model = MockModel(
+            id="registered_parent_tool",
+            name="Registered Parent Tool",
+            path="src/tools/registered_parent_tool/gui.py",
+            type="special_app",
+        )
+        tool = ParentRecordingTool()
+        register_embeddable_tool(tool)
+        try:
+            result = SpecialAppHandler().get_dockable_ui(model, tmp_path)
+        finally:
+            unregister_embeddable_tool(tool.tool_id)
+
+        assert result is tool.widget
+        assert tool.parent_seen is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Pass the documented None Qt parent through SpecialAppHandler when opening registered embeddable tools
- Replace the permissive mock assertion with an explicit parent expectation
- Add a contract-shaped fake embeddable tool regression so missing parent arguments fail in tests

Closes #8191.

## Validation
- py -3.13 -m pytest -q tests\\launchers\\test_model_handlers.py::TestSpecialAppHandler::test_registered_embeddable_tool_receives_parent_argument tests\\launchers\\test_model_handlers.py::TestSpecialAppHandler::test_dockable_probe_uses_registered_embeddable_tool
- py -3.13 -m pytest -q tests\\launchers\\test_model_handlers.py tests\\launchers\\test_launcher_model_handlers.py tests\\launchers\\launcher_embed\\test_contract_validation.py tests\\launchers\\launcher_embed\\test_registry_ops.py tests\\launchers\\launcher_embed\\test_embedded_host_edges.py
- py -3.13 -m ruff check src\\launchers\\launcher_model_handlers.py tests\\launchers\\test_model_handlers.py
- py -3.13 -m ruff format --check src\\launchers\\launcher_model_handlers.py tests\\launchers\\test_model_handlers.py
- py -3.13 scripts\\ci\\check_file_size_budget.py --base-ref origin/main
- git diff --check
- pre-push hooks: ruff, format, formatter guidance, no wildcard imports, no debug statements, no print() in src, mypy, bandit, pytest