### PR TITLE
Fix #8238: validate X-factor stretch timestamps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,9 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Enforced X-factor timestamp invariants so invalid
+  duplicate, non-monotonic, non-finite, or length-mismatched timebases cannot
+  produce infinite stretch rates (#8238).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/api/services/analysis_service.py
+++ b/src/api/services/analysis_service.py
@@ -592,6 +592,35 @@ class AnalysisService:
             return None
         return times
 
+    def _resolve_x_factor_dt(
+        self,
+        request_data: dict[str, Any],
+        trajectory_length: int,
+    ) -> float | None:
+        """Resolve a positive finite sample interval for X-factor stretch."""
+        raw_times = request_data.get("times", request_data.get("time"))
+        if raw_times is None:
+            return 1.0
+
+        try:
+            time_array = np.asarray(raw_times, dtype=float).reshape(-1)
+        except (TypeError, ValueError):
+            return None
+
+        if time_array.size != trajectory_length or not np.all(np.isfinite(time_array)):
+            return None
+
+        deltas = np.diff(time_array)
+        if deltas.size == 0 or not np.all(np.isfinite(deltas)):
+            return None
+        if not np.all(deltas > 0.0):
+            return None
+
+        dt = float(np.mean(deltas))
+        if not np.isfinite(dt) or dt <= 0.0:
+            return None
+        return dt
+
     def _compute_x_factor(
         self,
         request: AnalysisRequest,
@@ -621,12 +650,7 @@ class AnalysisService:
         if positions.ndim != 2 or positions.shape[0] < 2:
             return None
 
-        times = request_data.get("times", request_data.get("time"))
-        if times is not None:
-            time_array = np.asarray(times, dtype=float).reshape(-1)
-            dt = float(np.mean(np.diff(time_array))) if time_array.size > 1 else 1.0
-        else:
-            dt = 1.0
+        dt = self._resolve_x_factor_dt(request_data, positions.shape[0])
 
         class _SwingMetricContext(SwingMetricsMixin):
             pass
@@ -635,13 +659,18 @@ class AnalysisService:
         context.joint_positions = positions
         context.times = np.arange(positions.shape[0], dtype=float)
         context.club_head_speed = None
-        context.dt = dt
+        context.dt = dt if dt is not None else 1.0
 
         x_factor = context.compute_x_factor(int(shoulder_idx), int(hip_idx))
         if x_factor is None or x_factor.size == 0:
             return None
 
-        stretch = context.compute_x_factor_stretch(int(shoulder_idx), int(hip_idx))
+        stretch = None
+        if dt is not None:
+            stretch = context.compute_x_factor_stretch(
+                int(shoulder_idx),
+                int(hip_idx),
+            )
         payload: dict[str, Any] = {
             "values": x_factor.tolist(),
             "peak": float(np.max(np.abs(x_factor))),

--- a/src/shared/python/analysis/swing_metrics.py
+++ b/src/shared/python/analysis/swing_metrics.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.signal import savgol_filter
 
 from src.shared.python.analysis.dataclasses import PeakInfo
-from src.shared.python.core.contracts import ensure
+from src.shared.python.core.contracts import ensure, require
 
 
 class SwingMetricsMixin:
@@ -168,13 +168,21 @@ class SwingMetricsMixin:
         if x_factor is None:
             return None
 
+        dt = float(self.dt)
+        require(np.isfinite(dt) and dt > 0.0, "dt must be finite and positive", dt)
+
         # Calculate derivative (finite difference)
-        x_factor_velocity = np.gradient(x_factor, self.dt)
+        x_factor_velocity = np.asarray(np.gradient(x_factor, dt), dtype=float)
         peak_stretch_rate = float(np.max(np.abs(x_factor_velocity)))
 
         ensure(
-            peak_stretch_rate >= 0,
-            "peak stretch rate must be non-negative",
+            np.all(np.isfinite(x_factor_velocity)),
+            "x-factor stretch rate must be finite",
+            x_factor_velocity,
+        )
+        ensure(
+            np.isfinite(peak_stretch_rate) and peak_stretch_rate >= 0,
+            "peak stretch rate must be finite and non-negative",
             peak_stretch_rate,
         )
 

--- a/tests/unit/analysis/test_swing_metrics.py
+++ b/tests/unit/analysis/test_swing_metrics.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+from src.shared.python.core.contracts import ContractViolationError
 from src.shared.python.analysis.swing_metrics import SwingMetricsMixin
+
+pytestmark = pytest.mark.unit
 
 
 def _make_instance(n_samples: int = 100, n_joints: int = 3) -> SwingMetricsMixin:
@@ -128,3 +132,11 @@ class TestComputeXFactorStretch:
         obj = _make_instance(n_joints=2)
         result = obj.compute_x_factor_stretch(0, 5)
         assert result is None
+
+    @pytest.mark.parametrize("dt", [0.0, -0.1, float("nan"), float("inf")])
+    def test_invalid_dt_violates_stretch_precondition(self, dt: float) -> None:
+        obj = _make_instance(n_joints=3)
+        obj.dt = dt
+
+        with pytest.raises(ContractViolationError, match="dt"):
+            obj.compute_x_factor_stretch(0, 1)

--- a/tests/unit/api/test_analysis_service.py
+++ b/tests/unit/api/test_analysis_service.py
@@ -413,6 +413,46 @@ class TestAnalyzeSwingSequenceInternal:
         assert result["x_factor"]["peak"] == pytest.approx(60.0)
         assert result["x_factor"]["peak_stretch_rate"] == pytest.approx(600.0)
 
+    @pytest.mark.parametrize(
+        "times",
+        [
+            [0.0, 0.0],
+            [0.1, 0.0],
+            [0.0, float("nan")],
+            [0.0],
+        ],
+    )
+    async def test_swing_sequence_omits_x_factor_stretch_for_invalid_timestamps(
+        self, analysis_service, times: list[float]
+    ) -> None:
+        """Invalid timebases must not serialize infinite stretch rates."""
+        from src.api.models.requests import AnalysisRequest
+
+        class Engine:
+            pass
+
+        request = AnalysisRequest(
+            analysis_type="swing_sequence",
+            data_source="simulation",
+            parameters={},
+            data={
+                "joint_positions": [
+                    [0.0, 0.0],
+                    [np.pi / 2.0, np.pi / 6.0],
+                ],
+                "shoulder_joint_idx": 0,
+                "hip_joint_idx": 1,
+                "times": times,
+            },
+        )
+
+        result = await analysis_service._analyze_swing_sequence(request, Engine())
+
+        assert result["x_factor"]["values"] == pytest.approx([0.0, 60.0])
+        assert result["x_factor"]["peak"] == pytest.approx(60.0)
+        assert "stretch_rate" not in result["x_factor"]
+        assert "peak_stretch_rate" not in result["x_factor"]
+
 
 class TestToListHelper:
     """Tests for _to_list helper method."""


### PR DESCRIPTION
## Summary
- validate X-factor request timestamps before deriving `dt` for stretch-rate computation
- omit stretch metrics when supplied timestamps are duplicate, non-monotonic, non-finite, or length-mismatched while preserving valid X-factor values/peak
- add DbC pre/postconditions in `SwingMetricsMixin.compute_x_factor_stretch()` so invalid `dt` or non-finite stretch output cannot pass the metric boundary
- add regression coverage for invalid timebases and update SPEC.md freshness

## Validation
- `py -3.13 -m pytest tests\unit\api\test_analysis_service.py tests\unit\analysis\test_swing_metrics.py -q`
- `py -3.13 -m ruff check src\api\services\analysis_service.py src\shared\python\analysis\swing_metrics.py tests\unit\api\test_analysis_service.py tests\unit\analysis\test_swing_metrics.py`
- `py -3.13 -m ruff format --check src\api\services\analysis_service.py src\shared\python\analysis\swing_metrics.py tests\unit\api\test_analysis_service.py tests\unit\analysis\test_swing_metrics.py`
- `npx prettier --check SPEC.md`
- `git diff --check`
- pre-push hook: ruff, format, formatter guidance, wildcard/debug/print guards, prettier, mypy, bandit, pytest

Closes #8238