### PR TITLE
fix(api): report launcher stop failures

### DIFF
--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -493,7 +493,7 @@ def _execute_tile_launch(
 
 def _register_launcher_endpoints(app: FastAPI) -> None:
     """Register launcher manifest, logo, launch, process, and stop endpoints."""
-    from src.api.services.launcher_service import LauncherService
+    from src.api.services.launcher_service import LauncherService, StopProcessStatus
 
     _repo_root = Path(__file__).parent.parent.parent
     _launcher_service = LauncherService(repo_root=_repo_root)
@@ -571,10 +571,19 @@ def _register_launcher_endpoints(app: FastAPI) -> None:
     ) -> dict[str, Any] | JSONResponse:
         """Stop a running engine/tool process by name."""
         _enforce_launcher_mutation_guard(request)
-        if not _launcher_service.stop_process(name):
+        stop_result = _launcher_service.stop_process(name)
+        if stop_result.status is StopProcessStatus.NOT_FOUND:
             logger.warning("[stop] Process not found: %s", name)
             return JSONResponse(
                 status_code=404, content={"detail": f"Process not found: {name}"}
+            )
+        if stop_result.status is StopProcessStatus.FAILED:
+            logger.error("[stop] Failed to stop process: %s", name)
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "detail": stop_result.detail or f"Failed to stop process: {name}"
+                },
             )
         return {"status": "stopped", "name": name}
 

--- a/src/api/services/launcher_service.py
+++ b/src/api/services/launcher_service.py
@@ -11,6 +11,9 @@ be agnostic of the GUI launcher).
 
 from __future__ import annotations
 
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +21,28 @@ from src.shared.python.core.contracts import precondition
 from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
+STOP_PROCESS_TIMEOUT_SECONDS = 5.0
+
+
+class StopProcessStatus(str, Enum):
+    """Outcome categories for a launcher process-stop request."""
+
+    STOPPED = "stopped"
+    NOT_FOUND = "not_found"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class StopProcessResult:
+    """Structured result for stopping a launcher process."""
+
+    status: StopProcessStatus
+    name: str
+    detail: str = ""
+
+    def __bool__(self) -> bool:
+        """Preserve truthiness for legacy callers that expect a bool."""
+        return self.status is StopProcessStatus.STOPPED
 
 
 class LauncherService:
@@ -88,30 +113,50 @@ class LauncherService:
             }
         return processes
 
+    def _fallback_stop_process(self, name: str, proc: Any) -> bool:
+        """Attempt bounded terminate/kill fallback after tree-kill failure."""
+        if proc.poll() is not None:
+            return True
+        try:
+            logger.warning("[stop] Falling back to terminate() for %s", name)
+            proc.terminate()
+            try:
+                proc.wait(timeout=STOP_PROCESS_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                logger.warning("[stop] terminate() timed out for %s; killing", name)
+                proc.kill()
+                proc.wait(timeout=STOP_PROCESS_TIMEOUT_SECONDS)
+        except (OSError, RuntimeError, subprocess.TimeoutExpired):
+            logger.exception("[stop] Failed to stop process %s", name)
+            return False
+        return proc.poll() is not None
+
     @precondition(
         lambda self, name: name is not None and len(name) > 0,
         "Process name must be a non-empty string",
     )
-    def stop_process(self, name: str) -> bool:
+    def stop_process(self, name: str) -> StopProcessResult:
         """Stop a running process by name.
 
         Args:
             name: Process name.
 
         Returns:
-            True if process was found and stopped, False if not found.
+            Structured stop outcome for API/UI status mapping.
         """
-        if not (name is not None):
-            raise ValueError("name must be provided")
         from src.shared.python.security.subprocess_utils import kill_process_tree
 
         running = self.process_manager.running_processes
         proc = running.get(name)
         if proc is None:
-            return False
+            return StopProcessResult(StopProcessStatus.NOT_FOUND, name)
 
         logger.info("[stop] Killing process tree for %s (pid=%s)", name, proc.pid)
-        kill_process_tree(proc.pid)
+        tree_stopped = kill_process_tree(proc.pid)
+        if not tree_stopped and not self._fallback_stop_process(name, proc):
+            detail = f"Failed to stop process: {name}"
+            logger.error("[stop] %s remains running after stop attempts", name)
+            return StopProcessResult(StopProcessStatus.FAILED, name, detail)
         del running[name]
         logger.info("[stop] Process %s stopped and removed", name)
-        return True
+        return StopProcessResult(StopProcessStatus.STOPPED, name)

--- a/tests/api/test_launcher_launch_api.py
+++ b/tests/api/test_launcher_launch_api.py
@@ -497,6 +497,24 @@ class TestStopEndpoint:
             client.post("/api/launcher/stop/Drake Golf Model")
             mock_kill.assert_called_once_with(54321)
 
+    def test_stop_failure_returns_500_and_keeps_process_tracked(self, client) -> None:
+        """A failed process stop must not be reported as a 200/stopped response."""
+        mock_proc = MagicMock(spec=_PROCESS_SPEC)
+        mock_proc.pid = 54321
+        mock_proc.poll.return_value = None
+        mock_proc.terminate.side_effect = OSError("access denied")
+        client._mock_process_manager.running_processes["Drake Golf Model"] = mock_proc
+
+        with patch(
+            "src.shared.python.security.subprocess_utils.kill_process_tree",
+            return_value=False,
+        ):
+            resp = client.post("/api/launcher/stop/Drake Golf Model")
+
+        assert resp.status_code == 500
+        assert "failed to stop" in resp.json()["detail"].lower()
+        assert "Drake Golf Model" in client._mock_process_manager.running_processes
+
 
 # ── Integration: launch → list → stop cycle ──────────────────────────
 

--- a/tests/unit/api/services/test_launcher_service.py
+++ b/tests/unit/api/services/test_launcher_service.py
@@ -8,12 +8,13 @@ run quickly and deterministically without launching actual processes.
 from __future__ import annotations
 
 import sys
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.api.services.launcher_service import LauncherService
+from src.api.services.launcher_service import LauncherService, StopProcessStatus
 
 
 @pytest.fixture
@@ -177,7 +178,7 @@ class TestLauncherServiceMethods:
         ):
             result = launcher_service.stop_process("test_proc")
 
-            assert result is True
+            assert result.status is StopProcessStatus.STOPPED
             mock_module.kill_process_tree.assert_called_once_with(1234)
             assert "test_proc" not in running_processes
 
@@ -189,7 +190,7 @@ class TestLauncherServiceMethods:
 
         result = launcher_service.stop_process("non_existent_proc")
 
-        assert result is False
+        assert result.status is StopProcessStatus.NOT_FOUND
 
     def test_stop_process_empty_name(self, launcher_service: LauncherService) -> None:
         """Test stop_process with empty name raises ValueError."""
@@ -200,3 +201,75 @@ class TestLauncherServiceMethods:
         """Test stop_process with None raises ValueError."""
         with pytest.raises(ValueError, match="Process name must be a non-empty string"):
             launcher_service.stop_process(None)  # type: ignore
+
+    def test_stop_process_failed_tree_kill_keeps_live_process_tracked(
+        self, launcher_service: LauncherService
+    ) -> None:
+        """A failed tree kill must not report success for a still-running process."""
+        mock_pm = MagicMock()
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+        mock_proc.poll.return_value = None
+        mock_proc.terminate.side_effect = OSError("access denied")
+        running_processes = {"test_proc": mock_proc}
+        mock_pm.running_processes = running_processes
+        launcher_service._process_manager = mock_pm
+
+        mock_module = MagicMock()
+        mock_module.kill_process_tree.return_value = False
+
+        with patch.dict(
+            sys.modules, {"src.shared.python.security.subprocess_utils": mock_module}
+        ):
+            result = launcher_service.stop_process("test_proc")
+
+        assert result.status is StopProcessStatus.FAILED
+        assert "test_proc" in running_processes
+        mock_proc.terminate.assert_called_once()
+
+    def test_stop_process_falls_back_to_terminate_then_kill(
+        self, launcher_service: LauncherService
+    ) -> None:
+        """When tree kill fails, bounded terminate/kill fallback can still stop it."""
+
+        class TimeoutThenKillProcess:
+            pid = 9876
+
+            def __init__(self) -> None:
+                self.terminated = False
+                self.killed = False
+                self.returncode: int | None = None
+
+            def poll(self) -> int | None:
+                return self.returncode
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def wait(self, timeout: float | None = None) -> int:
+                if self.returncode is None:
+                    raise subprocess.TimeoutExpired("demo", timeout)
+                return self.returncode
+
+            def kill(self) -> None:
+                self.killed = True
+                self.returncode = -9
+
+        mock_pm = MagicMock()
+        proc = TimeoutThenKillProcess()
+        running_processes = {"test_proc": proc}
+        mock_pm.running_processes = running_processes
+        launcher_service._process_manager = mock_pm
+
+        mock_module = MagicMock()
+        mock_module.kill_process_tree.return_value = False
+
+        with patch.dict(
+            sys.modules, {"src.shared.python.security.subprocess_utils": mock_module}
+        ):
+            result = launcher_service.stop_process("test_proc")
+
+        assert result.status is StopProcessStatus.STOPPED
+        assert proc.terminated is True
+        assert proc.killed is True
+        assert "test_proc" not in running_processes


### PR DESCRIPTION
## Summary
- Add structured stop outcomes for launcher process termination
- Fall back to bounded terminate/kill when process-tree termination reports failure
- Preserve tracking and return HTTP 500 when a process remains running after stop attempts

Closes #8192.

## Validation
- py -3.13 -m pytest -q tests\\unit\\api\\services\\test_launcher_service.py tests\\api\\test_launcher_launch_api.py::TestStopEndpoint
- py -3.13 -m pytest -q tests\\api\\test_launcher_launch_api.py tests\\unit\\api\\services\\test_launcher_service.py
- py -3.13 -m ruff check src\\api\\services\\launcher_service.py src\\api\\local_server.py tests\\unit\\api\\services\\test_launcher_service.py tests\\api\\test_launcher_launch_api.py
- py -3.13 -m ruff format --check src\\api\\services\\launcher_service.py src\\api\\local_server.py tests\\unit\\api\\services\\test_launcher_service.py tests\\api\\test_launcher_launch_api.py
- py -3.13 scripts\\ci\\check_file_size_budget.py --base-ref origin/main
- git diff --check
- pre-push hooks: ruff, format, formatter guidance, no wildcard imports, no debug statements, no print() in src, mypy, bandit, pytest