### PR TITLE
Fix #8235: preserve durable terminal task states

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened durable task lifecycle invariants for #8235.
+  Completed, failed, and cancelled tasks are now immutable through public
+  progress, heartbeat, completion, failure, cancellation, and retry-release
+  methods, with SQLite retry release guarded at the SQL transition boundary.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/api/task_manager_durable.py
+++ b/src/api/task_manager_durable.py
@@ -46,6 +46,15 @@ class TaskStatus(enum.Enum):
     CANCELLED = "cancelled"
 
 
+TERMINAL_TASK_STATUSES = frozenset(
+    {
+        TaskStatus.COMPLETED.value,
+        TaskStatus.FAILED.value,
+        TaskStatus.CANCELLED.value,
+    }
+)
+
+
 @dataclass
 class TaskRecord:
     """Complete task record with all metadata for durability and replay.
@@ -97,6 +106,11 @@ class TaskRecord:
     priority: int = 0
 
 
+def _is_terminal(record: TaskRecord) -> bool:
+    """Return True when a task record is in an immutable terminal state."""
+    return record.status in TERMINAL_TASK_STATUSES
+
+
 class StorageBackend(Protocol):
     """Protocol for task storage backends."""
 
@@ -136,7 +150,7 @@ class StorageBackend(Protocol):
         """Acquire a pending task for processing (claim ownership)."""
         ...
 
-    def release_task(self, task_id: str) -> None:
+    def release_task(self, task_id: str) -> bool:
         """Release a task back to pending (for retry)."""
         ...
 
@@ -488,10 +502,10 @@ class SQLiteBackend:
                 )
             return None
 
-    def release_task(self, task_id: str) -> None:
+    def release_task(self, task_id: str) -> bool:
         """Release a task back to pending (for retry)."""
         with self._lock, self._transaction() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 UPDATE tasks SET
                     status = 'pending',
@@ -499,10 +513,11 @@ class SQLiteBackend:
                     retry_count = retry_count + 1,
                     heartbeat_at = ?,
                     updated_at = ?
-                WHERE task_id = ?
+                WHERE task_id = ? AND status = 'running'
             """,
                 (time.time(), time.time(), task_id),
             )
+            return cursor.rowcount > 0
 
     def cleanup(self) -> int:
         """Clean up expired tasks, return count deleted."""
@@ -698,6 +713,8 @@ class DurableTaskManager:
         record = self.backend.get_task(task_id)
         if not record:
             return False
+        if _is_terminal(record):
+            return False
 
         record.progress = min(max(progress, 0.0), 100.0)
         record.heartbeat_at = time.time()
@@ -716,6 +733,8 @@ class DurableTaskManager:
         record = self.backend.get_task(task_id)
         if not record:
             return False
+        if _is_terminal(record):
+            return False
 
         record.heartbeat_at = time.time()
         self.backend.update_task(record)
@@ -733,6 +752,8 @@ class DurableTaskManager:
         """
         record = self.backend.get_task(task_id)
         if not record:
+            return False
+        if _is_terminal(record):
             return False
 
         record.status = TaskStatus.COMPLETED.value
@@ -756,6 +777,8 @@ class DurableTaskManager:
         """
         record = self.backend.get_task(task_id)
         if not record:
+            return False
+        if _is_terminal(record):
             return False
 
         record.status = TaskStatus.FAILED.value
@@ -804,6 +827,8 @@ class DurableTaskManager:
         record = self.backend.get_task(task_id)
         if not record:
             return False
+        if _is_terminal(record):
+            return False
 
         if record.retry_count >= record.max_retries:
             logger.warning(
@@ -811,7 +836,8 @@ class DurableTaskManager:
             )
             return False
 
-        self.backend.release_task(task_id)
+        if not self.backend.release_task(task_id):
+            return False
         logger.info(
             "Released task %s for retry (attempt %d/%d)",
             task_id,

--- a/tests/api/test_task_manager_durable.py
+++ b/tests/api/test_task_manager_durable.py
@@ -48,6 +48,19 @@ def _wait_until_task_missing(
     return backend.get_task(task_id) is None
 
 
+def _terminal_snapshot(record: TaskRecord) -> dict[str, object]:
+    return {
+        "status": record.status,
+        "progress": record.progress,
+        "result": record.result,
+        "error": record.error,
+        "completed_at": record.completed_at,
+        "heartbeat_at": record.heartbeat_at,
+        "worker_id": record.worker_id,
+        "retry_count": record.retry_count,
+    }
+
+
 class TestSQLiteBackend:
     """Test the SQLite storage backend."""
 
@@ -210,6 +223,25 @@ class TestSQLiteBackend:
         assert "ttl-expired" in expired_ids
         assert "retention-expired" in expired_ids
 
+    def test_release_task_rejects_terminal_records(self, sqlite_backend: SQLiteBackend):
+        """Backend retry release must not requeue terminal records (#8235)."""
+        record = TaskRecord(
+            task_id="terminal-release",
+            status=TaskStatus.COMPLETED.value,
+            result={"ok": True},
+            progress=100.0,
+            completed_at=time.time(),
+        )
+        sqlite_backend.create_task(record)
+        before = sqlite_backend.get_task(record.task_id)
+        assert before is not None
+
+        assert sqlite_backend.release_task(record.task_id) is False
+
+        after = sqlite_backend.get_task(record.task_id)
+        assert after is not None
+        assert _terminal_snapshot(after) == _terminal_snapshot(before)
+
 
 class TestDurableTaskManager:
     """Test the durable task manager orchestrator."""
@@ -326,9 +358,47 @@ class TestDurableTaskManager:
         assert task is not None
         assert task.status == TaskStatus.CANCELLED.value
 
-        # Cannot cancel completed task
-        task_manager.mark_completed(task_id, {"res": "ok"})
+        # Terminal tasks cannot be mutated after cancellation.
+        assert task_manager.mark_completed(task_id, {"res": "ok"}) is False
         assert task_manager.cancel_task(task_id) is False
+        task = task_manager.get_task(task_id)
+        assert task is not None
+        assert task.status == TaskStatus.CANCELLED.value
+
+    @pytest.mark.parametrize(
+        "terminal_state",
+        [
+            TaskStatus.CANCELLED,
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+        ],
+    )
+    def test_terminal_tasks_reject_public_mutations(
+        self, task_manager: DurableTaskManager, terminal_state: TaskStatus
+    ):
+        """Regression #8235: terminal durable tasks are immutable."""
+        task_id = task_manager.create_task()
+        if terminal_state is TaskStatus.CANCELLED:
+            assert task_manager.cancel_task(task_id) is True
+        elif terminal_state is TaskStatus.COMPLETED:
+            assert task_manager.mark_completed(task_id, {"result": "done"}) is True
+        else:
+            assert task_manager.mark_failed(task_id, "original error") is True
+
+        terminal = task_manager.get_task(task_id)
+        assert terminal is not None
+        before = _terminal_snapshot(terminal)
+
+        assert task_manager.update_progress(task_id, 42.0) is False
+        assert task_manager.heartbeat(task_id) is False
+        assert task_manager.mark_completed(task_id, {"result": "rewritten"}) is False
+        assert task_manager.mark_failed(task_id, "rewritten error") is False
+        assert task_manager.release_task(task_id) is False
+        assert task_manager.cancel_task(task_id) is False
+
+        after = task_manager.get_task(task_id)
+        assert after is not None
+        assert _terminal_snapshot(after) == before
 
     def test_find_stalled_tasks(self, task_manager: DurableTaskManager):
         """Test stalled task integration."""


### PR DESCRIPTION
## Summary
- add a shared terminal-state predicate for durable task records
- reject public progress, heartbeat, completion, failure, cancellation, and retry-release mutations once a task is completed, failed, or cancelled
- guard SQLite retry release at the SQL transition boundary so terminal records cannot be requeued by backend callers
- add regression tests proving terminal records remain unchanged across invalid lifecycle calls
- update SPEC.md for the durable task lifecycle invariant

Closes #8235

## Validation
- py -3.13 -m pytest tests\\api\\test_task_manager_durable.py -q
- py -3.13 -m ruff check src\\api\\task_manager_durable.py tests\\api\\test_task_manager_durable.py
- py -3.13 -m ruff format --check src\\api\\task_manager_durable.py tests\\api\\test_task_manager_durable.py
- 
px prettier --check SPEC.md
- git diff --check
- pre-push hook (ruff, ruff format, formatter guidance, no wildcard/debug/print, prettier, mypy, bandit, scoped pytest)