### PR TITLE
Fix #8239: enforce terrain contact invariants

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Enforced terrain contact invariants so non-finite
+  coordinates, malformed force/velocity vectors, negative radii, and
+  non-positive masses fail before contact-force or turf-energy computation
+  (#8239).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/shared/python/physics/_terrain_physics.py
+++ b/src/shared/python/physics/_terrain_physics.py
@@ -20,6 +20,70 @@ def _magnitude(vec: np.ndarray) -> float:
     return math.sqrt(float(np.dot(arr, arr)))
 
 
+def _validate_finite_scalar(name: str, value: float) -> float:
+    if value is None:
+        raise ValueError(f"{name} must be provided")
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not math.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
+def _validate_nonnegative_scalar(name: str, value: float) -> float:
+    scalar = _validate_finite_scalar(name, value)
+    if scalar < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return scalar
+
+
+def _validate_positive_scalar(name: str, value: float) -> float:
+    scalar = _validate_finite_scalar(name, value)
+    if scalar <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return scalar
+
+
+def _validate_xy(x: float, y: float) -> tuple[float, float]:
+    return _validate_finite_scalar("x", x), _validate_finite_scalar("y", y)
+
+
+def _validate_xyz(x: float, y: float, z: float) -> tuple[float, float, float]:
+    return (
+        _validate_finite_scalar("x", x),
+        _validate_finite_scalar("y", y),
+        _validate_finite_scalar("z", z),
+    )
+
+
+def _validate_vector3(name: str, value: np.ndarray) -> np.ndarray:
+    if value is None:
+        raise ValueError(f"{name} must be provided")
+    try:
+        vector = np.asarray(value, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite 3-vector") from exc
+    if vector.shape != (3,):
+        raise ValueError(f"{name} must be a finite 3-vector")
+    if not np.all(np.isfinite(vector)):
+        raise ValueError(f"{name} must be finite")
+    return vector
+
+
+def _ensure_finite_vector3(name: str, value: np.ndarray) -> np.ndarray:
+    vector = _validate_vector3(name, value)
+    return vector
+
+
+def _ensure_finite_energy_payload(payload: dict[str, float]) -> dict[str, float]:
+    for name, value in payload.items():
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be finite")
+    return payload
+
+
 # Energy-absorption blend weights (#7055).
 #
 # The fraction of normal-impact kinetic energy absorbed by turf is modelled as
@@ -85,8 +149,8 @@ class TerrainContactModel:
         Returns:
             True if in contact
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
         ground_height = self.terrain.get_elevation(x, y)
         contact_height = z - radius
 
@@ -110,8 +174,8 @@ class TerrainContactModel:
         Returns:
             Penetration depth (positive when penetrating, meters)
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
         ground_height = self.terrain.get_elevation(x, y)
         contact_height = z - radius
 
@@ -139,8 +203,11 @@ class TerrainContactModel:
         Returns:
             Contact force vector (3,) [N]
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
+        velocity_vector = (
+            _validate_vector3("velocity", velocity) if velocity is not None else None
+        )
         penetration = self.compute_penetration(x, y, z, radius)
 
         if penetration <= 0:
@@ -159,9 +226,9 @@ class TerrainContactModel:
 
         # Damping force (if velocity provided)
         damping_force = 0.0
-        if velocity is not None:
+        if velocity_vector is not None:
             # Velocity component in normal direction
-            v_normal = np.dot(velocity, normal)
+            v_normal = np.dot(velocity_vector, normal)
             # Only damp if moving into surface
             if v_normal < 0:
                 damping_force = -damping * v_normal
@@ -170,7 +237,7 @@ class TerrainContactModel:
         force_magnitude = spring_force + damping_force
 
         # Force acts in normal direction
-        return force_magnitude * normal
+        return _ensure_finite_vector3("contact_force", force_magnitude * normal)
 
     def compute_friction_force(
         self,
@@ -196,11 +263,15 @@ class TerrainContactModel:
         Returns:
             Friction force vector (3,) [N]
         """
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
+        velocity = _validate_vector3("velocity", velocity)
+
         # Get normal force if not provided
-        if x is None:
-            raise ValueError("x must be provided")
         if normal_force is None:
             normal_force = self.compute_contact_force(x, y, z, radius, velocity)
+        else:
+            normal_force = _validate_vector3("normal_force", normal_force)
 
         normal_force_magnitude = _magnitude(normal_force)
         if normal_force_magnitude < 1e-6:
@@ -226,7 +297,9 @@ class TerrainContactModel:
         # Direction opposes motion
         friction_direction = -v_tangent / v_tangent_magnitude
 
-        return friction_magnitude * friction_direction
+        return _ensure_finite_vector3(
+            "friction_force", friction_magnitude * friction_direction
+        )
 
 
 @dataclass
@@ -268,8 +341,8 @@ class CompressibleTurfModel:
             Dictionary with compression_depth, effective_stiffness,
             max_compression, and compression_ratio
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
         material = self.terrain.get_material(x, y)
         ground_height = self.terrain.get_elevation(x, y)
 
@@ -326,8 +399,11 @@ class CompressibleTurfModel:
         Returns:
             Contact force vector (3,) [N]
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
+        velocity_vector = (
+            _validate_vector3("velocity", velocity) if velocity is not None else None
+        )
         material = self.terrain.get_material(x, y)
         state = self.get_compression_state(x, y, z, radius)
 
@@ -343,8 +419,8 @@ class CompressibleTurfModel:
 
         # Damping force
         damping_force = 0.0
-        if velocity is not None:
-            v_normal = np.dot(velocity, normal)
+        if velocity_vector is not None:
+            v_normal = np.dot(velocity_vector, normal)
             # Damping increases with compression (energy absorption)
             effective_damping = (
                 self.base_damping
@@ -368,7 +444,7 @@ class CompressibleTurfModel:
             )
             force_magnitude += grass_resistance
 
-        return force_magnitude * normal
+        return _ensure_finite_vector3("contact_force", force_magnitude * normal)
 
     def compute_lie_quality(
         self,
@@ -390,8 +466,8 @@ class CompressibleTurfModel:
             Dictionary with lie_type, sitting_depth, grass_interference,
             and playability_factor
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
+        ball_radius = _validate_nonnegative_scalar("ball_radius", ball_radius)
         material = self.terrain.get_material(x, y)
         terrain_type = self.terrain.get_terrain_type(x, y)
 
@@ -465,8 +541,10 @@ class CompressibleTurfModel:
             Dictionary with kinetic_energy, absorbed_energy,
             remaining_energy, and energy_absorption_ratio
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
+        impact_velocity = _validate_vector3("impact_velocity", impact_velocity)
+        mass = _validate_positive_scalar("mass", mass)
+        _validate_nonnegative_scalar("radius", radius)
         material = self.terrain.get_material(x, y)
         normal = self.terrain.get_normal(x, y)
 
@@ -495,11 +573,13 @@ class CompressibleTurfModel:
 
         remaining_energy = kinetic_energy - absorbed_energy
 
-        return {
-            "kinetic_energy": float(kinetic_energy),
-            "absorbed_energy": float(absorbed_energy),
-            "remaining_energy": float(max(0.0, remaining_energy)),
-            "energy_absorption_ratio": float(
-                absorbed_energy / kinetic_energy if kinetic_energy > 0 else 0.0
-            ),
-        }
+        return _ensure_finite_energy_payload(
+            {
+                "kinetic_energy": float(kinetic_energy),
+                "absorbed_energy": float(absorbed_energy),
+                "remaining_energy": float(max(0.0, remaining_energy)),
+                "energy_absorption_ratio": float(
+                    absorbed_energy / kinetic_energy if kinetic_energy > 0 else 0.0
+                ),
+            }
+        )

--- a/src/shared/python/physics/terrain_mixin.py
+++ b/src/shared/python/physics/terrain_mixin.py
@@ -20,6 +20,14 @@ from typing import Any, Protocol
 import numpy as np
 
 from src.shared.python.logging_pkg.logging_config import get_logger
+from src.shared.python.physics._terrain_physics import (
+    _ensure_finite_vector3,
+    _validate_nonnegative_scalar,
+    _validate_positive_scalar,
+    _validate_vector3,
+    _validate_xy,
+    _validate_xyz,
+)
 from src.shared.python.physics.terrain import Terrain, TerrainType
 from src.shared.python.physics.terrain_engine import (
     CompressibleTurfModel,
@@ -114,8 +122,7 @@ class TerrainMixin:
         Returns:
             Ground height (meters), or 0.0 if no terrain
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return 0.0
 
@@ -131,8 +138,7 @@ class TerrainMixin:
         Returns:
             Unit normal vector (3,)
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return np.array([0.0, 0.0, 1.0])
 
@@ -151,8 +157,7 @@ class TerrainMixin:
         Returns:
             Terrain type at the position
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return TerrainType.FAIRWAY
 
@@ -168,8 +173,7 @@ class TerrainMixin:
         Returns:
             Friction coefficient
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return 0.5
 
@@ -186,8 +190,7 @@ class TerrainMixin:
         Returns:
             Coefficient of restitution
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return 0.6
 
@@ -217,8 +220,11 @@ class TerrainMixin:
         Returns:
             Contact force vector (3,) [N]
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
+        velocity = (
+            _validate_vector3("velocity", velocity) if velocity is not None else None
+        )
         if not self._terrain_enabled or self._terrain is None:
             return np.zeros(3)
 
@@ -251,8 +257,9 @@ class TerrainMixin:
         Returns:
             Friction force vector (3,) [N]
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
+        velocity = _validate_vector3("velocity", velocity)
         if not self._terrain_enabled or self._contact_model is None:
             return np.zeros(3)
 
@@ -276,8 +283,8 @@ class TerrainMixin:
         Returns:
             True if in contact with terrain
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y, z = _validate_xyz(x, y, z)
+        radius = _validate_nonnegative_scalar("radius", radius)
         if self._terrain is None or self._contact_model is None:
             return False
 
@@ -299,8 +306,8 @@ class TerrainMixin:
         Returns:
             Dictionary with lie quality metrics
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
+        ball_radius = _validate_nonnegative_scalar("ball_radius", ball_radius)
         if self._turf_model is None:
             return {
                 "lie_type": "unknown",
@@ -325,8 +332,7 @@ class TerrainMixin:
         Returns:
             Dictionary with friction, restitution, stiffness, damping
         """
-        if x is None:
-            raise ValueError("x must be provided")
+        x, y = _validate_xy(x, y)
         if self._terrain is None:
             return {
                 "friction": 0.5,
@@ -411,8 +417,9 @@ class TerrainAwareSimulation:
         Returns:
             Total force vector (3,) [N]
         """
-        if position is None:
-            raise ValueError("position must be provided")
+        position = _validate_vector3("position", position)
+        velocity = _validate_vector3("velocity", velocity)
+        radius = _validate_nonnegative_scalar("radius", radius)
         x, y, z = position
 
         # Contact force (normal)
@@ -430,7 +437,7 @@ class TerrainAwareSimulation:
             x, y, z, radius, velocity
         )
 
-        return contact_force + friction_force
+        return _ensure_finite_vector3("terrain_force", contact_force + friction_force)
 
     def simulate_ball_landing(
         self,
@@ -452,8 +459,10 @@ class TerrainAwareSimulation:
         Returns:
             Dictionary with landing results
         """
-        if impact_position is None:
-            raise ValueError("impact_position must be provided")
+        impact_position = _validate_vector3("impact_position", impact_position)
+        impact_velocity = _validate_vector3("impact_velocity", impact_velocity)
+        ball_mass = _validate_positive_scalar("ball_mass", ball_mass)
+        ball_radius = _validate_nonnegative_scalar("ball_radius", ball_radius)
         x, y, z = impact_position
 
         # Get terrain properties

--- a/tests/unit/physics/test_terrain_mixin.py
+++ b/tests/unit/physics/test_terrain_mixin.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from src.shared.python.physics.terrain import ElevationMap, Terrain, TerrainType
 from src.shared.python.physics.terrain_mixin import TerrainMixin
+
+pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
 # Minimal concrete class implementing TerrainMixin
@@ -104,6 +107,11 @@ class TestTerrainMixinQueries:
         tt = mixin.get_terrain_type(0.0, 0.0)
         assert isinstance(tt, TerrainType)
 
+    def test_get_ground_height_rejects_non_finite_coordinate(self) -> None:
+        mixin = _SimpleMixin()
+        with pytest.raises(ValueError, match="finite"):
+            mixin.get_ground_height(0.0, np.nan)
+
 
 # ---------------------------------------------------------------------------
 # get_terrain_friction / get_terrain_restitution
@@ -125,3 +133,29 @@ class TestTerrainMixinFriction:
         mixin = self._mixin_with_terrain()
         r = mixin.get_terrain_restitution(0.0, 0.0)
         assert 0.0 <= r <= 1.0
+
+
+class TestTerrainMixinContracts:
+    def test_contact_force_rejects_negative_radius_before_disabled_fallback(
+        self,
+    ) -> None:
+        mixin = _SimpleMixin()
+        mixin.enable_terrain(False)
+
+        with pytest.raises(ValueError, match="radius"):
+            mixin.compute_terrain_contact_force(0.0, 0.0, 0.0, radius=-0.1)
+
+    def test_friction_force_rejects_malformed_velocity_before_disabled_fallback(
+        self,
+    ) -> None:
+        mixin = _SimpleMixin()
+        mixin.enable_terrain(False)
+
+        with pytest.raises(ValueError, match="velocity"):
+            mixin.compute_terrain_friction_force(
+                0.0,
+                0.0,
+                0.0,
+                radius=0.0,
+                velocity=np.array([1.0, 0.0]),
+            )

--- a/tests/unit/physics/test_terrain_representation.py
+++ b/tests/unit/physics/test_terrain_representation.py
@@ -314,6 +314,17 @@ class TestContactModelPenetration:
         assert model.is_in_contact(5.0, 5.0, z=-0.1) is True
         assert model.is_in_contact(5.0, 5.0, z=0.5) is False
 
+    @pytest.mark.parametrize(
+        ("x", "y", "z"),
+        [(float("nan"), 5.0, 0.0), (5.0, float("inf"), 0.0), (5.0, 5.0, -np.inf)],
+    )
+    def test_penetration_rejects_non_finite_coordinates(
+        self, x: float, y: float, z: float
+    ) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="finite"):
+            model.compute_penetration(x, y, z)
+
 
 class TestContactForce:
     def test_no_force_without_penetration(self) -> None:
@@ -334,6 +345,22 @@ class TestContactForce:
         assert force[0] == pytest.approx(0.0, abs=1e-6)
         assert force[1] == pytest.approx(0.0, abs=1e-6)
         assert force[2] > 0.0
+
+    def test_contact_force_rejects_negative_radius(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="radius"):
+            model.compute_contact_force(5.0, 5.0, z=-0.1, radius=-0.5)
+
+    @pytest.mark.parametrize(
+        "velocity",
+        [np.array([0.0, 0.0]), np.array([0.0, 0.0, np.nan])],
+    )
+    def test_contact_force_rejects_malformed_velocity(
+        self, velocity: np.ndarray
+    ) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="velocity"):
+            model.compute_contact_force(5.0, 5.0, z=-0.1, velocity=velocity)
 
 
 class TestFrictionForce:
@@ -386,6 +413,29 @@ class TestFrictionForce:
         )
         assert np.allclose(friction, np.zeros(3))
 
+    def test_friction_rejects_malformed_velocity(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="velocity"):
+            model.compute_friction_force(
+                5.0,
+                5.0,
+                z=-0.1,
+                radius=0.0,
+                velocity=np.array([2.0, 0.0, 0.0, 0.0]),
+            )
+
+    def test_friction_rejects_malformed_normal_force(self) -> None:
+        model = TerrainContactModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="normal_force"):
+            model.compute_friction_force(
+                5.0,
+                5.0,
+                z=-0.1,
+                radius=0.0,
+                velocity=np.array([2.0, 0.0, 0.0]),
+                normal_force=np.array([0.0, 0.0, np.inf]),
+            )
+
 
 class TestCompressibleTurf:
     def test_lie_quality_keys_and_ranges(self) -> None:
@@ -437,3 +487,22 @@ class TestCompressibleTurf:
         # Huge penetration is clamped to the material's max compression depth.
         assert state["compression_depth"] <= state["max_compression"] + 1e-9
         assert 0.0 <= state["compression_ratio"] <= 1.0
+
+    def test_energy_absorption_rejects_negative_mass(self) -> None:
+        model = CompressibleTurfModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="mass"):
+            model.compute_energy_absorption(
+                5.0,
+                5.0,
+                impact_velocity=np.array([10.0, 0.0, -5.0]),
+                mass=-1.0,
+            )
+
+    def test_energy_absorption_rejects_malformed_impact_velocity(self) -> None:
+        model = CompressibleTurfModel(terrain=_green_terrain())
+        with pytest.raises(ValueError, match="impact_velocity"):
+            model.compute_energy_absorption(
+                5.0,
+                5.0,
+                impact_velocity=np.array([10.0, 0.0]),
+            )


### PR DESCRIPTION
## Summary
- add shared terrain scalar/vector validators for finite coordinates, non-negative radii, positive masses, and finite 3-vectors
- enforce those invariants in terrain contact, friction, compressible turf, energy absorption, and TerrainMixin/TerrainAwareSimulation entry points
- add postcondition-style finite checks for returned force vectors and turf energy payloads
- add regression coverage for non-finite coordinates, negative radii/masses, malformed velocity vectors, malformed normal-force vectors, and mixin disabled-fallback validation
- update SPEC.md freshness

## Validation
- `py -3.13 -m pytest tests\unit\physics\test_terrain_representation.py tests\unit\physics\test_terrain_mixin.py tests\unit\physics\test_terrain_energy_split_7055.py -q`
- `py -3.13 -m ruff check src\shared\python\physics\_terrain_physics.py src\shared\python\physics\terrain_mixin.py tests\unit\physics\test_terrain_representation.py tests\unit\physics\test_terrain_mixin.py`
- `py -3.13 -m ruff format --check src\shared\python\physics\_terrain_physics.py src\shared\python\physics\terrain_mixin.py tests\unit\physics\test_terrain_representation.py tests\unit\physics\test_terrain_mixin.py`
- `npx prettier --check SPEC.md`
- `git diff --check`
- pre-push hook: ruff, format, formatter guidance, wildcard/debug/print guards, prettier, mypy, bandit, pytest

Closes #8239