### PR TITLE
fix(api): lazy-load service reexports

### DIFF
--- a/src/api/services/__init__.py
+++ b/src/api/services/__init__.py
@@ -1,9 +1,13 @@
-"""API business-logic services."""
+"""API business-logic services.
 
-from .analysis_service import AnalysisService
-from .chat_service import ChatService
-from .launcher_service import LauncherService
-from .simulation_service import SimulationService, SimulationStats
+Service classes are re-exported lazily so importing one service submodule does
+not import optional dependencies owned by unrelated services.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
 
 __all__: list[str] = [
     "AnalysisService",
@@ -12,3 +16,26 @@ __all__: list[str] = [
     "SimulationService",
     "SimulationStats",
 ]
+
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    "AnalysisService": ("analysis_service", "AnalysisService"),
+    "ChatService": ("chat_service", "ChatService"),
+    "LauncherService": ("launcher_service", "LauncherService"),
+    "SimulationService": ("simulation_service", "SimulationService"),
+    "SimulationStats": ("simulation_service", "SimulationStats"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve service re-exports only when requested."""
+    if not isinstance(name, str):
+        raise TypeError(f"attribute name must be a str, not {type(name)!r}")
+    try:
+        module_name, attr_name = _LAZY_ATTRS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/tests/architecture/test_circular_dependencies.py
+++ b/tests/architecture/test_circular_dependencies.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import subprocess
 import sys
 from pathlib import Path
 
@@ -102,6 +103,52 @@ class TestApiDoesNotImportLaunchers:
                 )
         finally:
             sys.modules.update(saved)
+
+    def test_launcher_service_import_does_not_import_sibling_services(self) -> None:
+        """LauncherService import must not load unrelated optional services."""
+        saved = {
+            name: sys.modules.pop(name)
+            for name in list(sys.modules)
+            if name.startswith("src.api.services")
+        }
+        forbidden = {
+            "src.api.services.analysis_service",
+            "src.api.services.chat_service",
+            "src.api.services.simulation_service",
+        }
+        try:
+            mod = importlib.import_module("src.api.services.launcher_service")
+            assert hasattr(mod, "LauncherService")
+            loaded = forbidden.intersection(sys.modules)
+            assert not loaded, f"launcher_service import loaded {sorted(loaded)}"
+        finally:
+            sys.modules.update(saved)
+
+    def test_launcher_service_clean_subprocess_import_is_narrow(self) -> None:
+        """Clean interpreter import should not rely on pytest import side effects."""
+        repo_root = Path(__file__).resolve().parents[2]
+        code = (
+            "import importlib, sys\n"
+            "importlib.import_module('src.api.services.launcher_service')\n"
+            "forbidden = {\n"
+            "    'src.api.services.analysis_service',\n"
+            "    'src.api.services.chat_service',\n"
+            "    'src.api.services.simulation_service',\n"
+            "}\n"
+            "loaded = sorted(forbidden.intersection(sys.modules))\n"
+            "if loaded:\n"
+            "    raise SystemExit('loaded forbidden services: ' + ', '.join(loaded))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr or result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace eager `src.api.services` package re-exports with lazy `__getattr__` resolution
- Preserve `from src.api.services import LauncherService` and parent `from src.api import LauncherService` compatibility
- Add architecture regressions that cleanly import `launcher_service` without loading sibling services

Closes #8193.

## Validation
- py -3.13 -m pytest -q tests\architecture\test_circular_dependencies.py::TestApiDoesNotImportLaunchers::test_launcher_service_import_does_not_import_sibling_services tests\architecture\test_circular_dependencies.py::TestApiDoesNotImportLaunchers::test_launcher_service_clean_subprocess_import_is_narrow
- py -3.13 -m pytest -q tests\architecture\test_circular_dependencies.py::TestApiDoesNotImportLaunchers tests\unit\api\services\test_launcher_service.py
- py -3.13 -m pytest -q tests\architecture\test_circular_dependencies.py tests\unit\api\services\test_launcher_service.py tests\unit\test_api_services.py
- py -3.13 -c "from src.api.services import LauncherService; import sys; print(LauncherService.__name__); forbidden={'src.api.services.analysis_service','src.api.services.chat_service','src.api.services.simulation_service'}; loaded=sorted(forbidden.intersection(sys.modules)); sys.exit(','.join(loaded) if loaded else 0)"
- py -3.13 -c "from src.api import LauncherService; print(LauncherService.__name__)"
- py -3.13 -m ruff check src\api\services\__init__.py tests\architecture\test_circular_dependencies.py
- py -3.13 -m ruff format --check src\api\services\__init__.py tests\architecture\test_circular_dependencies.py
- py -3.13 scripts\ci\check_file_size_budget.py --base-ref origin/main
- git diff --check
- pre-push hooks: ruff, format, formatter guidance, no wildcard imports, no debug statements, no print() in src, mypy, bandit, pytest