### PR TITLE
Fix optional-stack Pinocchio skip policy

### DIFF
--- a/.github/workflows/ci-optional-stack.yml
+++ b/.github/workflows/ci-optional-stack.yml
@@ -308,31 +308,17 @@ jobs:
             tests/engines/test_pinocchio_recorder.py \
             --timeout=60 \
             --timeout-method=thread \
+            --junitxml=/tmp/pinocchio-junit.xml \
             -v --tb=short \
             2>&1 | tee /tmp/pinocchio-test-results.txt
           rc=$?
           set -e
 
-          passed=$(grep -c "PASSED" /tmp/pinocchio-test-results.txt || true)
-          failed=$(grep -c "FAILED" /tmp/pinocchio-test-results.txt || true)
-          skipped=$(grep -c "SKIPPED" /tmp/pinocchio-test-results.txt || true)
-          echo "- Passed: $passed | Failed: $failed | Skipped: $skipped" >> "$GITHUB_STEP_SUMMARY"
-
-          if [[ "$rc" -eq 5 ]]; then
-            echo "::warning::No Pinocchio ecosystem tests were collected in the optional-stack lane."
-          elif [[ "$rc" -ne 0 ]]; then
-            echo "::error::Pinocchio ecosystem tests failed with pytest exit code $rc."
-            exit "$rc"
-          fi
-
-          # If Pinocchio IS installed but all tests were skipped, that is a
-          # regression  -  the guard conditions may no longer match the installed
-          # package API.
-          if [[ "${{ steps.pinocchio_install.outputs.available }}" == "true" ]] && \
-             [[ "$passed" -eq 0 ]] && [[ "$skipped" -gt 0 ]]; then
-            echo "::warning::Pinocchio is installed but ALL pinocchio tests were skipped." \
-              "Check that skipTest() guard conditions are still valid."
-          fi
+          python3 scripts/ci/check_optional_stack_skip_policy.py \
+            --junit /tmp/pinocchio-junit.xml \
+            --available "${{ steps.pinocchio_install.outputs.available }}" \
+            --pytest-exit-code "$rc" \
+            --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Run Unit Tests (Optional Stack)
         # Run the non-engine unit suite with optional extras present. Native

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -1925,6 +1926,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Hardened the optional-stack Pinocchio ecosystem lane for #8225. The workflow now emits a JUnit report and delegates the availability/skip policy to `scripts/ci/check_optional_stack_skip_policy.py`, so a provisioned Pinocchio stack fails on zero collected tests or zero passing ecosystem cases instead of warning and continuing; focused unit coverage pins available, unavailable, all-skipped, and pytest exit-code 5 behavior. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/scripts/ci/check_optional_stack_skip_policy.py
+++ b/scripts/ci/check_optional_stack_skip_policy.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Enforce optional-stack pytest skip policy from JUnit results."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import defusedxml.ElementTree as ElementTree
+
+
+class OptionalStackPolicyError(RuntimeError):
+    """Raised when an optional-stack test lane did not validate real behavior."""
+
+
+def summarize_junit(junit_path: Path) -> dict[str, int]:
+    """Return pass/skip/fail/error testcase counts for a JUnit XML report."""
+    if not junit_path.exists():
+        raise FileNotFoundError(f"JUnit report not found: {junit_path}")
+
+    counts = {"passed": 0, "skipped": 0, "failed": 0, "error": 0, "matched": 0}
+    root = ElementTree.parse(junit_path).getroot()
+    for testcase in root.iter("testcase"):
+        counts["matched"] += 1
+        if testcase.find("skipped") is not None:
+            counts["skipped"] += 1
+        elif testcase.find("failure") is not None:
+            counts["failed"] += 1
+        elif testcase.find("error") is not None:
+            counts["error"] += 1
+        else:
+            counts["passed"] += 1
+    return counts
+
+
+def check_optional_stack_skip_policy(
+    *,
+    junit_path: Path,
+    dependency_available: bool,
+    pytest_exit_code: int,
+) -> dict[str, int]:
+    """Return JUnit counts or raise when optional-stack coverage is false-green."""
+    if pytest_exit_code not in {0, 5}:
+        raise OptionalStackPolicyError(
+            "optional-stack pytest run failed with exit code "
+            f"{pytest_exit_code}; see test output above"
+        )
+
+    if pytest_exit_code == 5:
+        if dependency_available:
+            raise OptionalStackPolicyError(
+                "Pinocchio is available, but pytest collected zero ecosystem tests"
+            )
+        return {"passed": 0, "skipped": 0, "failed": 0, "error": 0, "matched": 0}
+
+    counts = summarize_junit(junit_path)
+    if dependency_available and counts["passed"] < 1:
+        raise OptionalStackPolicyError(
+            "Pinocchio is available, but no ecosystem testcase passed: "
+            f"passed={counts['passed']} skipped={counts['skipped']} "
+            f"failed={counts['failed']} error={counts['error']} "
+            f"matched={counts['matched']}"
+        )
+    return counts
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def _append_summary(path: Path, counts: dict[str, int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "- Passed: {passed} | Failed: {failed} | Skipped: {skipped} | "
+            "Matched: {matched}\n".format(**counts)
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--junit", required=True, type=Path)
+    parser.add_argument("--available", required=True, type=_parse_bool)
+    parser.add_argument("--pytest-exit-code", required=True, type=int)
+    parser.add_argument("--summary-file", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    try:
+        counts = check_optional_stack_skip_policy(
+            junit_path=args.junit,
+            dependency_available=args.available,
+            pytest_exit_code=args.pytest_exit_code,
+        )
+    except (FileNotFoundError, OptionalStackPolicyError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)  # noqa: T201 - CI signal
+        return 1
+
+    if args.summary_file is not None:
+        _append_summary(args.summary_file, counts)
+
+    print(  # noqa: T201 - intentional CI summary
+        "Optional-stack skip policy satisfied: "
+        f"passed={counts['passed']} skipped={counts['skipped']} "
+        f"failed={counts['failed']} error={counts['error']} "
+        f"matched={counts['matched']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_ci_infrastructure.py
+++ b/tests/ci/test_ci_infrastructure.py
@@ -1186,10 +1186,6 @@ class TestCIEnvironmentCompatibility:
 
         for step_name, log_file in [
             ("Run API Tests (Optional Stack)", "/tmp/api-test-results.txt"),
-            (
-                "Run Pinocchio Ecosystem Tests (Optional Stack)",
-                "/tmp/pinocchio-test-results.txt",
-            ),
             ("Run Unit Tests (Optional Stack)", "/tmp/unit-test-results.txt"),
         ]:
             step = job[job.index(f"- name: {step_name}") :]
@@ -1222,8 +1218,18 @@ class TestCIEnvironmentCompatibility:
                 "- name: Run Pinocchio Ecosystem Tests (Optional Stack)"
             ) : job.index("- name: Run Unit Tests (Optional Stack)")
         ]
-        assert '[[ "$rc" -eq 5 ]]' in pinocchio_step
-        assert 'exit "$rc"' in pinocchio_step
+        assert "tee /tmp/pinocchio-test-results.txt || true" not in pinocchio_step
+        assert "set -o pipefail" in pinocchio_step
+        assert "rc=$?" in pinocchio_step
+        assert 'grep -c "FAILED"' not in pinocchio_step
+        assert "scripts/ci/check_optional_stack_skip_policy.py" in pinocchio_step
+        assert "--junitxml=/tmp/pinocchio-junit.xml" in pinocchio_step
+        assert "--available" in pinocchio_step
+        assert '--pytest-exit-code "$rc"' in pinocchio_step
+        assert (
+            "::warning::Pinocchio is installed but ALL pinocchio tests were skipped"
+            not in pinocchio_step
+        )
 
     def test_physics_validation_script_targets_collect_tests(self) -> None:
         """Every physics runner target must collect at least one real test."""

--- a/tests/unit/scripts/test_optional_stack_skip_policy.py
+++ b/tests/unit/scripts/test_optional_stack_skip_policy.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.check_optional_stack_skip_policy import (
+    OptionalStackPolicyError,
+    check_optional_stack_skip_policy,
+    main,
+    summarize_junit,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_junit(path: Path, body: str) -> None:
+    path.write_text(
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f"<testsuites><testsuite>{body}</testsuite></testsuites>\n",
+        encoding="utf-8",
+    )
+
+
+def test_available_dependency_accepts_at_least_one_passed_case(tmp_path: Path) -> None:
+    junit = tmp_path / "pinocchio.xml"
+    _write_junit(
+        junit,
+        '<testcase name="test_recorder_basic"/>'
+        '<testcase name="test_optional_gui"><skipped message="headless"/></testcase>',
+    )
+
+    counts = check_optional_stack_skip_policy(
+        junit_path=junit,
+        dependency_available=True,
+        pytest_exit_code=0,
+    )
+
+    assert counts["passed"] == 1
+    assert counts["skipped"] == 1
+
+
+def test_available_dependency_rejects_all_skipped_cases(tmp_path: Path) -> None:
+    junit = tmp_path / "pinocchio.xml"
+    _write_junit(
+        junit,
+        '<testcase name="test_recorder_basic"><skipped message="missing gui"/></testcase>',
+    )
+
+    with pytest.raises(OptionalStackPolicyError, match="no ecosystem testcase passed"):
+        check_optional_stack_skip_policy(
+            junit_path=junit,
+            dependency_available=True,
+            pytest_exit_code=0,
+        )
+
+
+def test_unavailable_dependency_allows_all_skipped_cases(tmp_path: Path) -> None:
+    junit = tmp_path / "pinocchio.xml"
+    _write_junit(
+        junit,
+        '<testcase name="test_recorder_basic"><skipped message="missing pinocchio"/></testcase>',
+    )
+
+    counts = check_optional_stack_skip_policy(
+        junit_path=junit,
+        dependency_available=False,
+        pytest_exit_code=0,
+    )
+
+    assert counts["passed"] == 0
+    assert counts["skipped"] == 1
+
+
+def test_available_dependency_rejects_pytest_collection_exit_code_5(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(OptionalStackPolicyError, match="collected zero"):
+        check_optional_stack_skip_policy(
+            junit_path=tmp_path / "missing.xml",
+            dependency_available=True,
+            pytest_exit_code=5,
+        )
+
+
+def test_unavailable_dependency_allows_pytest_collection_exit_code_5(
+    tmp_path: Path,
+) -> None:
+    counts = check_optional_stack_skip_policy(
+        junit_path=tmp_path / "missing.xml",
+        dependency_available=False,
+        pytest_exit_code=5,
+    )
+
+    assert counts == {"passed": 0, "skipped": 0, "failed": 0, "error": 0, "matched": 0}
+
+
+def test_junit_summary_counts_failures_and_errors(tmp_path: Path) -> None:
+    junit = tmp_path / "pinocchio.xml"
+    _write_junit(
+        junit,
+        '<testcase name="test_passed"/>'
+        '<testcase name="test_skipped"><skipped/></testcase>'
+        '<testcase name="test_failed"><failure/></testcase>'
+        '<testcase name="test_error"><error/></testcase>',
+    )
+
+    assert summarize_junit(junit) == {
+        "passed": 1,
+        "skipped": 1,
+        "failed": 1,
+        "error": 1,
+        "matched": 4,
+    }
+
+
+def test_main_writes_summary_file(tmp_path: Path) -> None:
+    junit = tmp_path / "pinocchio.xml"
+    summary = tmp_path / "summary.md"
+    _write_junit(junit, '<testcase name="test_recorder_basic"/>')
+
+    assert (
+        main(
+            [
+                "--junit",
+                str(junit),
+                "--available",
+                "true",
+                "--pytest-exit-code",
+                "0",
+                "--summary-file",
+                str(summary),
+            ]
+        )
+        == 0
+    )
+    assert "Passed: 1 | Failed: 0 | Skipped: 0 | Matched: 1" in summary.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
## Summary
- add `scripts/ci/check_optional_stack_skip_policy.py` to enforce optional-stack JUnit pass/skip policy
- make the Pinocchio optional-stack lane emit JUnit and call the policy helper instead of warning on all-skipped provisioned runs
- fail when Pinocchio is available and pytest collects zero ecosystem tests or records zero passing ecosystem cases
- keep unavailable Pinocchio runs allowed to skip, with summary counts still written to the job summary

Closes #8225

## Validation
- `py -3.13 -m pytest -n 0 tests\unit\scripts\test_optional_stack_skip_policy.py tests\ci\test_ci_infrastructure.py::TestCIEnvironmentCompatibility::test_ci_optional_stack_pytest_exit_codes_are_gating -q`
- `py -3.13 -m ruff check scripts\ci\check_optional_stack_skip_policy.py tests\unit\scripts\test_optional_stack_skip_policy.py tests\ci\test_ci_infrastructure.py`
- `py -3.13 -m ruff format --check scripts\ci\check_optional_stack_skip_policy.py tests\unit\scripts\test_optional_stack_skip_policy.py tests\ci\test_ci_infrastructure.py`
- `py -3.13 -m mypy scripts\ci\check_optional_stack_skip_policy.py tests\unit\scripts\test_optional_stack_skip_policy.py`
- `npx prettier --check SPEC.md .github\workflows\ci-optional-stack.yml`
- `py -3.13 scripts\check_workflows_no_silent_failures.py`
- `py -3.13 scripts\ci\check_workflow_contexts.py`
- `py -3.13 scripts\check_workflow_inventory.py`
- `py -3.13 scripts\ci\check_workflow_pytest_paths.py`
- `py -3.13 scripts\ci\check_optional_stack_skip_policy.py --junit <temp passing junit> --available true --pytest-exit-code 0`
- `py -3.13 scripts\ci\check_todo_discipline.py`
- `git diff --check`
- pre-push hook passed during authenticated branch push

Note: `py -3.13 scripts\ci\check_suite_marker_ratchet.py` still fails on a pre-existing clean-main baseline mismatch; the reported unmarked tests do not include the new `tests\unit\scripts\test_optional_stack_skip_policy.py`, which is marked `pytest.mark.unit`.