### PR TITLE
Fix no-op test placeholder guard

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -762,6 +762,9 @@ jobs:
       - name: Test Layout Guard
         run: python3 scripts/check_test_layout.py
 
+      - name: No-op Test Placeholder Guard
+        run: python3 scripts/ci/check_noop_tests.py
+
       - name: In-Tree Pytest Collection Guard
         run: python3 scripts/check_pytest_intree_testpaths.py
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -1925,6 +1926,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Added a no-op pytest placeholder guard for #8228. `scripts/ci/check_noop_tests.py` now walks configured pytest `testpaths` and fails on collected test functions whose effective body is only `pass`, `...`, or `assert True`; `ci-standard` runs the guard and focused unit tests cover colocated `src/**/tests`, docstring-only placeholders, and real no-exception tests with setup work. The lower-body simulator test on current main already contains real deque/history and damped-least-squares IK assertions. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/scripts/ci/check_noop_tests.py
+++ b/scripts/ci/check_noop_tests.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Reject collected test functions whose body is only a no-op placeholder."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = Path("pyproject.toml")
+
+
+def iter_test_files(repo_root: Path) -> list[Path]:
+    """Return configured pytest test files under pyproject testpaths."""
+    testpaths = _load_testpaths(repo_root / PYPROJECT)
+    test_files: list[Path] = []
+    for testpath in testpaths:
+        root = repo_root / testpath
+        if root.is_file() and root.name.startswith("test_") and root.suffix == ".py":
+            test_files.append(root)
+        elif root.is_dir():
+            test_files.extend(sorted(root.rglob("test_*.py")))
+    return sorted(set(test_files))
+
+
+def find_noop_tests(repo_root: Path) -> list[str]:
+    """Return repo-relative findings for no-op test functions."""
+    findings: list[str] = []
+    for test_file in iter_test_files(repo_root):
+        relative_path = test_file.relative_to(repo_root).as_posix()
+        try:
+            tree = ast.parse(
+                test_file.read_text(encoding="utf-8"), filename=relative_path
+            )
+        except SyntaxError as exc:
+            findings.append(f"{relative_path}:{exc.lineno}: syntax error: {exc.msg}")
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if not node.name.startswith("test_"):
+                continue
+            noop_kind = _noop_test_kind(node)
+            if noop_kind is not None:
+                findings.append(
+                    f"{relative_path}:{node.lineno}: {node.name} is a no-op "
+                    f"placeholder ({noop_kind})"
+                )
+    return findings
+
+
+def _load_testpaths(pyproject_path: Path) -> list[str]:
+    if not pyproject_path.exists():
+        raise FileNotFoundError(f"pyproject.toml not found: {pyproject_path}")
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    testpaths = data["tool"]["pytest"]["ini_options"]["testpaths"]
+    if not isinstance(testpaths, list) or not all(
+        isinstance(path, str) for path in testpaths
+    ):
+        raise ValueError("pyproject pytest testpaths must be a list of strings")
+    return testpaths
+
+
+def _effective_body(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[ast.stmt]:
+    body = list(node.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        return body[1:]
+    return body
+
+
+def _noop_test_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    body = _effective_body(node)
+    if len(body) != 1:
+        return None
+    statement = body[0]
+    if isinstance(statement, ast.Pass):
+        return "pass"
+    if (
+        isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Constant)
+        and statement.value.value is Ellipsis
+    ):
+        return "ellipsis"
+    if isinstance(statement, ast.Assert) and _is_constant_true(statement.test):
+        return "assert-true"
+    return None
+
+
+def _is_constant_true(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant):
+        return node.value is True
+    return False
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="Repository root to audit.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    findings = find_noop_tests(args.repo_root.resolve())
+    if findings:
+        print("No-op test guard failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"- {finding}", file=sys.stderr)
+        return 1
+    print("No no-op placeholder tests found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_noop_test_guard.py
+++ b/tests/unit/scripts/test_noop_test_guard.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.check_noop_tests import find_noop_tests, main
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_pyproject(root: Path, *testpaths: str) -> None:
+    quoted = ", ".join(f'"{testpath}"' for testpath in testpaths)
+    _write(
+        root / "pyproject.toml",
+        "[tool.pytest.ini_options]\n"
+        f"testpaths = [{quoted}]\n"
+        'python_files = "test_*.py"\n',
+    )
+
+
+def test_guard_rejects_assert_true_placeholder(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "tests", "src/pkg/tests")
+    _write(
+        tmp_path / "src" / "pkg" / "tests" / "test_simulator.py",
+        "def test_placeholder():\n    assert True\n",
+    )
+
+    findings = find_noop_tests(tmp_path)
+
+    assert findings == [
+        "src/pkg/tests/test_simulator.py:1: test_placeholder is a no-op "
+        "placeholder (assert-true)"
+    ]
+
+
+def test_guard_rejects_docstring_plus_pass(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "tests")
+    _write(
+        tmp_path / "tests" / "test_contract.py",
+        'def test_placeholder():\n    """placeholder."""\n    pass\n',
+    )
+
+    assert "placeholder (pass)" in find_noop_tests(tmp_path)[0]
+
+
+def test_guard_accepts_real_no_exception_test(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "tests")
+    _write(
+        tmp_path / "tests" / "test_contract.py",
+        "def test_does_not_raise():\n"
+        "    value = int('1')\n"
+        "    assert True  # documents no exception after real setup\n",
+    )
+
+    assert find_noop_tests(tmp_path) == []
+
+
+def test_guard_ignores_non_test_helpers(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "tests")
+    _write(
+        tmp_path / "tests" / "test_contract.py",
+        "def helper():\n    pass\ndef test_real():\n    assert 1 + 1 == 2\n",
+    )
+
+    assert find_noop_tests(tmp_path) == []
+
+
+def test_main_returns_nonzero_for_noop_test(tmp_path: Path) -> None:
+    _write_pyproject(tmp_path, "tests")
+    _write(
+        tmp_path / "tests" / "test_contract.py", "def test_placeholder():\n    ...\n"
+    )
+
+    assert main(["--repo-root", str(tmp_path)]) == 1


### PR DESCRIPTION
## Summary
- add `scripts/ci/check_noop_tests.py` to reject pytest-collected functions whose effective body is only `pass`, `...`, or `assert True`
- wire the no-op placeholder guard into `ci-standard`
- add focused unit coverage for colocated `src/**/tests`, docstring-only placeholders, non-test helpers, and real no-exception tests with setup work
- verify the current lower-body simulator test already contains real deque/history and damped-least-squares IK assertions instead of the stale placeholder body reported in the issue

Closes #8228

## Validation
- `py -3.13 scripts\ci\check_noop_tests.py`
- `py -3.13 -m pytest -n 0 tests\unit\scripts\test_noop_test_guard.py src\engines\lower_body_model\tests\test_simulator.py -q`
- `py -3.13 -m ruff check scripts\ci\check_noop_tests.py tests\unit\scripts\test_noop_test_guard.py src\engines\lower_body_model\tests\test_simulator.py`
- `py -3.13 -m ruff format --check scripts\ci\check_noop_tests.py tests\unit\scripts\test_noop_test_guard.py src\engines\lower_body_model\tests\test_simulator.py`
- `py -3.13 -m mypy scripts\ci\check_noop_tests.py tests\unit\scripts\test_noop_test_guard.py`
- `npx prettier --check SPEC.md .github\workflows\ci-standard.yml`
- `py -3.13 scripts\ci\check_workflow_contexts.py`
- `py -3.13 scripts\check_workflows_no_silent_failures.py`
- `py -3.13 scripts\check_workflow_inventory.py`
- `py -3.13 scripts\ci\check_workflow_pytest_paths.py`
- `git diff --check`
- pre-push hook passed during authenticated branch push