### PR TITLE
Fix motion-matching importorskip scope

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -1925,6 +1926,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Scoped motion-matching optional dependency OSError handling for #8226. The unit motion-matching conftest no longer rewrites `pytest.importorskip` process-wide; `tests.support.optional_deps.importorskip_optional()` provides explicit allowlisted OSError skips for call sites that need DLL-load tolerance, and a repo-hygiene AST regression prevents conftests from globally patching pytest import behavior again. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/tests/support/optional_deps.py
+++ b/tests/support/optional_deps.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 
 __all__ = [
+    "importorskip_optional",
     "missing_is_optional",
     "scoped_import_with_optional_mocks",
     "skip_unless_optional",
@@ -69,6 +70,38 @@ def skip_unless_optional(exc: ImportError, allowed: Iterable[str]) -> None:
             allow_module_level=True,
         )
     # Not optional → a real bug. Caller re-raises.
+
+
+def importorskip_optional(
+    modname: str,
+    *,
+    allowed_oserror_modules: Iterable[str],
+    minversion: str | None = None,
+    reason: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Import or skip an explicit optional module, including allowlisted OSErrors.
+
+    Unlike a global ``pytest.importorskip`` monkeypatch, this helper scopes
+    Windows DLL-load tolerance to the call site and the named optional module.
+    OSError for any non-allowlisted module re-raises as a real test failure.
+    """
+    try:
+        return pytest.importorskip(
+            modname,
+            minversion=minversion,
+            reason=reason,
+            **kwargs,
+        )
+    except OSError as exc:
+        top_level = modname.split(".", 1)[0]
+        allowed = {name.split(".", 1)[0] for name in allowed_oserror_modules}
+        if top_level in allowed:
+            pytest.skip(
+                f"optional dependency unavailable due to OSError: {modname}: {exc}",
+                allow_module_level=True,
+            )
+        raise
 
 
 @contextmanager

--- a/tests/support/test_optional_deps.py
+++ b/tests/support/test_optional_deps.py
@@ -8,6 +8,7 @@ from types import ModuleType
 import pytest
 
 from tests.support.optional_deps import (
+    importorskip_optional,
     missing_is_optional,
     scoped_import_with_optional_mocks,
     skip_unless_optional,
@@ -67,3 +68,23 @@ def test_scoped_import_with_optional_mocks_restores_modules() -> None:
 
     assert sys.modules.get(dependency_name) is before_dependency
     assert sys.modules.get(target_name) is before_target
+
+
+def test_importorskip_optional_skips_allowlisted_oserror(monkeypatch) -> None:
+    def raise_oserror(*_args, **_kwargs):
+        raise OSError("[WinError 126] DLL load failed")
+
+    monkeypatch.setattr(pytest, "importorskip", raise_oserror)
+
+    with pytest.raises(pytest.skip.Exception):
+        importorskip_optional("mujoco", allowed_oserror_modules={"mujoco"})
+
+
+def test_importorskip_optional_reraises_unallowlisted_oserror(monkeypatch) -> None:
+    def raise_oserror(*_args, **_kwargs):
+        raise OSError("[WinError 126] DLL load failed")
+
+    monkeypatch.setattr(pytest, "importorskip", raise_oserror)
+
+    with pytest.raises(OSError, match="DLL load failed"):
+        importorskip_optional("src.bad_import", allowed_oserror_modules={"mujoco"})

--- a/tests/unit/motion_matching/conftest.py
+++ b/tests/unit/motion_matching/conftest.py
@@ -334,25 +334,3 @@ def sample_skeleton_points() -> dict[str, tuple[float, float, float]]:
         "butt": (0.0, 0.0, 0.9),
         "clubhead": (0.5, 0.0, 0.1),
     }
-
-
-# =============================================================================
-# Global Patches for Environmental Issues
-# =============================================================================
-
-# Patch pytest.importorskip to catch OSError on Windows
-_original_importorskip = pytest.importorskip
-
-
-def _safe_importorskip(modname, minversion=None, reason=None, **kwargs):
-    try:
-        return _original_importorskip(
-            modname, minversion=minversion, reason=reason, **kwargs
-        )
-    except OSError as e:
-        if "WinError" in str(e):
-            pytest.skip(f"Skipping {modname} due to OSError: {e}")
-        raise
-
-
-pytest.importorskip = _safe_importorskip

--- a/tests/unit/repo_hygiene/test_no_global_importorskip_patch.py
+++ b/tests/unit/repo_hygiene/test_no_global_importorskip_patch.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.unit
+
+
+def _assigns_pytest_importorskip(node: ast.AST) -> bool:
+    targets: list[ast.AST]
+    if isinstance(node, ast.Assign):
+        targets = list(node.targets)
+    elif isinstance(node, ast.AnnAssign | ast.AugAssign):
+        targets = [node.target]
+    else:
+        return False
+    return any(_is_pytest_importorskip(target) for target in targets)
+
+
+def _calls_setattr_pytest_importorskip(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "setattr"
+        and len(node.args) >= 2
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "pytest"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == "importorskip"
+    )
+
+
+def _is_pytest_importorskip(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "importorskip"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "pytest"
+    )
+
+
+def test_conftests_do_not_patch_pytest_importorskip_globally() -> None:
+    offenders: list[str] = []
+    for conftest in sorted((REPO_ROOT / "tests").rglob("conftest.py")):
+        tree = ast.parse(conftest.read_text(encoding="utf-8"), filename=str(conftest))
+        for node in ast.walk(tree):
+            if _assigns_pytest_importorskip(node) or _calls_setattr_pytest_importorskip(
+                node
+            ):
+                rel_path = conftest.relative_to(REPO_ROOT).as_posix()
+                line = getattr(node, "lineno", 0)
+                offenders.append(f"{rel_path}:{line}")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- remove the process-global `pytest.importorskip` monkeypatch from `tests/unit/motion_matching/conftest.py`
- add `tests.support.optional_deps.importorskip_optional()` for explicit allowlisted OSError skips at call sites that need DLL-load tolerance
- add regression coverage for allowlisted vs unallowlisted OSError behavior
- add a repo-hygiene AST test that rejects conftests assigning or `setattr`-patching `pytest.importorskip`

Closes #8226

## Validation
- `py -3.13 -m pytest -n 0 tests\support\test_optional_deps.py tests\unit\repo_hygiene\test_no_global_importorskip_patch.py -q`
- `py -3.13 -m pytest -n 0 --collect-only tests\unit\motion_matching tests\support\test_optional_deps.py tests\unit\repo_hygiene\test_no_global_importorskip_patch.py -q`
- `py -3.13 -m ruff check tests\support\optional_deps.py tests\support\test_optional_deps.py tests\unit\repo_hygiene\test_no_global_importorskip_patch.py tests\unit\motion_matching\conftest.py`
- `py -3.13 -m ruff format --check tests\support\optional_deps.py tests\support\test_optional_deps.py tests\unit\repo_hygiene\test_no_global_importorskip_patch.py tests\unit\motion_matching\conftest.py`
- `py -3.13 -m mypy tests\support\optional_deps.py tests\support\test_optional_deps.py tests\unit\repo_hygiene\test_no_global_importorskip_patch.py`
- `npx prettier --check SPEC.md`
- direct `rg` check found no global `pytest.importorskip` assignments
- `git diff --check`
- pre-push hook passed during authenticated branch push