### PR TITLE
Fix LOD baseline ratchet

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,12 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened the Law-of-Demeter baseline ratchet for #8218.
+  Baseline mode now fails on stale allowances as well as new deep attribute
+  chains, preserving prior LOD reductions instead of letting fixed chains be
+  reintroduced under an oversized baseline. The checked-in
+  `scripts/ci/lod_baseline.txt` was regenerated from current source and now has
+  zero stale reductions.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/scripts/ci/check_lod.py
+++ b/scripts/ci/check_lod.py
@@ -22,7 +22,8 @@ Allow-list rationale (these are library API patterns, not LOD violations):
 
 The script exits with code 0 if no violations are found, code 1 otherwise.
 When a baseline is supplied, checked-in violations are tolerated and only
-new path/chain occurrences fail the check.
+new path/chain occurrences fail the check. Stale baseline allowances also fail
+so previously removed LOD chains cannot be silently reintroduced later.
 """
 
 from __future__ import annotations
@@ -295,6 +296,14 @@ def _baseline_excess(
     return excess
 
 
+def _baseline_reductions(
+    violations: list[Violation],
+    baseline: Counter[BaselineKey],
+) -> Counter[BaselineKey]:
+    """Return baseline allowances that are larger than current findings."""
+    return baseline - _violation_counts(violations)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -345,12 +354,27 @@ def main(argv: list[str] | None = None) -> int:
         excess = _baseline_excess(violations, baseline)
         for rel_path, lineno, chain in excess:
             print(f"{rel_path}:{lineno}: new LOD chain >2 deep: {chain}")
-        if not excess:
-            reductions = sum((baseline - _violation_counts(violations)).values())
+
+        reductions = _baseline_reductions(violations, baseline)
+        if reductions:
+            for rel_path, chain in sorted(reductions):
+                print(
+                    f"{rel_path}: stale LOD baseline allowance for {chain}: "
+                    f"{reductions[(rel_path, chain)]}",
+                    file=sys.stderr,
+                )
             print(
-                f"check_lod: clean no-growth scan ({len(files)} files scanned under "
+                f"check_lod: found {sum(reductions.values())} stale baseline "
+                "allowance(s); run --write-baseline after verifying the reductions.",
+                file=sys.stderr,
+            )
+            return 0 if args.advisory else 1
+
+        if not excess:
+            print(
+                f"check_lod: clean strict-baseline scan ({len(files)} files scanned under "
                 f"{root}; {len(violations)} baseline violation occurrences; "
-                f"{reductions} reductions)"
+                "0 reductions)"
             )
             return 0
         print(

--- a/scripts/ci/lod_baseline.txt
+++ b/scripts/ci/lod_baseline.txt
@@ -7,7 +7,6 @@ src/api/routes/data_explorer.py	_dataset_storage._local.conn.close	1
 src/api/routes/data_explorer.py	_dataset_storage.db_path.parent.exists	1
 src/api/routes/data_explorer.py	_dataset_storage.db_path.parent.resolve	1
 src/api/routes/data_explorer.py	self._local.conn.execute	1
-src/api/routes/simulation_ws.py	websocket.app.state.engine_manager	1
 src/api/routes/terrain.py	terrain.default_type.name.lower	1
 src/api/task_manager_durable.py	self._local.conn.execute	2
 src/api/task_manager_durable.py	self._local.conn.row_factory	1
@@ -199,7 +198,6 @@ src/shared/python/biomechanics/swing_plane_visualization.py	self.current_scene.f
 src/shared/python/body_part_viz/renderers/pyqtgl_renderer.py	entry.fitted.centroid.shape	1
 src/shared/python/chat/router_factory.py	request.app.state.chat_service.get_session_history	1
 src/shared/python/chat/router_factory.py	request.app.state.chat_service.list_sessions	1
-src/shared/python/chat/router_factory.py	websocket.app.state.chat_service	1
 src/shared/python/chat/skills_manager.py	md_path.parent.name.lower	1
 src/shared/python/config/provider_catalog.py	config_dir.parent.parent.resolve	1
 src/shared/python/control_interface.py	self._state.strategy.value	1
@@ -342,9 +340,6 @@ src/tools/model_explorer/_chain_widget.py	self.tree.nodes.get	1
 src/tools/model_explorer/_chain_widget.py	self.tree.nodes.values	1
 src/tools/model_explorer/_chain_widget.py	self.tree.root.name	1
 src/tools/model_explorer/_ee_widget.py	self.library.end_effectors.get	1
-src/tools/model_explorer/_frankenstein_panels.py	self.model.joints.items	1
-src/tools/model_explorer/_frankenstein_panels.py	self.model.links.items	1
-src/tools/model_explorer/_frankenstein_panels.py	self.model.materials.items	1
 src/tools/model_explorer/_mujoco_viewer_backend.py	mujoco.mjtFrame.mjFRAME_BODY.value	1
 src/tools/model_explorer/_mujoco_viewer_backend.py	mujoco.mjtFrame.mjFRAME_NONE.value	1
 src/tools/model_explorer/_mujoco_viewer_backend.py	mujoco.mjtVisFlag.mjVIS_COM.value	1
@@ -353,15 +348,6 @@ src/tools/model_explorer/_mujoco_viewer_backend.py	mujoco.mjtVisFlag.mjVIS_CONTA
 src/tools/model_explorer/_mujoco_viewer_backend.py	mujoco.mjtVisFlag.mjVIS_JOINT.value	1
 src/tools/model_explorer/_mujoco_viewer_backend.py	self._model.vis.global_.offheight	1
 src/tools/model_explorer/_mujoco_viewer_backend.py	self._model.vis.global_.offwidth	1
-src/tools/model_explorer/frankenstein_editor/editor.py	self.left_panel.file_label.setText	3
-src/tools/model_explorer/frankenstein_editor/editor.py	self.left_panel.save_btn.setEnabled	2
-src/tools/model_explorer/frankenstein_editor/editor.py	self.left_panel.tree.currentItem	3
-src/tools/model_explorer/frankenstein_editor/editor.py	self.right_panel.file_label.setText	2
-src/tools/model_explorer/frankenstein_editor/editor.py	self.right_panel.save_btn.setEnabled	2
-src/tools/model_explorer/frankenstein_editor/editor.py	self.right_panel.tree.currentItem	2
-src/tools/model_explorer/frankenstein_editor/panel.py	self.model.joints.items	1
-src/tools/model_explorer/frankenstein_editor/panel.py	self.model.links.items	1
-src/tools/model_explorer/frankenstein_editor/panel.py	self.model.materials.items	1
 src/tools/model_explorer/mujoco_viewer.py	mujoco.mjtFrame.mjFRAME_BODY.value	1
 src/tools/model_explorer/mujoco_viewer.py	mujoco.mjtFrame.mjFRAME_NONE.value	1
 src/tools/model_explorer/mujoco_viewer.py	mujoco.mjtVisFlag.mjVIS_COM.value	1
@@ -380,15 +366,12 @@ src/tools/starting_pose_matcher/gui_playback.py	self._anim.event_source.stop	1
 src/tools/starting_pose_matcher/skeleton_extractors/mujoco.py	self._mujoco.MjModel.from_xml_path	1
 src/tools/starting_pose_matcher/skeleton_extractors/mujoco.py	self._mujoco.MjModel.from_xml_string	1
 src/tools/starting_pose_matcher/skeleton_extractors/mujoco.py	self._mujoco.mjtObj.mjOBJ_BODY	1
-src/tools/training_controller/controller.py	self._scheduler.registry.has	2
-src/tools/training_controller/controller.py	self._scheduler.registry.list	1
 src/tools/training_controller/gui.py	ax.xaxis.label.set_color	1
 src/tools/training_controller/gui.py	ax.yaxis.label.set_color	1
 src/tools/training_controller/gui.py	job.config.framework.value.upper	1
 src/tools/training_controller/gui.py	job.config.hyperparameters.items	1
 src/tools/training_controller/gui.py	job.status.value.upper	1
 src/tools/training_controller/gui.py	self.controller.dataset_registry.list	2
-src/tools/training_controller/gui.py	self.controller.scheduler.registry.get	1
 src/tools/training_controller/view_model.py	job.config.framework.value	1
 src/unreal_integration/_viewer_base.py	self.backend_type.name.lower	1
 src/unreal_integration/skeleton_mapper.py	self.source_type.name.lower	1

--- a/tests/scripts/wave9_scripts_b/test_check_lod.py
+++ b/tests/scripts/wave9_scripts_b/test_check_lod.py
@@ -148,7 +148,7 @@ def test_main_baseline_allows_existing_path_chain_count(
     baseline.write_text("src/app.py\tself.a.b.c.d\t1\n")
 
     assert mod.main([str(root), "--baseline", str(baseline)]) == 0
-    assert "clean no-growth scan" in capsys.readouterr().out
+    assert "clean strict-baseline scan" in capsys.readouterr().out
 
 
 def test_main_baseline_fails_when_path_chain_count_grows(
@@ -164,6 +164,31 @@ def test_main_baseline_fails_when_path_chain_count_grows(
     captured = capsys.readouterr()
     assert "new LOD chain" in captured.out
     assert "found 1 new LOD violation" in captured.err
+
+
+def test_main_baseline_fails_when_allowance_is_stale(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    (root / "app.py").write_text("x = 1\n")
+    baseline = tmp_path / "lod_baseline.txt"
+    baseline.write_text("src/app.py\tself.a.b.c.d\t1\n")
+
+    assert mod.main([str(root), "--baseline", str(baseline)]) == 1
+    captured = capsys.readouterr()
+    assert "stale LOD baseline allowance" in captured.err
+    assert "run --write-baseline" in captured.err
+
+
+def test_main_baseline_advisory_allows_stale_allowance(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    (root / "app.py").write_text("x = 1\n")
+    baseline = tmp_path / "lod_baseline.txt"
+    baseline.write_text("src/app.py\tself.a.b.c.d\t1\n")
+
+    assert mod.main([str(root), "--baseline", str(baseline), "--advisory"]) == 0
 
 
 def test_write_baseline_records_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make `scripts/ci/check_lod.py --baseline` fail when the checked-in baseline has stale allowances below current source counts
- keep `--advisory` available for report-only operation while CI/default mode remains strict
- regenerate `scripts/ci/lod_baseline.txt` from current source to remove 26 stale allowances
- add regression tests proving stale baseline allowances fail and advisory mode remains non-blocking
- update `SPEC.md` for the LOD ratchet behavior change

Closes #8218

## Validation
- `py -3.13 scripts\ci\check_lod.py --baseline scripts\ci\lod_baseline.txt`
- `py -3.13 -m pytest -n 0 tests\scripts\wave9_scripts_b\test_check_lod.py -q`
- `py -3.13 -m ruff check scripts\ci\check_lod.py tests\scripts\wave9_scripts_b\test_check_lod.py`
- `py -3.13 -m ruff format --check scripts\ci\check_lod.py tests\scripts\wave9_scripts_b\test_check_lod.py`
- `py -3.13 -m mypy scripts\ci\check_lod.py tests\scripts\wave9_scripts_b\test_check_lod.py`
- `npx prettier --check SPEC.md`
- `git diff --check`
- pre-push hook passed ruff, formatting, formatter guidance, wildcard/debug guards, prettier, bandit, and pytest