### PR TITLE
fix(vendor): record immutable biomech provenance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,11 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened biomechanics vendored snapshot provenance (#8200).
+  `scripts/update_biomech_vendor.py` now requires full commit SHA refs by
+  default, exposes `--allow-mutable-ref` for deliberate branch/tag snapshots,
+  and records the requested ref, resolved commit SHA, mutable-ref opt-in, URL,
+  URL-override state, and clean working-tree state in `VENDOR_PROVENANCE.txt`.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains
@@ -1925,6 +1931,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Hardened biomechanics vendored snapshot provenance (#8200). `scripts/update_biomech_vendor.py` now requires full commit SHA refs by default, exposes `--allow-mutable-ref` for deliberate branch/tag snapshots, and records the requested ref, resolved commit SHA, mutable-ref opt-in, URL, URL-override state, and clean working-tree state in `VENDOR_PROVENANCE.txt`. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/docs/adr/0014-shared-biomech-models.md
+++ b/docs/adr/0014-shared-biomech-models.md
@@ -83,6 +83,9 @@ implemented by `_resolve_sibling()` in
    `tool_pack:resolve()` for tool packs) is called.
 3. **Vendored snapshot** at `vendor/biomech-models/<RepoName>/`,
    committed via `scripts/update_biomech_vendor.py --repo ... --ref ...`.
+   Snapshot refs are full commit SHAs by default. Branches and tags require
+   `--allow-mutable-ref`, and provenance records both the requested ref and
+   the resolved commit SHA.
 4. **Env-var override** — `<REPO>_HOME` (e.g. `MUJOCO_MODELS_HOME`) —
    for power users and ad-hoc layouts.
 

--- a/docs/architecture/biomech_workspace.md
+++ b/docs/architecture/biomech_workspace.md
@@ -61,16 +61,23 @@ python3 -c "from src.shared.python.config.model_source_providers import resolve_
 
 When no sibling checkout exists, the discovery layer falls through to
 `vendor/biomech-models/<RepoName>/`. Snapshots are produced from
-tagged releases:
+immutable commits by default:
 
 ```bash
-python3 scripts/update_biomech_vendor.py --repo MuJoCo_Models --ref v1.4.0
-python3 scripts/update_biomech_vendor.py --repo Drake_Models --ref v0.3.2
+python3 scripts/update_biomech_vendor.py --repo MuJoCo_Models --ref <40-character-commit-sha>
+python3 scripts/update_biomech_vendor.py --repo Drake_Models --ref <40-character-commit-sha>
+```
+
+Branches and tags are mutable and require an explicit opt-in:
+
+```bash
+python3 scripts/update_biomech_vendor.py --repo MuJoCo_Models --ref v1.4.0 --allow-mutable-ref
 ```
 
 Each snapshot includes the manifest file (`model_pack.yaml` or
 `tool_pack.yaml`) and a `models/` tree. A `VENDOR_PROVENANCE.txt`
-marker records the source URL and ref.
+marker records the source URL, requested ref, resolved commit SHA, mutable-ref
+opt-in state, URL-override state, and clean working-tree state.
 
 Snapshots are committed to UpstreamDrift; CI uses them and never clones
 the sibling repos at test time.

--- a/scripts/update_biomech_vendor.py
+++ b/scripts/update_biomech_vendor.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger("update_biomech_vendor")
+_FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
 
 
 KNOWN_SIBLINGS: dict[str, str] = {
@@ -45,6 +47,7 @@ class VendorOptions:
     ref: str
     url: str
     vendor_root: Path
+    allow_mutable_ref: bool = False
 
 
 def _repo_root() -> Path:
@@ -63,7 +66,18 @@ def _parse_args(argv: list[str] | None) -> VendorOptions:
     parser.add_argument(
         "--ref",
         required=True,
-        help="Git ref (tag or branch) to snapshot, e.g. v1.4.0.",
+        help=(
+            "Full 40-character commit SHA to snapshot. Branches and tags require "
+            "--allow-mutable-ref."
+        ),
+    )
+    parser.add_argument(
+        "--allow-mutable-ref",
+        action="store_true",
+        help=(
+            "Permit branch or tag refs. Provenance still records the resolved "
+            "commit SHA, but rerunning the command may snapshot different content."
+        ),
     )
     parser.add_argument(
         "--url",
@@ -88,25 +102,60 @@ def _parse_args(argv: list[str] | None) -> VendorOptions:
         ref=args.ref,
         url=url,
         vendor_root=vendor_root,
+        allow_mutable_ref=args.allow_mutable_ref,
     )
+
+
+def _is_full_commit_sha(ref: str) -> bool:
+    """Return whether ``ref`` is an immutable full commit SHA."""
+    return _FULL_COMMIT_SHA.fullmatch(ref) is not None
+
+
+def _validate_ref_policy(options: VendorOptions) -> None:
+    """Reject mutable refs unless the caller explicitly opted in."""
+    if _is_full_commit_sha(options.ref) or options.allow_mutable_ref:
+        return
+    raise ValueError(
+        "--ref must be a full 40-character commit SHA. Use --allow-mutable-ref "
+        "to snapshot a branch or tag deliberately.",
+    )
+
+
+def _run_git(checkout: Path, *args: str) -> str:
+    """Run git in ``checkout`` and return stripped stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 def _shallow_clone(url: str, ref: str, target: Path) -> None:
     """Shallow-clone ``url`` at ``ref`` into ``target``."""
     logger.info("Cloning %s @ %s", url, ref)
-    subprocess.run(
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--branch",
-            ref,
-            url,
-            str(target),
-        ],
-        check=True,
-    )
+    target.mkdir(parents=True, exist_ok=False)
+    _run_git(target, "init")
+    _run_git(target, "remote", "add", "origin", url)
+    _run_git(target, "fetch", "--depth", "1", "origin", ref)
+    _run_git(target, "checkout", "--detach", "FETCH_HEAD")
+
+
+def _resolved_commit(checkout: Path) -> str:
+    """Return the exact commit checked out for the snapshot."""
+    return _run_git(checkout, "rev-parse", "HEAD")
+
+
+def _working_tree_clean(checkout: Path) -> bool:
+    """Return whether checkout has no uncommitted tracked or untracked changes."""
+    return _run_git(checkout, "status", "--porcelain") == ""
+
+
+def _uses_url_override(options: VendorOptions) -> bool:
+    """Return whether options use a non-default source URL."""
+    return options.url != KNOWN_SIBLINGS[options.repo]
 
 
 def _models_root_from_manifest(checkout: Path) -> Path | None:
@@ -169,7 +218,13 @@ def _copy_manifest(checkout: Path, destination_root: Path) -> None:
             logger.info("Copied %s", manifest_path.name)
 
 
-def _write_provenance(destination_root: Path, options: VendorOptions) -> None:
+def _write_provenance(
+    destination_root: Path,
+    options: VendorOptions,
+    *,
+    commit_sha: str,
+    working_tree_clean: bool,
+) -> None:
     """Write a small marker file documenting how the snapshot was produced."""
     marker = destination_root / "VENDOR_PROVENANCE.txt"
     marker.write_text(
@@ -177,7 +232,11 @@ def _write_provenance(destination_root: Path, options: VendorOptions) -> None:
             [
                 f"repo: {options.repo}",
                 f"ref: {options.ref}",
+                f"commit: {commit_sha}",
                 f"url: {options.url}",
+                f"url_override: {str(_uses_url_override(options)).lower()}",
+                f"mutable_ref_allowed: {str(options.allow_mutable_ref).lower()}",
+                f"working_tree_clean: {str(working_tree_clean).lower()}",
                 "produced by: scripts/update_biomech_vendor.py",
                 "",
             ]
@@ -192,10 +251,13 @@ def snapshot(options: VendorOptions) -> Path:
     Returns the destination directory containing the snapshot. The directory
     is overwritten on each invocation.
     """
+    _validate_ref_policy(options)
     destination_root = options.vendor_root / options.repo
     with tempfile.TemporaryDirectory(prefix="biomech-vendor-") as tmpdir:
         checkout = Path(tmpdir) / "checkout"
         _shallow_clone(options.url, options.ref, checkout)
+        commit_sha = _resolved_commit(checkout)
+        working_tree_clean = _working_tree_clean(checkout)
 
         models_root = _models_root_from_manifest(checkout)
         if models_root is None:
@@ -210,7 +272,12 @@ def snapshot(options: VendorOptions) -> Path:
         _copy_tree(models_root, destination_models)
         destination_root.mkdir(parents=True, exist_ok=True)
         _copy_manifest(checkout, destination_root)
-        _write_provenance(destination_root, options)
+        _write_provenance(
+            destination_root,
+            options,
+            commit_sha=commit_sha,
+            working_tree_clean=working_tree_clean,
+        )
     logger.info("Snapshot ready at %s", destination_root)
     return destination_root
 
@@ -226,6 +293,9 @@ def main(argv: list[str] | None = None) -> int:
     except FileNotFoundError as exc:
         logger.error("%s", exc)
         return 2
+    except ValueError as exc:
+        logger.error("%s", exc)
+        return 3
     return 0
 
 

--- a/tests/scripts/test_update_biomech_vendor.py
+++ b/tests/scripts/test_update_biomech_vendor.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import update_biomech_vendor
+
+pytestmark = pytest.mark.unit
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_source_repo(tmp_path: Path) -> tuple[Path, str]:
+    source = tmp_path / "source"
+    source.mkdir()
+    _run_git(source, "init", "-b", "main")
+    _run_git(source, "config", "user.email", "test@example.invalid")
+    _run_git(source, "config", "user.name", "Test User")
+    models = source / "models"
+    models.mkdir()
+    (models / "model.txt").write_text("model data\n", encoding="utf-8")
+    _run_git(source, "add", "models/model.txt")
+    _run_git(source, "commit", "-m", "seed model")
+    return source, _run_git(source, "rev-parse", "HEAD")
+
+
+def test_snapshot_records_resolved_commit_for_mutable_ref(
+    tmp_path: Path,
+) -> None:
+    source, commit_sha = _make_source_repo(tmp_path)
+    options = update_biomech_vendor.VendorOptions(
+        repo="MuJoCo_Models",
+        ref="main",
+        url=str(source),
+        vendor_root=tmp_path / "vendor",
+        allow_mutable_ref=True,
+    )
+
+    destination = update_biomech_vendor.snapshot(options)
+
+    provenance = (destination / "VENDOR_PROVENANCE.txt").read_text(encoding="utf-8")
+    assert f"commit: {commit_sha}" in provenance
+    assert "ref: main" in provenance
+    assert "url_override: true" in provenance
+    assert "mutable_ref_allowed: true" in provenance
+    assert "working_tree_clean: true" in provenance
+
+
+def test_snapshot_accepts_full_commit_sha_without_mutable_ref_opt_in(
+    tmp_path: Path,
+) -> None:
+    source, commit_sha = _make_source_repo(tmp_path)
+    options = update_biomech_vendor.VendorOptions(
+        repo="MuJoCo_Models",
+        ref=commit_sha,
+        url=str(source),
+        vendor_root=tmp_path / "vendor",
+    )
+
+    destination = update_biomech_vendor.snapshot(options)
+
+    provenance = (destination / "VENDOR_PROVENANCE.txt").read_text(encoding="utf-8")
+    assert f"ref: {commit_sha}" in provenance
+    assert f"commit: {commit_sha}" in provenance
+    assert "mutable_ref_allowed: false" in provenance
+
+
+def test_mutable_ref_requires_explicit_opt_in(tmp_path: Path) -> None:
+    source, _commit_sha = _make_source_repo(tmp_path)
+    options = update_biomech_vendor.VendorOptions(
+        repo="MuJoCo_Models",
+        ref="main",
+        url=str(source),
+        vendor_root=tmp_path / "vendor",
+        allow_mutable_ref=False,
+    )
+
+    with pytest.raises(ValueError, match="full 40-character commit SHA"):
+        update_biomech_vendor.snapshot(options)


### PR DESCRIPTION
## Summary
- require full 40-character commit SHA refs by default for biomech vendor snapshots
- add `--allow-mutable-ref` for deliberate branch/tag snapshots while still recording the resolved commit
- write requested ref, resolved commit SHA, source URL, URL override state, mutable-ref opt-in, and clean working-tree state to `VENDOR_PROVENANCE.txt`
- update ADR/workspace/SPEC docs for the reproducibility contract

## Validation
- `py -3.13 -m pytest -n 0 tests\scripts\test_update_biomech_vendor.py tests\scripts\test_check_vendor_updates.py -q`
- `py -3.13 -m ruff check scripts\update_biomech_vendor.py tests\scripts\test_update_biomech_vendor.py`
- `py -3.13 -m ruff format --check scripts\update_biomech_vendor.py tests\scripts\test_update_biomech_vendor.py`
- `py -3.13 -m mypy scripts\update_biomech_vendor.py tests\scripts\test_update_biomech_vendor.py`
- `npx --yes prettier --check SPEC.md docs\architecture\biomech_workspace.md docs\adr\0014-shared-biomech-models.md`
- `py -3.13 scripts\update_biomech_vendor.py --help | Select-String -Pattern "allow-mutable-ref|40-character"`
- pre-push hooks: ruff, ruff format, formatter guidance, wildcard/debug/print guards, prettier, mypy, bandit, pytest

Fixes #8200