### PR TITLE
Fix #8199: restore shared test collectability

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Restored stale shared CORS and humanoid preview test
+  collectability for #8199. The CORS helper now enforces invalid-app and
+  invalid-origin preconditions before middleware registration, and the preview
+  smoke test imports `BodyParameters` from the supported public package API.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/shared/python/cors.py
+++ b/src/shared/python/cors.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from src.shared.python.contracts import PreconditionError
 
 # Default local-development origins used when CORS_ORIGINS env var is unset.
 DEFAULT_ORIGINS: list[str] = [
@@ -58,6 +59,14 @@ def add_cors_middleware(
         allow_headers: Allowed HTTP headers. Defaults to ``["*"]``.
         **kwargs: Extra keyword arguments forwarded to ``CORSMiddleware``.
     """
+    if not isinstance(app, FastAPI):
+        raise PreconditionError("app must be a FastAPI instance")
+    if origins is not None and (
+        not isinstance(origins, list)
+        or any(not isinstance(origin, str) for origin in origins)
+    ):
+        raise PreconditionError("origins must be a list of strings")
+
     env_origins = os.environ.get("CORS_ORIGINS")
     resolved_origins: list[str]
     if env_origins:

--- a/src/shared/python/humanoid_character_builder/tests/test_preview.py
+++ b/src/shared/python/humanoid_character_builder/tests/test_preview.py
@@ -8,7 +8,10 @@
 import sys
 from unittest.mock import patch
 
-from humanoid_character_builder.interfaces import BodyParameters, CharacterBuilder
+import pytest
+from humanoid_character_builder import BodyParameters, CharacterBuilder
+
+pytestmark = pytest.mark.unit
 
 
 def test_simulation_missing_mujoco() -> None:

--- a/src/shared/python/tests/test_cors.py
+++ b/src/shared/python/tests/test_cors.py
@@ -2,12 +2,7 @@ import os
 from typing import Any
 
 import pytest
-from cors import (
-    DEFAULT_ALLOW_HEADERS,
-    DEFAULT_ALLOW_METHODS,
-    DEFAULT_ORIGINS,
-    add_cors_middleware,
-)
+from cors import DEFAULT_ORIGINS, add_cors_middleware
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -17,6 +12,8 @@ from src.shared.python.contracts import (
     get_contract_level,
     set_contract_level,
 )
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
@@ -51,8 +48,8 @@ def test_add_cors_middleware_default(clean_env) -> Any:
     add_cors_middleware(app)
     kwargs = get_cors_kwargs(app)
     assert kwargs["allow_origins"] == DEFAULT_ORIGINS
-    assert kwargs["allow_methods"] == DEFAULT_ALLOW_METHODS
-    assert kwargs["allow_headers"] == DEFAULT_ALLOW_HEADERS
+    assert kwargs["allow_methods"] == ["*"]
+    assert kwargs["allow_headers"] == ["*"]
     assert kwargs["allow_credentials"] is True
 
 


### PR DESCRIPTION
## Summary
- update stale CORS tests to assert the current public middleware defaults
- add explicit CORS precondition checks so invalid app/origins fail before middleware registration
- update humanoid preview smoke test to import BodyParameters from the supported public package API
- mark restored colocated shared tests as unit tests and update SPEC.md

Closes #8199

## Validation
- py -3.13 -m pytest src\\shared\\python\\tests\\test_cors.py src\\shared\\python\\humanoid_character_builder\\tests\\test_preview.py -q
- py -3.13 -m ruff check src\\shared\\python\\cors.py src\\shared\\python\\tests\\test_cors.py src\\shared\\python\\humanoid_character_builder\\tests\\test_preview.py
- py -3.13 -m ruff format --check src\\shared\\python\\cors.py src\\shared\\python\\tests\\test_cors.py src\\shared\\python\\humanoid_character_builder\\tests\\test_preview.py
- 
px prettier --check SPEC.md
- git diff --check
- pre-push hook (ruff, ruff format, formatter guidance, no wildcard/debug/print, prettier, mypy, bandit, scoped pytest)