### PR TITLE
fix(tests): add editable tools mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,11 @@ repository. The widget itself lives in Tools; UpstreamDrift only owns
 the optional install path and the Sidekick design-token passthrough.
 
 - **Setup:** run `scripts/setup_tools_workspace.sh` to wire an editable
-  sibling checkout, or pass `--tools-mode editable` to pytest (see the
+  Tools checkout, then pass `--tools-mode editable` to pytest (see the
   `--tools-mode` fixture in `tests/conftest.py` and the "Cross-Repo
-  Dependencies" section of `CLAUDE.md`).
+  Dependencies" section of `CLAUDE.md`). Use `--tools-mode vendored` to
+  validate the pinned `vendor/ud-tools` submodule, and reserve
+  `--tools-mode local` for deliberate UpstreamDrift child-copy precedence tests.
 - **Detection:** `gui_launcher.is_tools_sidebar_available()` returns
   whether the shared module imports. `LauncherDiagnostics.check_tools_sidebar()`
   exposes the same probe in the diagnostic report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ If you genuinely need to break one of these rules, add `# noqa: <CODE> - <reason
 
 ## Cross-Repo Dependencies
 
-- **Tools integration surface:** shared Python utilities are vendored in `vendor/ud-tools/`, and optional editable sibling wiring lives behind `scripts/setup_tools_workspace.sh` plus the pytest `--tools-mode` fixtures in `tests/conftest.py`.
+- **Tools integration surface:** shared Python utilities are vendored in `vendor/ud-tools/`, and optional editable sibling wiring lives behind `scripts/setup_tools_workspace.sh` plus the pytest `--tools-mode` fixtures in `tests/conftest.py`. Use `--tools-mode vendored` for the pinned submodule, `--tools-mode editable` for `TOOLS_REPO_PATH`/`TOOLS_REPO_ROOT`, `_tools_dep`, or `../Tools`, and `--tools-mode local` only when intentionally exercising UpstreamDrift child copies first.
 - Breaking changes to Tools public API require a coordinated PR here.
 - Gasification_Model also depends on Tools — avoid transitive breakage.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.481 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,12 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Aligned pytest Tools resolution modes with the documented
+  editable workflow (#8204). `--tools-mode editable` now selects
+  `TOOLS_REPO_PATH`, `TOOLS_REPO_ROOT`, `_tools_dep`, or `../Tools` before
+  UpstreamDrift child copies, `--tools-mode vendored` remains the pinned
+  `vendor/ud-tools` validation lane, and `--tools-mode local` remains reserved
+  for deliberate child-copy precedence tests.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains
@@ -1925,6 +1932,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.481 | Aligned pytest Tools resolution modes with the documented editable workflow (#8204). `--tools-mode editable` now selects `TOOLS_REPO_PATH`, `TOOLS_REPO_ROOT`, `_tools_dep`, or `../Tools` before UpstreamDrift child copies, `--tools-mode vendored` remains the pinned `vendor/ud-tools` validation lane, and `--tools-mode local` remains reserved for deliberate child-copy precedence tests. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/scripts/setup_tools_workspace.sh
+++ b/scripts/setup_tools_workspace.sh
@@ -28,6 +28,7 @@ mkdir -p "$(dirname "$tools_link")"
 ln -sfn "$tools_target" "$tools_link"
 
 echo "Linked Tools workspace: $tools_link -> $(readlink "$tools_link")"
+echo "Run pytest with --tools-mode editable to use this Tools checkout."
 
 tools_python_paths=(
   "$tools_repo_root/src/shared/python"

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,20 +34,20 @@ Scientific validation lives in `tests/analytical/` for closed-form baselines and
 
 ## Conftests
 
-| Path                                                      | Scope            | Purpose                                                                                              |
-| --------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------- |
-| `conftest.py`                                             | session          | Imports MuJoCo before collection on Windows to avoid DLL initialization crashes.                     |
-| `tests/conftest.py`                                       | session/function | Adds `--tools-mode`, controls Tools path precedence, and isolates protected engine modules per test. |
-| `tests/heavy_integration/conftest.py`                     | session/function | Marks heavy tests as `live_simulation` and provides headless display plus engine fixtures.           |
-| `tests/integration/conftest.py`                           | package          | Re-exports shared fixture-library helpers for integration tests.                                     |
-| `tests/parity/conftest.py`                                | module/function  | Provides FastAPI client and fresh pendulum engine fixtures.                                          |
-| `tests/shared_contracts/conftest.py`                      | session          | Resolves real, vendored, or sibling Tools checkouts for shared contract tests.                       |
-| `tests/unit/conftest.py`                                  | function         | Mocks optional native dependencies and resets those mocks between unit tests.                        |
-| `tests/unit/dashboard/conftest.py`                        | package          | Documents dashboard test path handling; no fixtures.                                                 |
-| `tests/unit/engines/*/conftest.py`                        | package          | Documents engine test path handling or mocks missing optional engine modules.                        |
-| `tests/unit/engines/simscape/*/conftest.py`               | package          | Documents Simscape test path handling; no fixtures.                                                  |
-| `tests/unit/plotting/conftest.py`                         | package          | Pre-mocks PyQt6 modules to avoid Qt DLL crashes in plotting tests.                                   |
-| `tests/unit/tools/humanoid_character_builder/conftest.py` | function         | Skips torch-dependent tests when local torch binaries are unavailable.                               |
+| Path                                                      | Scope            | Purpose                                                                                                                                |
+| --------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `conftest.py`                                             | session          | Imports MuJoCo before collection on Windows to avoid DLL initialization crashes.                                                       |
+| `tests/conftest.py`                                       | session/function | Adds `--tools-mode` (`local`, `vendored`, `editable`), controls Tools path precedence, and isolates protected engine modules per test. |
+| `tests/heavy_integration/conftest.py`                     | session/function | Marks heavy tests as `live_simulation` and provides headless display plus engine fixtures.                                             |
+| `tests/integration/conftest.py`                           | package          | Re-exports shared fixture-library helpers for integration tests.                                                                       |
+| `tests/parity/conftest.py`                                | module/function  | Provides FastAPI client and fresh pendulum engine fixtures.                                                                            |
+| `tests/shared_contracts/conftest.py`                      | session          | Resolves real, vendored, or sibling Tools checkouts for shared contract tests.                                                         |
+| `tests/unit/conftest.py`                                  | function         | Mocks optional native dependencies and resets those mocks between unit tests.                                                          |
+| `tests/unit/dashboard/conftest.py`                        | package          | Documents dashboard test path handling; no fixtures.                                                                                   |
+| `tests/unit/engines/*/conftest.py`                        | package          | Documents engine test path handling or mocks missing optional engine modules.                                                          |
+| `tests/unit/engines/simscape/*/conftest.py`               | package          | Documents Simscape test path handling; no fixtures.                                                                                    |
+| `tests/unit/plotting/conftest.py`                         | package          | Pre-mocks PyQt6 modules to avoid Qt DLL crashes in plotting tests.                                                                     |
+| `tests/unit/tools/humanoid_character_builder/conftest.py` | function         | Skips torch-dependent tests when local torch binaries are unavailable.                                                                 |
 
 ## Layout Guard
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,14 +477,45 @@ def _default_biomech_mode() -> str:
     return "vendored"
 
 
+def _tools_repo_path_override() -> str | None:
+    """Return the legacy explicit Tools path override, if configured."""
+    return os.environ.get("TOOLS_REPO_PATH")
+
+
+def _editable_tools_root_override() -> str | None:
+    """Return an explicitly configured Tools checkout path, if any."""
+    return _tools_repo_path_override() or os.environ.get("TOOLS_REPO_ROOT")
+
+
+def _editable_tools_root(root_dir: Path) -> Path:
+    """Resolve the editable Tools checkout used by ``--tools-mode editable``."""
+    explicit_tools = _editable_tools_root_override()
+    candidates = [
+        Path(explicit_tools) if explicit_tools else None,
+        root_dir / "_tools_dep",
+        root_dir.parent / "Tools",
+    ]
+    for candidate in candidates:
+        if candidate is not None and candidate.is_dir():
+            return candidate.resolve()
+    raise RuntimeError(
+        "--tools-mode editable requires TOOLS_REPO_PATH, TOOLS_REPO_ROOT, "
+        "_tools_dep, or a sibling ../Tools checkout.",
+    )
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add command line options for Tools vendoring resolution."""
     parser.addoption(
         "--tools-mode",
         action="store",
         default="local",
-        choices=["local", "vendored"],
-        help="Tools resolution mode: 'local' (src/shared/python) or 'vendored' (vendor/ud-tools/src/shared/python)",
+        choices=["local", "vendored", "editable"],
+        help=(
+            "Tools resolution mode: 'local' (src/shared/python first), "
+            "'vendored' (vendor/ud-tools first), or 'editable' "
+            "(TOOLS_REPO_PATH/TOOLS_REPO_ROOT, _tools_dep, or ../Tools first)."
+        ),
     )
     parser.addoption(
         "--biomech-mode",
@@ -512,8 +543,11 @@ def pytest_configure(config: pytest.Config) -> None:
     mode = config.getoption("--tools-mode")
     root_dir = Path(__file__).resolve().parent.parent
     local_path = str((root_dir / "src/shared/python").resolve())
-    explicit_tools = os.environ.get("TOOLS_REPO_PATH")
-    tools_root = Path(explicit_tools or root_dir / "vendor/ud-tools").resolve()
+    explicit_tools = _tools_repo_path_override()
+    if mode == "editable":
+        tools_root = _editable_tools_root(root_dir)
+    else:
+        tools_root = Path(explicit_tools or root_dir / "vendor/ud-tools").resolve()
     parent_paths = [
         str((tools_root / "src/shared/python").resolve()),
         str((tools_root / "src").resolve()),
@@ -543,10 +577,10 @@ def pytest_configure(config: pytest.Config) -> None:
             clean_path.append(p)
     sys.path = clean_path
 
-    parent_mode = explicit_tools is not None or mode == "vendored"
+    parent_mode = explicit_tools is not None or mode in {"vendored", "editable"}
     if parent_mode:
-        for path in reversed(parent_paths):
-            sys.path.insert(0, path)
+        for parent_path in reversed(parent_paths):
+            sys.path.insert(0, parent_path)
         sys.path.append(local_path)
     else:
         # Force local shared codebase to have precedence

--- a/tests/shared_contracts/test_tools_vendoring.py
+++ b/tests/shared_contracts/test_tools_vendoring.py
@@ -41,6 +41,14 @@ class _ConfigStub:
         return self._tools_mode
 
 
+class _ParserStub:
+    def __init__(self) -> None:
+        self.options: dict[str, dict[str, object]] = {}
+
+    def addoption(self, name: str, **kwargs: object) -> None:
+        self.options[name] = kwargs
+
+
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
@@ -51,6 +59,18 @@ def _local_tools_path() -> str:
 
 def _vendored_tools_path() -> str:
     return str((_repo_root() / "vendor/ud-tools/src/shared/python").resolve())
+
+
+def _vendored_tools_root() -> Path:
+    return (_repo_root() / "vendor/ud-tools").resolve()
+
+
+def _tools_python_paths(tools_root: Path) -> list[str]:
+    return [
+        str((tools_root / "src/shared/python").resolve()),
+        str((tools_root / "src").resolve()),
+        str((tools_root / "src/python/src").resolve()),
+    ]
 
 
 def _seed_sys_path() -> list[str]:
@@ -73,22 +93,29 @@ def _configure_tools_mode(
     mode: str,
     *,
     alias_contracts: bool = False,
+    existing_paths: set[str] | None = None,
 ) -> None:
     root_conftest = _load_root_conftest()
     local_path = _local_tools_path()
     vendored_path = _vendored_tools_path()
+    default_existing = set(_tools_python_paths(_vendored_tools_root()))
     real_exists = root_conftest.os.path.exists
 
     def _fake_exists(path: object) -> bool:
-        return str(path) in {local_path, vendored_path} or real_exists(path)
+        return (
+            str(path) in {local_path, vendored_path}
+            or str(path) in default_existing
+            or str(path) in (existing_paths or set())
+            or real_exists(path)
+        )
 
     monkeypatch.setattr(root_conftest.os.path, "exists", _fake_exists)
     if alias_contracts:
-        canonical_module = ModuleType("src.shared.python.contracts")
+        canonical_module = ModuleType("shared.python.contracts")
         real_import_module = importlib.import_module
 
         def _fake_import_module(name: str, package: str | None = None) -> ModuleType:
-            if name == "src.shared.python.contracts":
+            if name == "shared.python.contracts":
                 sys.modules[name] = canonical_module
                 return canonical_module
             return real_import_module(name, package)
@@ -138,6 +165,57 @@ def test_tools_mode_vendored_prefers_vendor_shared_python(
     )
 
 
+def test_tools_mode_editable_is_a_documented_parser_choice() -> None:
+    parser = _ParserStub()
+
+    _load_root_conftest().pytest_addoption(parser)  # type: ignore[arg-type]
+
+    tools_mode = parser.options["--tools-mode"]
+    assert tools_mode["choices"] == ["local", "vendored", "editable"]
+    assert "TOOLS_REPO_ROOT" in str(tools_mode["help"])
+
+
+def test_tools_mode_editable_prefers_explicit_tools_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tools_root = tmp_path / "Tools"
+    for path in _tools_python_paths(tools_root):
+        Path(path).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("TOOLS_REPO_ROOT", str(tools_root))
+    monkeypatch.setattr(sys, "path", _seed_sys_path())
+
+    _configure_tools_mode(
+        monkeypatch=monkeypatch,
+        mode="editable",
+        existing_paths=set(_tools_python_paths(tools_root)),
+    )
+
+    assert sys.path[:3] == _tools_python_paths(tools_root)
+    assert sys.path.index(_tools_python_paths(tools_root)[0]) < sys.path.index(
+        _local_tools_path()
+    )
+
+
+def test_tools_mode_editable_fails_loudly_when_checkout_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_conftest = _load_root_conftest()
+    local_path = _local_tools_path()
+    vendored_path = _vendored_tools_path()
+
+    def _fake_exists(path: object) -> bool:
+        return str(path) in {local_path, vendored_path}
+
+    monkeypatch.delenv("TOOLS_REPO_PATH", raising=False)
+    monkeypatch.delenv("TOOLS_REPO_ROOT", raising=False)
+    monkeypatch.setattr(root_conftest.os.path, "exists", _fake_exists)
+    monkeypatch.setattr(root_conftest.Path, "is_dir", lambda self: False)
+
+    with pytest.raises(RuntimeError, match="--tools-mode editable requires"):
+        root_conftest.pytest_configure(_ConfigStub("editable"))
+
+
 def test_tools_mode_aliases_contract_modules_to_one_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -151,6 +229,5 @@ def test_tools_mode_aliases_contract_modules_to_one_identity(
 
     _configure_tools_mode(monkeypatch, "vendored", alias_contracts=True)
 
-    canonical = sys.modules["src.shared.python.contracts"]
+    canonical = sys.modules["shared.python.contracts"]
     assert sys.modules["contracts"] is canonical
-    assert sys.modules["shared.python.contracts"] is canonical


### PR DESCRIPTION
## Summary
- add `editable` as a supported `--tools-mode` parser choice
- resolve editable Tools roots from `TOOLS_REPO_PATH`, `TOOLS_REPO_ROOT`, `_tools_dep`, or `../Tools`, with a loud failure when unavailable
- keep `vendored` as the pinned `vendor/ud-tools` lane and `local` as explicit child-copy-first mode
- align AGENTS/CLAUDE/test docs and setup script output with the supported modes

## Validation
- `$env:TOOLS_REPO_PATH='C:\Users\diete\Repositories\Tools'; py -3.13 -m pytest --tools-mode editable --collect-only tests\unit\repo_hygiene\test_vendor_submodule_clean.py -q`
- `py -3.13 -m pytest -n 0 tests\shared_contracts\test_tools_vendoring.py -q`
- `py -3.13 -m ruff check tests\conftest.py tests\shared_contracts\test_tools_vendoring.py`
- `py -3.13 -m ruff format --check tests\conftest.py tests\shared_contracts\test_tools_vendoring.py`
- `npx --yes prettier --check SPEC.md AGENTS.md CLAUDE.md tests\README.md`
- `git diff --check`
- pre-push hooks: ruff, ruff format, formatter guidance, prettier, mypy, bandit, pytest

Note: a manual broad mypy invocation against `tests/conftest.py` walked unrelated existing type debt before being stopped for machine health; the configured pre-push mypy hook skipped this file set.

Fixes #8204