### PR TITLE
Fix #8205: classify Data Processor shadow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,9 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Classified the remaining Data Processor shared-code shadow
+  for #8205 with issue-specific owner, reason, and sunset metadata so the Tools
+  child-copy boundary has an explicit contract instead of an unapproved overlap.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/scripts/config/shadow_modules.yaml
+++ b/scripts/config/shadow_modules.yaml
@@ -40,6 +40,11 @@ shadows:
   data_processing:
     tracking_issue: 5623
     sunset_date: "2026-12-31"
+  data_processor:
+    tracking_issue: 8205
+    owner: upstreamdrift
+    reason: "Rust bulk-I/O engine child copy retained for the Data Processor launcher while Tools remains canonical."
+    sunset_date: "2026-12-31"
   deprecation.py:
     tracking_issue: 5623
     sunset_date: "2026-12-31"

--- a/tests/unit/repo_hygiene/test_no_deprecated_imports.py
+++ b/tests/unit/repo_hygiene/test_no_deprecated_imports.py
@@ -8,13 +8,36 @@ directory must no longer exist anywhere in the tree.
 Issue: #5619, #6564
 """
 
+import ast
 import pathlib
 
+import pytest
+
 REPO_ROOT = pathlib.Path(__file__).parents[3]
+pytestmark = pytest.mark.unit
 
 DEPRECATED_PACKAGE_DIR = (
     REPO_ROOT / "src" / "shared" / "python" / "upstream_drift_tools"
 )
+DEPRECATED_PACKAGE_NAME = "upstream_drift_tools"
+
+
+def _is_deprecated_module(module_name: str | None) -> bool:
+    return module_name == DEPRECATED_PACKAGE_NAME or bool(
+        module_name and module_name.startswith(f"{DEPRECATED_PACKAGE_NAME}.")
+    )
+
+
+def _has_deprecated_import(content: str) -> bool:
+    tree = ast.parse(content)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(
+            _is_deprecated_module(alias.name) for alias in node.names
+        ):
+            return True
+        if isinstance(node, ast.ImportFrom) and _is_deprecated_module(node.module):
+            return True
+    return False
 
 
 def _find_deprecated_imports(directory: str, ignore_self: bool = False) -> list[str]:
@@ -25,13 +48,25 @@ def _find_deprecated_imports(directory: str, ignore_self: bool = False) -> list[
             continue
         try:
             content = py_file.read_text(encoding="utf-8")
-            if "upstream_drift_tools" in content:
+            if _has_deprecated_import(content):
                 found_files.append(
                     str(py_file.relative_to(REPO_ROOT)).replace("\\", "/")
                 )
-        except UnicodeDecodeError:
+        except (SyntaxError, UnicodeDecodeError):
             pass
     return found_files
+
+
+def test_deprecated_import_detection_ignores_literal_strings():
+    content = 'MODULE = "upstream_drift_tools"\n'
+
+    assert not _has_deprecated_import(content)
+
+
+def test_deprecated_import_detection_flags_import_statements():
+    assert _has_deprecated_import("import upstream_drift_tools\n")
+    assert _has_deprecated_import("import upstream_drift_tools.theme\n")
+    assert _has_deprecated_import("from upstream_drift_tools.theme import Colors\n")
 
 
 def test_no_upstream_drift_tools_imports_in_src():

--- a/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
+++ b/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
@@ -20,6 +20,7 @@ Design-by-contract:
 
 from __future__ import annotations
 
+import os
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,7 @@ import yaml
 
 # Repo root is three parents up: tests/unit/repo_hygiene/<this file>
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+pytestmark = pytest.mark.unit
 _VENDOR_SHARED = _REPO_ROOT / "vendor" / "ud-tools" / "src" / "shared" / "python"
 _UD_SHARED = _REPO_ROOT / "src" / "shared" / "python"
 _ALLOW_LIST_PATH = _REPO_ROOT / "scripts" / "config" / "shadow_modules.yaml"
@@ -61,6 +63,20 @@ def _module_names(root: Path) -> set[str]:
         if entry.is_dir() or (entry.is_file() and entry.suffix == ".py"):
             names.add(entry.name)
     return names
+
+
+def _tools_shared_root() -> Path | None:
+    """Return the Tools shared-python root from the vendor tree or explicit checkout."""
+    if _VENDOR_SHARED.is_dir():
+        return _VENDOR_SHARED
+
+    tools_repo = os.environ.get("TOOLS_REPO_PATH")
+    if tools_repo:
+        candidate = Path(tools_repo) / "src" / "shared" / "python"
+        if candidate.is_dir():
+            return candidate
+
+    return None
 
 
 def _load_allow_list() -> dict[str, dict[str, Any]]:
@@ -160,6 +176,32 @@ def test_allow_list_is_well_formed() -> None:
 
 
 @pytest.mark.unit
+def test_data_processor_shadow_has_issue_specific_classification() -> None:
+    """Regression #8205: data_processor must not rely on umbrella shadow metadata."""
+    metadata = _load_allow_list()["data_processor"]
+
+    assert metadata["tracking_issue"] == 8205
+    assert metadata["owner"] == "upstreamdrift"
+    assert "Rust bulk-I/O engine" in metadata["reason"]
+
+
+@pytest.mark.unit
+def test_tools_shared_root_uses_explicit_tools_checkout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Local shadow checks may use TOOLS_REPO_PATH when the submodule is absent."""
+    tools_shared = tmp_path / "Tools" / "src" / "shared" / "python"
+    tools_shared.mkdir(parents=True)
+
+    import tests.unit.repo_hygiene.test_no_shadow_of_tools_shared as _mod
+
+    monkeypatch.setattr(_mod, "_VENDOR_SHARED", tmp_path / "missing-vendor")
+    monkeypatch.setenv("TOOLS_REPO_PATH", str(tmp_path / "Tools"))
+
+    assert _mod._tools_shared_root() == tools_shared
+
+
+@pytest.mark.unit
 def test_no_unapproved_shadows_of_tools_shared() -> None:
     """Fail if any UD module shadows a Tools-shared module without approval.
 
@@ -167,13 +209,15 @@ def test_no_unapproved_shadows_of_tools_shared() -> None:
     that exists under both ``vendor/ud-tools/src/shared/python/`` and
     ``src/shared/python/`` with the same name.
     """
-    if not _VENDOR_SHARED.is_dir():
+    tools_shared = _tools_shared_root()
+    if tools_shared is None:
         pytest.skip(
-            f"Vendored Tools tree is unavailable at {_VENDOR_SHARED}; "
-            "run `git submodule update --init` for the full shadow check."
+            f"Tools shared tree is unavailable at {_VENDOR_SHARED}; "
+            "run `git submodule update --init` or set TOOLS_REPO_PATH for "
+            "the full shadow check."
         )
 
-    vendor_names = _module_names(_VENDOR_SHARED)
+    vendor_names = _module_names(tools_shared)
     ud_names = _module_names(_UD_SHARED)
     allowed = set(_load_allow_list().keys())
 


### PR DESCRIPTION
## Summary
- classify the remaining data_processor shared-code shadow with issue-specific owner, reason, and sunset metadata
- let the shadow hygiene test use TOOLS_REPO_PATH when the vendored Tools submodule is unavailable locally, while preserving endor/ud-tools as the primary source
- harden deprecated-alias import detection to parse real import statements instead of flagging inert string literals, covering the adjacent #8206 hygiene failure
- update SPEC.md for the shared-code boundary contract change

Closes #8205
Related: #8206

## Validation
- $env:TOOLS_REPO_PATH='C:\\Users\\diete\\Repositories\\Tools'; py -3.13 -m pytest tests\\unit\\repo_hygiene\\test_no_shadow_of_tools_shared.py tests\\unit\\repo_hygiene\\test_no_deprecated_imports.py -q
- py -3.13 -m ruff check tests\\unit\\repo_hygiene\\test_no_shadow_of_tools_shared.py tests\\unit\\repo_hygiene\\test_no_deprecated_imports.py
- py -3.13 -m ruff format --check tests\\unit\\repo_hygiene\\test_no_shadow_of_tools_shared.py tests\\unit\\repo_hygiene\\test_no_deprecated_imports.py
- 
px prettier --check SPEC.md scripts\\config\\shadow_modules.yaml
- git diff --check
- pre-push hook (ruff, ruff format, formatter guidance, prettier, bandit, scoped pytest)

## Notes
- A direct git submodule update --init vendor/ud-tools attempt hung during Tools clone/index-pack in the isolated worktree, so local shadow validation used the sibling Tools checkout through TOOLS_REPO_PATH.
- 	ests/unit/launcher/test_sidekick_extension_overlay.py full-file execution is still locally blocked by the incomplete vendored Tools runtime in this isolated worktree; that file is not changed by this PR.