### PR TITLE
Fix agent governance branch policy drift

### DIFF
--- a/.gaai/core/GAAI.md
+++ b/.gaai/core/GAAI.md
@@ -87,18 +87,18 @@ Welcome. This is the `.gaai/` folder — the GAAI framework living inside your p
 
 ## Branch Model & Automation
 
-AI agents work exclusively on the **`staging`** branch. Promotion to `production` is a human action via GitHub PR.
+AI agents work on **`main`-based topic branches**. Promotion into `main` happens
+by GitHub PR after required checks pass.
 
 ```
-staging  ←── AI works here
-   │  PR (human review)
-production  ←── Deploy via GitHub Actions
+topic branch  ->  PR into main  ->  protected main
 ```
 
 The **Delivery Daemon** automates delivery end-to-end:
 
 - Polls the backlog for `refined` stories
-- Marks them `in_progress` on staging (cross-device coordination via git push)
+- Marks them `in_progress` on the topic branch (cross-device coordination via
+  git push)
 - Launches AI agent sessions in isolated worktrees
 - Parallel execution (default: 3 concurrent slots, configurable via `--max-concurrent`)
 - Monitors session health via heartbeat and `--max-turns` safety limits

--- a/.gaai/project/contexts/rules/project.rules.md
+++ b/.gaai/project/contexts/rules/project.rules.md
@@ -2,8 +2,10 @@
 
 ## Safety
 
-1. All AI work on `staging` branch. Never commit directly to `main`.
-2. PRs target `staging`. No auto-merge. Human approval required.
+1. All AI work uses `main`-based topic branches. Never commit directly to `main`.
+2. PRs target `main`. Auto-merge may be enabled only after required checks pass.
+   Human approval is still required for destructive, release-impacting, or
+   security-impacting changes.
 3. No destructive git history operations.
 4. No secret commits (.env, API keys, credentials).
 

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -726,6 +726,9 @@ jobs:
       - name: Agent Docs Consistency Check
         run: python3 scripts/check_agent_docs_consistency.py
 
+      - name: Agent Governance Consistency Check
+        run: python3 scripts/check_agent_governance_consistency.py
+
       - name: Security Workflow Silent-Failure Guard
         run: python3 scripts/check_workflows_no_silent_failures.py
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -1925,6 +1926,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Aligned repo-local agent governance on the active `main` topic-branch model for #8211. `.gaai` project/core rules now match `CLAUDE.md`, destructive/security/release-impacting actions keep explicit human-review language, and `ci-standard` runs a dedicated governance consistency guard that fails on revived staging-only policy, staging-only PR filters, or agent automation based on `origin/staging`. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/scripts/check_agent_governance_consistency.py
+++ b/scripts/check_agent_governance_consistency.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Fail when repo-local agent governance disagrees on the branch model."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CLAUDE = Path("CLAUDE.md")
+GAAI_PROJECT_RULES = Path(".gaai/project/contexts/rules/project.rules.md")
+GAAI_CORE = Path(".gaai/core/GAAI.md")
+WORKFLOW_DIR = Path(".github/workflows")
+CANONICAL_PR_TARGET = "main"
+STAGING_POLICY_MARKERS = (
+    "All AI work on `staging` branch",
+    "PRs target `staging`",
+)
+STAGING_CORE_MARKERS = (
+    "work exclusively on the **`staging`** branch",
+    "staging  \u2190\u2500\u2500 AI works here",
+    "in_progress` on staging",
+)
+ORIGIN_STAGING = re.compile(r"\borigin/staging\b")
+PULL_REQUEST_STAGING_ONLY = re.compile(
+    r"pull_request:\s*(?:(?!\n\S).)*?branches:\s*\[\s*staging\s*\]",
+    re.DOTALL,
+)
+
+
+def audit_repository(repo_root: Path) -> list[str]:
+    """Audit branch-model policy files and agent workflow branch bases."""
+    if not repo_root.exists():
+        raise FileNotFoundError(f"repository root does not exist: {repo_root}")
+    if not repo_root.is_dir():
+        raise NotADirectoryError(f"repository root is not a directory: {repo_root}")
+
+    findings: list[str] = []
+    findings.extend(_audit_policy_files(repo_root))
+    findings.extend(_audit_workflows(repo_root))
+    return findings
+
+
+def _read_required(repo_root: Path, relative_path: Path) -> str:
+    path = repo_root / relative_path
+    if not path.exists():
+        raise FileNotFoundError(f"required governance file is missing: {relative_path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _audit_policy_files(repo_root: Path) -> list[str]:
+    findings: list[str] = []
+    claude = _read_required(repo_root, CLAUDE)
+    project_rules = _read_required(repo_root, GAAI_PROJECT_RULES)
+    gaai_core = _read_required(repo_root, GAAI_CORE)
+
+    if "PRs target `main`" not in claude:
+        findings.append("CLAUDE.md must declare PRs target `main`")
+    if "PRs target `main`" not in project_rules:
+        findings.append(
+            ".gaai/project/contexts/rules/project.rules.md must declare PRs "
+            "target `main`"
+        )
+    if any(marker in project_rules for marker in STAGING_POLICY_MARKERS):
+        findings.append(
+            ".gaai/project/contexts/rules/project.rules.md still directs AI work "
+            "or PRs to staging"
+        )
+    if any(marker in gaai_core for marker in STAGING_CORE_MARKERS):
+        findings.append(
+            ".gaai/core/GAAI.md still documents staging as the AI work branch"
+        )
+    if "`main`-based topic branches" not in project_rules:
+        findings.append(
+            ".gaai/project/contexts/rules/project.rules.md must require "
+            "`main`-based topic branches"
+        )
+    if "`main`-based topic branches" not in gaai_core:
+        findings.append(".gaai/core/GAAI.md must document `main`-based topic branches")
+
+    return findings
+
+
+def _audit_workflows(repo_root: Path) -> list[str]:
+    workflow_dir = repo_root / WORKFLOW_DIR
+    if not workflow_dir.exists():
+        return []
+
+    findings: list[str] = []
+    for workflow_file in sorted(workflow_dir.glob("*.yml")) + sorted(
+        workflow_dir.glob("*.yaml")
+    ):
+        text = workflow_file.read_text(encoding="utf-8")
+        relative_path = workflow_file.relative_to(repo_root).as_posix()
+        if ORIGIN_STAGING.search(text):
+            findings.append(
+                f"{relative_path} creates agent branches from origin/staging"
+            )
+        if PULL_REQUEST_STAGING_ONLY.search(text):
+            findings.append(
+                f"{relative_path} has a pull_request filter that omits main"
+            )
+    return findings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Fail when agent governance branch policy drifts."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="Repository root to audit.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the branch-model governance consistency audit."""
+    args = build_parser().parse_args(argv)
+    findings = audit_repository(args.repo_root.resolve())
+    if findings:
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+    print(f"Agent governance consistently targets {CANONICAL_PR_TARGET}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_agent_governance_consistency.py
+++ b/tests/unit/scripts/test_agent_governance_consistency.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_agent_governance_consistency import audit_repository
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_policy_files(root: Path, *, project_rules: str, gaai_core: str) -> None:
+    _write(
+        root / "CLAUDE.md",
+        "> PRs target `main`. Use focused topic branches such as `fix/...`.\n",
+    )
+    _write(
+        root / ".gaai" / "project" / "contexts" / "rules" / "project.rules.md",
+        project_rules,
+    )
+    _write(root / ".gaai" / "core" / "GAAI.md", gaai_core)
+
+
+def test_audit_repository_accepts_main_based_governance(tmp_path: Path) -> None:
+    _write_policy_files(
+        tmp_path,
+        project_rules=(
+            "1. All AI work uses `main`-based topic branches. "
+            "Never commit directly to `main`.\n"
+            "2. PRs target `main`. Auto-merge may be enabled only after "
+            "required checks pass.\n"
+        ),
+        gaai_core=(
+            "AI agents work on **`main`-based topic branches**. "
+            "Promotion happens by PR into `main`.\n"
+        ),
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "agent.yml",
+        "on:\n  pull_request:\n    branches: [main]\n"
+        'jobs:\n  branch:\n    steps:\n      - run: git checkout -B "$BRANCH_NAME" origin/main\n',
+    )
+
+    assert audit_repository(tmp_path) == []
+
+
+def test_audit_repository_rejects_staging_policy_conflicts(tmp_path: Path) -> None:
+    _write_policy_files(
+        tmp_path,
+        project_rules=(
+            "1. All AI work on `staging` branch. Never commit directly to `main`.\n"
+            "2. PRs target `staging`. No auto-merge. Human approval required.\n"
+        ),
+        gaai_core="AI agents work exclusively on the **`staging`** branch.\n",
+    )
+
+    findings = audit_repository(tmp_path)
+
+    assert (
+        ".gaai/project/contexts/rules/project.rules.md still directs AI work "
+        "or PRs to staging"
+    ) in findings
+    assert (
+        ".gaai/core/GAAI.md still documents staging as the AI work branch" in findings
+    )
+
+
+def test_audit_repository_rejects_automation_based_on_staging(
+    tmp_path: Path,
+) -> None:
+    _write_policy_files(
+        tmp_path,
+        project_rules=(
+            "1. All AI work uses `main`-based topic branches. "
+            "Never commit directly to `main`.\n"
+            "2. PRs target `main`. Auto-merge may be enabled only after "
+            "required checks pass.\n"
+        ),
+        gaai_core="AI agents work on **`main`-based topic branches**.\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "agent.yml",
+        "on:\n  pull_request:\n    branches: [staging]\n"
+        'jobs:\n  branch:\n    steps:\n      - run: git checkout -B "$BRANCH_NAME" origin/staging\n',
+    )
+
+    findings = audit_repository(tmp_path)
+
+    assert (
+        ".github/workflows/agent.yml creates agent branches from origin/staging"
+    ) in findings
+    assert (
+        ".github/workflows/agent.yml has a pull_request filter that omits main"
+    ) in findings


### PR DESCRIPTION
## Summary
- align `.gaai` project/core branch governance with `CLAUDE.md` on the active `main` topic-branch model
- keep explicit human-review language for destructive, release-impacting, and security-impacting actions
- add `scripts/check_agent_governance_consistency.py` to fail on revived staging-only policy, staging-only PR filters, or `origin/staging` agent automation
- wire the new governance guard into `ci-standard`

Closes #8211

## Validation
- `py -3.13 -m pytest -n 0 tests\unit\scripts\test_agent_governance_consistency.py -q`
- `py -3.13 scripts\check_agent_governance_consistency.py`
- `py -3.13 -m ruff check scripts\check_agent_governance_consistency.py tests\unit\scripts\test_agent_governance_consistency.py`
- `py -3.13 -m ruff format --check scripts\check_agent_governance_consistency.py tests\unit\scripts\test_agent_governance_consistency.py`
- `py -3.13 -m mypy scripts\check_agent_governance_consistency.py tests\unit\scripts\test_agent_governance_consistency.py`
- `py -3.13 scripts\check_agent_docs_consistency.py`
- `py -3.13 scripts\check_workflow_inventory.py`
- `py -3.13 scripts\check_workflows_no_silent_failures.py`
- `py -3.13 scripts\ci\check_workflow_contexts.py`
- `py -3.13 scripts\ci\check_workflow_pytest_paths.py`
- `npx prettier --check SPEC.md .gaai\project\contexts\rules\project.rules.md .gaai\core\GAAI.md .github\workflows\ci-standard.yml`
- `git diff --check`
- pre-push hook passed during authenticated branch push