### PR TITLE
Fix optional dependency mock-scope guard

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,13 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened optional-dependency mock hygiene for #8219. Unit
+  test configuration no longer installs persistent `pydrake`, `pinocchio`, or
+  `casadi` `MagicMock` modules during collection; it only resets engine
+  availability cache state around tests. The hygiene guard now scans pytest
+  collection hooks, recognizes string-form `patch.dict("sys.modules", ...)`,
+  covers Pinocchio and CasADi module names, and includes regression coverage for
+  collection-time mock pollution.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,67 +3,19 @@
 Provides shared fixtures and setup for all unit tests.
 """
 
-import sys
-from unittest.mock import MagicMock
-
 import pytest
 
 
-def pytest_configure(config):
-    """Configure pytest plugins and initialize fixtures early.
-
-    This hook runs before test collection, allowing us to mock modules
-    that test files will try to import. This prevents ModuleNotFoundError
-    during collection phase.
-
-    Using sys.modules directly here (not patch.dict) ensures the mock
-    persists through collection. Individual test classes use @patch.dict
-    to clean up per-test-scope.
-    """
-    # Mock Drake dependencies
-    if "pydrake" not in sys.modules:
-        sys.modules["pydrake"] = MagicMock()
-    if "pydrake.all" not in sys.modules:
-        sys.modules["pydrake.all"] = sys.modules["pydrake"]
-
-    # Mock optimization dependencies
-    if "casadi" not in sys.modules:
-        sys.modules["casadi"] = MagicMock()
-    if "pinocchio" not in sys.modules:
-        sys.modules["pinocchio"] = MagicMock()
-    if "pinocchio.casadi" not in sys.modules:
-        sys.modules["pinocchio.casadi"] = MagicMock()
-
-
 @pytest.fixture(autouse=True)
-def _reset_mocks_between_tests():
-    """Reset all mocked modules before each test to prevent cross-test pollution.
+def _reset_engine_availability_cache_between_tests():
+    """Reset optional-engine availability memoization around each unit test."""
+    _reset_engine_status_cache_if_available()
+    yield
+    _reset_engine_status_cache_if_available()
 
-    Although class-level @patch.dict decorators handle scoping, this fixture
-    ensures a clean slate for each test function that doesn't have explicit
-    patch decorators.
 
-    Crucially, it also clears the engine-availability memo cache. The
-    ``engine_availability`` probe imports ``sys.modules["pinocchio"]`` (etc.)
-    and caches the result; with a ``MagicMock`` installed during collection it
-    would otherwise cache the engine as AVAILABLE and poison later tests that
-    genuinely require the real bindings (see issue #7042). The probe now
-    detects mocks and reports NOT_INSTALLED, but resetting the cache per test
-    keeps that determination from leaking across the mock/unmock boundary.
-    """
-    # Reset the mocks to MagicMock() to clear any state
-    for module_name in [
-        "pydrake",
-        "pydrake.all",
-        "casadi",
-        "pinocchio",
-        "pinocchio.casadi",
-    ]:
-        if module_name in sys.modules:
-            sys.modules[module_name] = MagicMock()
-
-    # Drop any memoised availability verdict so each test re-probes against the
-    # current sys.modules state rather than a stale cross-test result.
+def _reset_engine_status_cache_if_available() -> None:
+    """Drop memoized engine availability verdicts when the helper is importable."""
     try:
         from src.shared.python.engine_core.engine_availability import (
             reset_engine_status_cache,
@@ -74,5 +26,3 @@ def _reset_mocks_between_tests():
         # engine_availability is an internal module; if it cannot be imported
         # the cache does not exist to poison, so there is nothing to reset.
         pass
-
-    yield

--- a/tests/unit/engines/pinocchio/test_induced_acceleration.py
+++ b/tests/unit/engines/pinocchio/test_induced_acceleration.py
@@ -3,22 +3,31 @@
 from __future__ import annotations
 
 import importlib
+import sys
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
-mock_pin = MagicMock()
-with patch.dict("sys.modules", {"pinocchio": mock_pin}):
-    induced_acceleration_mod = importlib.import_module(
-        "src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration"
-    )
-
-InducedAccelerationAnalyzer = (  # noqa: N816
-    induced_acceleration_mod.InducedAccelerationAnalyzer
+_MODULE_NAME = (
+    "src.engines.physics_engines.pinocchio.python.pinocchio_golf.induced_acceleration"
 )
+
+
+@pytest.fixture
+def induced_acceleration_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[tuple[Any, MagicMock], None, None]:
+    """Import induced acceleration with a scoped fake Pinocchio module."""
+    mock_pin = MagicMock()
+    monkeypatch.setitem(sys.modules, "pinocchio", mock_pin)
+    sys.modules.pop(_MODULE_NAME, None)
+    module = importlib.import_module(_MODULE_NAME)
+    monkeypatch.setattr(module, "pin", mock_pin)
+    yield module, mock_pin
+    sys.modules.pop(_MODULE_NAME, None)
 
 
 class TestPinocchioInducedAcceleration:
@@ -26,13 +35,13 @@ class TestPinocchioInducedAcceleration:
 
     @pytest.fixture(autouse=True)
     def reset_mocks(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, induced_acceleration_module: tuple[Any, MagicMock]
     ) -> Generator[None, None, None]:
         """Reset mocks before each test."""
+        induced_acceleration_mod, mock_pin = induced_acceleration_module
         mock_pin.reset_mock()
         mock_pin.aba.side_effect = None
         mock_pin.aba.return_value = MagicMock()  # Default return
-        monkeypatch.setattr(induced_acceleration_mod, "pin", mock_pin)
         yield
 
     @pytest.fixture
@@ -50,12 +59,20 @@ class TestPinocchioInducedAcceleration:
         return MagicMock()
 
     @pytest.fixture
-    def analyzer(self, mock_model, mock_data) -> InducedAccelerationAnalyzer:
+    def analyzer(
+        self,
+        induced_acceleration_module: tuple[Any, MagicMock],
+        mock_model: MagicMock,
+        mock_data: MagicMock,
+    ) -> Any:
         """Create analyzer instance."""
-        return InducedAccelerationAnalyzer(mock_model, mock_data)
+        induced_acceleration_mod, _mock_pin = induced_acceleration_module
+        return induced_acceleration_mod.InducedAccelerationAnalyzer(
+            mock_model, mock_data
+        )
 
     def test_induced_acceleration_initialization(
-        self, analyzer, mock_model, mock_data
+        self, analyzer: Any, mock_model: MagicMock, mock_data: MagicMock
     ) -> None:
         """Test initialization."""
         assert analyzer.model == mock_model
@@ -63,8 +80,14 @@ class TestPinocchioInducedAcceleration:
         assert analyzer._temp_data is not None
         assert analyzer._temp_data != mock_data  # Should be a new instance
 
-    def test_compute_components_logic(self, analyzer, mock_model) -> None:
+    def test_compute_components_logic(
+        self,
+        induced_acceleration_module: tuple[Any, MagicMock],
+        analyzer: Any,
+        mock_model: MagicMock,
+    ) -> None:
         """Test compute_components logical flow."""
+        _induced_acceleration_mod, mock_pin = induced_acceleration_module
         q = np.array([0.0, 0.0])
         v = np.array([0.1, 0.2])
         tau = np.array([1.0, 2.0])
@@ -102,8 +125,14 @@ class TestPinocchioInducedAcceleration:
         # Verify calls were made
         assert mock_pin.aba.call_count == 3
 
-    def test_compute_specific_control(self, analyzer, mock_model) -> None:
+    def test_compute_specific_control(
+        self,
+        induced_acceleration_module: tuple[Any, MagicMock],
+        analyzer: Any,
+        mock_model: MagicMock,
+    ) -> None:
         """Test compute_specific_control."""
+        _induced_acceleration_mod, mock_pin = induced_acceleration_module
         q = np.zeros(2)
         specific_tau = np.array([5.0, 5.0])
 
@@ -125,8 +154,14 @@ class TestPinocchioInducedAcceleration:
         np.testing.assert_allclose(result, [5.0, 5.0])
         assert mock_pin.aba.call_count == 2
 
-    def test_compute_counterfactuals(self, analyzer, mock_model) -> None:
+    def test_compute_counterfactuals(
+        self,
+        induced_acceleration_module: tuple[Any, MagicMock],
+        analyzer: Any,
+        mock_model: MagicMock,
+    ) -> None:
         """Test compute_counterfactuals."""
+        _induced_acceleration_mod, mock_pin = induced_acceleration_module
         q = np.zeros(2)
         v = np.zeros(2)
 

--- a/tests/unit/repo_hygiene/test_optional_dependency_mock_scope.py
+++ b/tests/unit/repo_hygiene/test_optional_dependency_mock_scope.py
@@ -20,12 +20,27 @@ _OPTIONAL_DEPENDENCY_MODULES = frozenset(
         "mujoco",
         "mujoco.viewer",
         "opensim",
+        "casadi",
+        "pinocchio",
+        "pinocchio.casadi",
         "pydrake",
         "pydrake.all",
     }
 )
+_PYTEST_COLLECTION_HOOKS = frozenset(
+    {
+        "pytest_configure",
+        "pytest_sessionstart",
+        "pytest_collection_modifyitems",
+        "pytest_collect_file",
+        "pytest_pycollect_makeitem",
+        "pytest_generate_tests",
+    }
+)
 _PREEXISTING_MODULE_SCOPE_PATCH_ALLOWLIST = frozenset(
     {
+        ("tests/integration/test_physics_engines_strict.py", 62),
+        ("tests/ui/test_golf_gui_tabs.py", 228),
         ("tests/integration/test_physics_interfaces.py", 20),
         ("tests/unit/engines/physics_engines/mujoco/test_docker_examples.py", 11),
         ("tests/unit/shared_python/test_plotting_coverage.py", 25),
@@ -39,25 +54,44 @@ _PREEXISTING_MODULE_SCOPE_PATCH_ALLOWLIST = frozenset(
 )
 
 
-def _iter_module_scope_nodes(statements: Iterable[ast.stmt]) -> Iterator[ast.stmt]:
+def _child_statement_blocks(statement: ast.stmt) -> list[list[ast.stmt]]:
+    child_blocks: list[list[ast.stmt]] = []
+    if isinstance(statement, ast.If | ast.For | ast.While):
+        child_blocks.extend([statement.body, statement.orelse])
+    elif isinstance(statement, ast.With):
+        child_blocks.append(statement.body)
+    elif isinstance(statement, ast.Try):
+        child_blocks.extend([statement.body, statement.orelse, statement.finalbody])
+        child_blocks.extend(handler.body for handler in statement.handlers)
+    elif isinstance(statement, ast.Match):
+        child_blocks.extend(case.body for case in statement.cases)
+    return child_blocks
+
+
+def _iter_nested_statements(statements: Iterable[ast.stmt]) -> Iterator[ast.stmt]:
     for statement in statements:
         if isinstance(statement, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
             continue
         yield statement
 
-        child_blocks: list[list[ast.stmt]] = []
-        if isinstance(statement, ast.If | ast.For | ast.While):
-            child_blocks.extend([statement.body, statement.orelse])
-        elif isinstance(statement, ast.With):
-            child_blocks.append(statement.body)
-        elif isinstance(statement, ast.Try):
-            child_blocks.extend([statement.body, statement.orelse, statement.finalbody])
-            child_blocks.extend(handler.body for handler in statement.handlers)
-        elif isinstance(statement, ast.Match):
-            child_blocks.extend(case.body for case in statement.cases)
+        for block in _child_statement_blocks(statement):
+            yield from _iter_nested_statements(block)
 
-        for block in child_blocks:
-            yield from _iter_module_scope_nodes(block)
+
+def _iter_module_scope_nodes(statements: Iterable[ast.stmt]) -> Iterator[ast.stmt]:
+    yield from _iter_nested_statements(statements)
+
+
+def _iter_pytest_collection_hook_nodes(
+    statements: Iterable[ast.stmt],
+) -> Iterator[tuple[str, ast.stmt]]:
+    for statement in statements:
+        if not isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if statement.name not in _PYTEST_COLLECTION_HOOKS:
+            continue
+        for child in _iter_nested_statements(statement.body):
+            yield statement.name, child
 
 
 def _is_sys_modules(node: ast.AST) -> bool:
@@ -66,6 +100,12 @@ def _is_sys_modules(node: ast.AST) -> bool:
         and node.attr == "modules"
         and isinstance(node.value, ast.Name)
         and node.value.id == "sys"
+    )
+
+
+def _is_sys_modules_reference(node: ast.AST) -> bool:
+    return _is_sys_modules(node) or (
+        isinstance(node, ast.Constant) and node.value == "sys.modules"
     )
 
 
@@ -106,9 +146,38 @@ def _calls_patch_dict_sys_modules(statement: ast.stmt) -> bool:
             and call.args
         ):
             continue
-        if _is_sys_modules(call.args[0]):
+        if _is_sys_modules_reference(call.args[0]):
             return True
     return False
+
+
+def _offenders_for_tree(relative: str, tree: ast.Module) -> list[str]:
+    offenders: list[str] = []
+    for statement in _iter_module_scope_nodes(tree.body):
+        dependency = _assigned_optional_dependency(statement)
+        if dependency is not None:
+            offenders.append(f"{relative}:{statement.lineno} assigns {dependency}")
+        if _calls_patch_dict_sys_modules(statement):
+            if (
+                relative,
+                statement.lineno,
+            ) in _PREEXISTING_MODULE_SCOPE_PATCH_ALLOWLIST:
+                continue
+            offenders.append(
+                f"{relative}:{statement.lineno} patches sys.modules at module scope"
+            )
+
+    for hook_name, statement in _iter_pytest_collection_hook_nodes(tree.body):
+        dependency = _assigned_optional_dependency(statement)
+        if dependency is not None:
+            offenders.append(
+                f"{relative}:{statement.lineno} assigns {dependency} in {hook_name}"
+            )
+        if _calls_patch_dict_sys_modules(statement):
+            offenders.append(
+                f"{relative}:{statement.lineno} patches sys.modules in {hook_name}"
+            )
+    return offenders
 
 
 def _candidate_python_files() -> list[Path]:
@@ -148,21 +217,48 @@ def test_no_module_scope_optional_dependency_sys_modules_mocks() -> None:
             continue
 
         relative = path.relative_to(_REPO_ROOT).as_posix()
-        for statement in _iter_module_scope_nodes(tree.body):
-            dependency = _assigned_optional_dependency(statement)
-            if dependency is not None:
-                offenders.append(f"{relative}:{statement.lineno} assigns {dependency}")
-            if _calls_patch_dict_sys_modules(statement):
-                if (
-                    relative,
-                    statement.lineno,
-                ) in _PREEXISTING_MODULE_SCOPE_PATCH_ALLOWLIST:
-                    continue
-                offenders.append(
-                    f"{relative}:{statement.lineno} patches sys.modules at module scope"
-                )
+        offenders.extend(_offenders_for_tree(relative, tree))
 
     assert not offenders, (
         "Optional dependency mocks must be installed by scoped fixtures or local "
         "helpers, not at module import/collection time:\n  " + "\n  ".join(offenders)
     )
+
+
+def test_pytest_configure_optional_dependency_assignment_is_reported() -> None:
+    tree = ast.parse(
+        """
+import sys
+from unittest.mock import MagicMock
+
+def pytest_configure(config):
+    if "pydrake" not in sys.modules:
+        sys.modules["pydrake"] = MagicMock()
+"""
+    )
+
+    offenders = _offenders_for_tree("tests/unit/conftest.py", tree)
+
+    assert offenders == ["tests/unit/conftest.py:7 assigns pydrake in pytest_configure"]
+
+
+def test_pytest_collection_hook_patch_dict_is_reported() -> None:
+    tree = ast.parse(
+        """
+from unittest.mock import MagicMock, patch
+
+def pytest_sessionstart(session):
+    with patch.dict("sys.modules", {"pinocchio": MagicMock()}):
+        pass
+"""
+    )
+
+    offenders = _offenders_for_tree("tests/unit/conftest.py", tree)
+
+    assert offenders == [
+        "tests/unit/conftest.py:5 patches sys.modules in pytest_sessionstart"
+    ]
+
+
+def test_pinocchio_and_casadi_are_optional_dependency_modules() -> None:
+    assert {"pinocchio", "pinocchio.casadi", "casadi"} <= _OPTIONAL_DEPENDENCY_MODULES


### PR DESCRIPTION
## Summary
- remove persistent collection-time optional dependency MagicMocks from `tests/unit/conftest.py`
- keep only per-test engine availability cache reset behavior
- extend the optional dependency mock-scope guard to inspect pytest collection hooks and string-form `patch.dict("sys.modules", ...)`
- include Pinocchio/CasADi optional dependency module names in the guard
- refactor the Pinocchio induced-acceleration unit test to import under a scoped fixture instead of module-scope `sys.modules` patching

Closes #8219

## Validation
- `py -3.13 -m pytest -n 0 tests\unit\repo_hygiene\test_optional_dependency_mock_scope.py tests\unit\engines\pinocchio\test_induced_acceleration.py -q`
- `py -3.13 -m pytest -n 0 --collect-only tests\unit\engines tests\unit\repo_hygiene\test_optional_dependency_mock_scope.py -q`
- `py -3.13 -m ruff check tests\unit\repo_hygiene\test_optional_dependency_mock_scope.py tests\unit\conftest.py tests\unit\engines\pinocchio\test_induced_acceleration.py`
- `py -3.13 -m ruff format --check tests\unit\repo_hygiene\test_optional_dependency_mock_scope.py tests\unit\conftest.py tests\unit\engines\pinocchio\test_induced_acceleration.py`
- `py -3.13 -m mypy tests\unit\repo_hygiene\test_optional_dependency_mock_scope.py tests\unit\conftest.py tests\unit\engines\pinocchio\test_induced_acceleration.py`
- `npx prettier --check SPEC.md`
- `git diff --check`
- pre-push hook passed during authenticated branch push