### PR TITLE
Fix #8227: require passing equivalence JUnit gates

### DIFF
--- a/.github/workflows/cross-engine-equivalence.yml
+++ b/.github/workflows/cross-engine-equivalence.yml
@@ -207,11 +207,12 @@ jobs:
         # Even with deps present, a JUnit report of only skipped JaxSim parity
         # cases must not green this required gate. This post-pytest assertion
         # fails unless at least one JaxSim/Pinocchio parity case passed.
+        if: always()
         shell: bash
         run: |
-          python3 scripts/ci/require_junit_test_passed.py \
-            test-results/cross-engine-equivalence-junit.xml \
-            test_jaxsim_pinocchio_free_body_dynamics_terms_match
+          python3 scripts/ci/assert_required_parity_ran.py \
+            --junit test-results/cross-engine-equivalence-junit.xml \
+            --require-name test_jaxsim_pinocchio_free_body_dynamics_terms_match
 
       - name: Upload equivalence report
         if: always()
@@ -320,6 +321,14 @@ jobs:
             -m "${{ matrix.marker }}" \
             -v -rs --tb=short -p no:xvfb \
             --junitxml="test-results/canonical-conformance-${{ matrix.engine }}-junit.xml"
+
+      - name: Assert canonical conformance cases actually ran
+        if: always()
+        shell: bash
+        run: |
+          python3 scripts/ci/assert_required_parity_ran.py \
+            --junit "test-results/canonical-conformance-${{ matrix.engine }}-junit.xml" \
+            --require-name test_five_conformance_checks_pass_against_stub_adapter
 
       - name: Upload conformance report
         if: always()

--- a/.github/workflows/urdf-cross-engine-equivalence.yml
+++ b/.github/workflows/urdf-cross-engine-equivalence.yml
@@ -147,6 +147,14 @@ jobs:
             -v -rs --tb=short -p no:xvfb \
             --junitxml=test-results/urdf-cross-engine-equivalence-junit.xml
 
+      - name: Assert URDF equivalence cases actually ran
+        if: always()
+        shell: bash
+        run: |
+          python3 scripts/ci/assert_required_parity_ran.py \
+            --junit test-results/urdf-cross-engine-equivalence-junit.xml \
+            --require-name test_cross_engine_fk_
+
       - name: Upload equivalence report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened the required cross-engine JUnit gates for #8227.
+  The JaxSim/Pinocchio, URDF FK, and canonical conformance workflows now reuse
+  the canonical required-parity report helper and fail required CI when their
+  mission-critical JUnit cases are absent, skipped-only, failed, or errored.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/tests/ci/test_assert_required_parity_ran.py
+++ b/tests/ci/test_assert_required_parity_ran.py
@@ -76,6 +76,32 @@ def test_absent_required_case_fails(tmp_path: Path) -> None:
         assert_parity_ran(junit, (_REQUIRED,))
 
 
+def test_failed_required_case_fails(tmp_path: Path) -> None:
+    junit = tmp_path / "junit.xml"
+    _write_junit(
+        junit,
+        body=(
+            f'<testcase classname="tests.cross_engine.test_jaxsim_vs_pinocchio" '
+            f'name="{_REQUIRED}"><failure message="mismatch"/></testcase>'
+        ),
+    )
+    with pytest.raises(ParityGateError):
+        assert_parity_ran(junit, (_REQUIRED,))
+
+
+def test_errored_required_case_fails(tmp_path: Path) -> None:
+    junit = tmp_path / "junit.xml"
+    _write_junit(
+        junit,
+        body=(
+            f'<testcase classname="tests.cross_engine.test_jaxsim_vs_pinocchio" '
+            f'name="{_REQUIRED}"><error message="crash"/></testcase>'
+        ),
+    )
+    with pytest.raises(ParityGateError):
+        assert_parity_ran(junit, (_REQUIRED,))
+
+
 def test_missing_report_fails(tmp_path: Path) -> None:
     assert (
         main(["--junit", str(tmp_path / "nope.xml"), "--require-name", _REQUIRED]) == 1

--- a/tests/ci/test_ci_infrastructure.py
+++ b/tests/ci/test_ci_infrastructure.py
@@ -360,8 +360,59 @@ class TestCIEnvironmentCompatibility:
         assert "pin>=2.6.0,<5.0.0" in workflow
         assert "scripts/ci/check_pinocchio_dynamics_api.py" in workflow
         # Post-pytest assertion that a required parity case passed (not skipped).
-        assert "scripts/ci/require_junit_test_passed.py" in workflow
-        assert "test_jaxsim_pinocchio_free_body_dynamics_terms_match" in workflow
+        post_gate = workflow[
+            workflow.index("Assert JaxSim parity cases actually ran") : workflow.index(
+                "Upload equivalence report"
+            )
+        ]
+        assert "scripts/ci/assert_required_parity_ran.py" in post_gate
+        assert "--junit test-results/cross-engine-equivalence-junit.xml" in post_gate
+        assert (
+            "--require-name test_jaxsim_pinocchio_free_body_dynamics_terms_match"
+            in post_gate
+        )
+
+    def test_urdf_cross_engine_equivalence_requires_passing_junit_case(
+        self,
+    ) -> None:
+        """The URDF equivalence workflow must not pass on skipped JUnit only."""
+        workflow = (
+            REPO_ROOT / ".github" / "workflows" / "urdf-cross-engine-equivalence.yml"
+        ).read_text(encoding="utf-8")
+
+        assert "test-results/urdf-cross-engine-equivalence-junit.xml" in workflow
+        post_gate = workflow[
+            workflow.index(
+                "Assert URDF equivalence cases actually ran"
+            ) : workflow.index("Upload equivalence report")
+        ]
+        assert "scripts/ci/assert_required_parity_ran.py" in post_gate
+        assert (
+            "--junit test-results/urdf-cross-engine-equivalence-junit.xml" in post_gate
+        )
+        assert "--require-name test_cross_engine_fk_" in post_gate
+
+    def test_canonical_conformance_gate_requires_passing_junit_case(self) -> None:
+        """The canonical conformance matrix must prove a real conformance pass."""
+        workflow = (
+            REPO_ROOT / ".github" / "workflows" / "cross-engine-equivalence.yml"
+        ).read_text(encoding="utf-8")
+
+        assert "canonical-conformance-${{ matrix.engine }}-junit.xml" in workflow
+        post_gate = workflow[
+            workflow.index(
+                "Assert canonical conformance cases actually ran"
+            ) : workflow.index("Upload conformance report")
+        ]
+        assert "scripts/ci/assert_required_parity_ran.py" in post_gate
+        assert (
+            '--junit "test-results/canonical-conformance-${{ matrix.engine }}-junit.xml"'
+            in post_gate
+        )
+        assert (
+            "--require-name test_five_conformance_checks_pass_against_stub_adapter"
+            in post_gate
+        )
 
     def test_jaxsim_upgrade_guard_runs_pinned_equivalence_and_gradient_checks(
         self,


### PR DESCRIPTION
## Summary
- replace the narrow JaxSim JUnit postcheck with the canonical required-parity helper
- add required-pass JUnit postchecks for URDF FK equivalence and canonical conformance workflows
- add regression tests for failed/errored required JUnit cases and workflow gate placement
- update SPEC.md for the CI gate hardening

Closes #8227

## Validation
- py -3.13 -m pytest tests\\ci\\test_assert_required_parity_ran.py tests\\ci\\test_ci_infrastructure.py -q
- py -3.13 -m ruff check tests\\ci\\test_assert_required_parity_ran.py tests\\ci\\test_ci_infrastructure.py scripts\\ci\\assert_required_parity_ran.py
- py -3.13 -m ruff format --check tests\\ci\\test_assert_required_parity_ran.py tests\\ci\\test_ci_infrastructure.py
- npx prettier --check SPEC.md .github\\workflows\\cross-engine-equivalence.yml .github\\workflows\\urdf-cross-engine-equivalence.yml
- git diff --check
- pre-push hook (ruff, ruff format, formatter guidance, prettier, bandit, pytest)