### PR TITLE
Fix deprecated alias hygiene residue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ plot_cartesian_delta_summary, summarize_for_pr_comment}` —
 - Channel registry in `channels.py` chooses transport per channel.
 - See [`docs/development/realtime_ipc.md`](docs/development/realtime_ipc.md).
 
-`src/shared/python/upstream_drift_tools/ui/tools_sidebar/`
+`src/shared/python/sidekick/ui/tools_sidebar/`
 
 - **Sidekick (UnifiedToolsSidebar)**: The right-hand collapsible dock that provides Chat Assistant, Reporting/Summarization, and context-aware utilities.
 - Exposes `create_tools_sidebar()` to act as the universal in-repo fallback.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,22 +199,21 @@ next `git submodule update` or vendor bump.
 ### Package naming — sidekick is canonical
 
 `sidekick` is the canonical package name for the shared tools utility library.
-`upstream_drift_tools` is a **deprecated alias** (compat shim provided by Tools
-PR #2885 / Stage 1). New code in `src/` and `tests/` must import from `sidekick`:
+The previous `upstream_drift_tools` alias has been removed from UpstreamDrift's
+local shared tree. New code in `src/` and `tests/` must import from `sidekick`:
 
 ```python
 # Correct (Stage 2+)
 from sidekick.theme import CatppuccinTheme
 import sidekick
 
-# Deprecated — do not use in new code
+# Removed — do not use in new code
 from upstream_drift_tools.theme import CatppuccinTheme  # noqa: removed in Stage 2
 ```
 
-The compat shim in `vendor/ud-tools` keeps `upstream_drift_tools` importable
-during the transition period, but the hygiene test
-`tests/unit/repo_hygiene/test_no_deprecated_imports.py` enforces that no
-`src/` or `tests/` file uses the old name.
+The hygiene test `tests/unit/repo_hygiene/test_no_deprecated_imports.py`
+enforces that no Python file under `src/` or `tests/` uses the old name and
+that `src/shared/python/upstream_drift_tools/` stays deleted.
 
 Repository-hygiene tests at `tests/unit/repo_hygiene/` enforce this:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Restored the `upstream_drift_tools` alias-removal hygiene
+  contract for #8206. The remaining executable test helper now clears only
+  canonical Sidekick/shared modules, and repo-owned contributor docs describe
+  the old alias as removed from UpstreamDrift instead of an active local shim.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/docs/governance/PACKAGE_ORGANIZATION.md
+++ b/docs/governance/PACKAGE_ORGANIZATION.md
@@ -46,7 +46,7 @@ first checking which package should own it long-term.
 | `biomech` / `biomechanics`                               | `biomechanics` holds muscle/dynamics code; `biomech` holds exercise schemas. Needs merge decision.                                                                       |
 | `plot_engine` / `plot_style` / `plot_theme` / `plotting` | Four packages covering rendering backends, color channels, theme management, and animation. `plot_theme` likely belongs in `sidekick.theme`.                             |
 | `data_processing` / `data_processor`                     | `data_processing` is the UI-agnostic extraction (issue #407); `data_processor` is the Rust bulk-I/O engine (issue #2989). Different concerns, confusingly similar names. |
-| `upstream_drift` / `upstream_drift_tools`                | `upstream_drift_tools` is a **deprecated alias** (see below). `upstream_drift` is a separate package — do not conflate them.                                             |
+| `upstream_drift` / historical tools alias                | The old tools alias package has been removed from UpstreamDrift. `upstream_drift` is a separate package — do not conflate them.                                          |
 
 ---
 
@@ -65,21 +65,19 @@ until explicitly documented otherwise.
 
 ---
 
-## `upstream_drift_tools` — deprecated, do not use
+## Historical tools alias — removed, do not use
 
-`src/shared/python/upstream_drift_tools/` is a **compatibility shim** created
-during the `upstream_drift_tools` → `sidekick` rename (issues #5619, #5623).
+UpstreamDrift no longer carries the old alias package that preceded
+`sidekick` (issues #5619, #5623, #6564).
 
-- It re-exports every public symbol from `sidekick`.
-- It emits a `DeprecationWarning` on first import.
-- It will be **removed** in a future major release.
 - The hygiene test `tests/unit/repo_hygiene/test_no_deprecated_imports.py`
-  enforces that no `src/` or `tests/` file imports `upstream_drift_tools`.
+  enforces that no Python file under `src/` or `tests/` imports the old alias
+  and that the deleted package directory does not return.
 
 **Migration:**
 
 ```python
-# Before (deprecated)
+# Before (removed)
 from upstream_drift_tools.theme import CatppuccinTheme
 
 # After (correct)

--- a/tests/unit/launcher/test_sidekick_extension_overlay.py
+++ b/tests/unit/launcher/test_sidekick_extension_overlay.py
@@ -56,14 +56,11 @@ def _clear_sidekick_modules(monkeypatch: pytest.MonkeyPatch) -> None:
             "shared",
             "sidekick",
             "src.shared",
-            "upstream_drift_tools",
         } or name.startswith(
             (
                 "shared.python",
                 "sidekick.",
                 "src.shared.python.sidekick",
-                "src.shared.python.upstream_drift_tools",
-                "upstream_drift_tools.",
             )
         ):
             monkeypatch.delitem(sys.modules, name, raising=False)


### PR DESCRIPTION
## Summary
- remove the remaining deprecated alias module names from the executable Sidekick overlay test helper
- update UpstreamDrift-owned contributor/governance docs to describe the old alias as removed from the local tree
- bump SPEC.md for the #8206 hygiene-contract restoration

Closes #8206

## Validation
- `py -3.13 -m pytest -n 0 tests\unit\repo_hygiene\test_no_deprecated_imports.py tests\unit\repo_hygiene\test_no_shadow_of_tools_shared.py -q` (5 passed, 1 skipped: full shadow check skipped because `vendor/ud-tools` is not initialized in this isolated worktree)
- `py -3.13 -m ruff check tests\unit\launcher\test_sidekick_extension_overlay.py`
- `py -3.13 -m ruff format --check tests\unit\launcher\test_sidekick_extension_overlay.py`
- `npx prettier --check AGENTS.md CLAUDE.md docs/governance/PACKAGE_ORGANIZATION.md SPEC.md`
- `git diff --check`
- pre-push hook: ruff, ruff format, formatter guidance, no wildcard/debug/print, prettier, mypy skipped/no files, bandit, pytest

## Notes
- `src/shared/python/upstream_drift_tools/` is absent on this branch.
- I did not edit Tools-owned child-copy files under `src/shared/python/`; the remaining legacy strings there are provenance-owned by Tools and should be corrected through the Tools source/bump path rather than patched only in UpstreamDrift.
- The local worktree lacks an initialized `vendor/ud-tools`; an attempted submodule initialization could not complete within the runner-health window, so the full shadow test is expected to run in CI where the vendor tree is available.