### PR TITLE
Fix Bot CI trigger bounded dispatch path

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -1,44 +1,38 @@
 name: Bot CI Trigger
 
-# This workflow ensures CI runs on bot-created PRs and commits.
+# Bounded CI recovery for bot-authored PRs.
 #
-# Problem: GitHub Actions using GITHUB_TOKEN don't trigger new workflow runs
-# to prevent infinite loops. This means bot PRs don't get CI checks.
-#
-# Solution: This workflow:
-# 1. Detects bot PRs that haven't had CI run
-# 2. Re-triggers CI using workflow_dispatch or by adding an empty commit
-# 3. Has loop prevention to avoid infinite runs
-#
-# IMPORTANT: For this to work properly, set up a BOT_PAT secret with a
-# Personal Access Token that has 'repo' and 'workflow' permissions.
+# GitHub suppresses many workflow runs created by GITHUB_TOKEN writes. This
+# workflow provides a narrow recovery path: inspect one PR head commit with
+# REST, then dispatch the standard CI workflow for that PR branch when the
+# expected checks are absent or a maintainer explicitly forces a retrigger.
 
 on:
-  # Run when PRs are opened or synchronized
   pull_request:
     types: [opened, synchronize, reopened]
-
-  # Also run on a schedule to catch any missed PRs
-  schedule:
-    - cron: "0 0 * * 0,4" # Every 2 hours (reduced from 15 min for cost control)
 
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to trigger CI for (optional)"
-        required: false
+        description: "PR number to trigger CI for"
+        required: true
       force:
-        description: "Force trigger even if checks exist"
+        description: "Trigger even if expected checks already exist"
         required: false
         type: boolean
         default: false
 
+permissions:
+  actions: write
+  checks: read
+  contents: read
+  pull-requests: read
+
 concurrency:
-  group: bot-ci-trigger-${{ github.event.pull_request.number || github.run_id }}
+  group: bot-ci-trigger-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  # -- Dispatcher: route to self-hosted if available --------------------------
   pick-runner:
     runs-on: d-sorg-fleet-docker
     timeout-minutes: 2
@@ -47,22 +41,21 @@ jobs:
     steps:
       - name: Set runner
         id: check
+        shell: bash
         run: |
           mkdir -p "$(dirname "$GITHUB_OUTPUT")"
           echo "runner=d-sorg-fleet-docker" >> "$GITHUB_OUTPUT"
           echo "Self-hosted dispatcher selected d-sorg-fleet-docker"
+
   check-and-trigger:
-    timeout-minutes: 30
+    timeout-minutes: 10
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
-    continue-on-error: true
     env:
-      BOT_PAT_TOKEN: ${{ secrets.BOT_PAT }}
-      RUNNER_CHECK_TOKEN_VALUE: ${{ secrets.RUNNER_CHECK_TOKEN }}
-      DEFAULT_GITHUB_TOKEN: ${{ github.token }}
-    # Only run for bot-authored PRs or scheduled/manual runs
+      GH_TOKEN: ${{ secrets.BOT_PAT || secrets.RUNNER_CHECK_TOKEN || github.token }}
+      FORCE: ${{ inputs.force || 'false' }}
+      INPUT_PR: ${{ inputs.pr_number || '' }}
     if: |
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        (contains(github.event.pull_request.user.login, 'bot') ||
@@ -71,171 +64,105 @@ jobs:
         github.event.pull_request.user.type == 'Bot'))
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          token: ${{ github.token }}
-          fetch-depth: 5
-
-      - name: Check Loop Prevention
-        id: loop-check
-        run: |
-          # Check recent commits for loop indicators
-          loop_count=0
-          while IFS= read -r msg; do
-            if [[ "$msg" == *"[skip ci]"* ]] || [[ "$msg" == *"[ci skip]"* ]]; then
-              continue
-            fi
-            if [[ "$msg" == *"trigger-ci"* ]] || [[ "$msg" == *"bot-ci-trigger"* ]]; then
-              ((loop_count++))
-            fi
-          done < <(git log --format="%s" -n 5)
-
-          if [ $loop_count -ge 3 ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "::warning::Loop prevention: $loop_count CI trigger commits detected"
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Find Bot PRs Without CI
-        id: find-prs
-        if: steps.loop-check.outputs.skip != 'true'
+      - name: Resolve target PR
+        id: target
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          INPUT_PR: ${{ inputs.pr_number }}
-          FORCE: ${{ inputs.force }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number || '' }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
         run: |
-          prs_to_trigger=""
+          set -euo pipefail
 
-          if [ -n "$INPUT_PR" ]; then
-            # Manual trigger for specific PR
-            prs_to_trigger="$INPUT_PR"
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            # PR event - check this specific PR
-            PR_NUMBER="${{ github.event.pull_request.number }}"
+          TARGET_PR="$INPUT_PR"
+          HEAD_REF="$EVENT_HEAD_REF"
+          HEAD_SHA="$EVENT_HEAD_SHA"
+          HEAD_REPO="$EVENT_HEAD_REPO"
+          PR_STATE="open"
 
-            # Check if CI has already run
-            checks=$(gh pr checks "$PR_NUMBER" || echo "")
-
-            if [ -z "$checks" ] || [ "$FORCE" == "true" ]; then
-              prs_to_trigger="$PR_NUMBER"
-            else
-              # Check if quality-gate or ci-standard passed/ran
-              if ! echo "$checks" | grep -qE "(quality-gate|ci-standard|CI Standard)"; then
-                prs_to_trigger="$PR_NUMBER"
-              fi
-            fi
-          else
-            # Scheduled run - find all bot PRs without checks
-            bot_prs=$(gh pr list --author "github-actions[bot]" --state open --json number,author --jq '.[].number' || echo "")
-
-            for pr in $bot_prs; do
-              checks=$(gh pr checks "$pr" || echo "")
-              if [ -z "$checks" ] || ! echo "$checks" | grep -qE "(quality-gate|ci-standard|CI Standard)"; then
-                prs_to_trigger="$prs_to_trigger $pr"
-              fi
-            done
-
-            # Also check PRs from other bot-like authors
-            for author in "dependabot[bot]" "renovate[bot]" "claude[bot]" "google-labs-jules[bot]"; do
-              more_prs=$(gh pr list --author "$author" --state open --json number --jq '.[].number' || echo "")
-              for pr in $more_prs; do
-                checks=$(gh pr checks "$pr" || echo "")
-                if [ -z "$checks" ] || ! echo "$checks" | grep -qE "(quality-gate|ci-standard)"; then
-                  prs_to_trigger="$prs_to_trigger $pr"
-                fi
-              done
-            done
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            TARGET_PR="$EVENT_PR"
+          elif [[ ! "$TARGET_PR" =~ ^[0-9]+$ ]]; then
+            echo "::error::workflow_dispatch requires a numeric pr_number input."
+            exit 1
           fi
 
-          # Trim whitespace and remove duplicates
-          prs_to_trigger=$(echo "$prs_to_trigger" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
-
-          echo "PRs to trigger: $prs_to_trigger"
-          echo "prs=$prs_to_trigger" >> $GITHUB_OUTPUT
-
-          if [ -z "$prs_to_trigger" ]; then
-            echo "No PRs need CI triggering"
+          if [ -z "$HEAD_REF" ] || [ -z "$HEAD_SHA" ] || [ -z "$HEAD_REPO" ]; then
+            pr_fields=$(
+              gh api "repos/$GITHUB_REPOSITORY/pulls/$TARGET_PR" \
+                --jq '[.head.ref, .head.sha, .head.repo.full_name, .state] | @tsv'
+            )
+            IFS=$'\t' read -r HEAD_REF HEAD_SHA HEAD_REPO PR_STATE <<< "$pr_fields"
           fi
 
-      - name: Validate bot trigger token
-        id: token-check
-        if: steps.loop-check.outputs.skip != 'true' && steps.find-prs.outputs.prs != ''
-        run: |
-          for candidate in BOT_PAT_TOKEN RUNNER_CHECK_TOKEN_VALUE DEFAULT_GITHUB_TOKEN; do
-            token="${!candidate:-}"
-            if [ -z "$token" ]; then
-              continue
-            fi
+          if [ "$PR_STATE" != "open" ]; then
+            echo "::error::PR #$TARGET_PR is $PR_STATE; refusing to trigger CI."
+            exit 1
+          fi
 
-            if GH_TOKEN="$token" gh auth status >/dev/null 2>&1 &&
-               GH_TOKEN="$token" gh api graphql -f query='{ viewer { login } }' >/dev/null 2>&1; then
-              echo "::add-mask::$token"
-              echo "BOT_TRIGGER_TOKEN=$token" >> "$GITHUB_ENV"
-              echo "can_trigger=true" >> "$GITHUB_OUTPUT"
-              echo "token_source=$candidate" >> "$GITHUB_OUTPUT"
-              echo "Using authenticated CI trigger token from $candidate"
-              exit 0
-            fi
+          if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::PR #$TARGET_PR comes from $HEAD_REPO; workflow_dispatch can only target branches in $GITHUB_REPOSITORY."
+            exit 1
+          fi
 
-            echo "::warning::Bot trigger token candidate $candidate is unavailable or invalid; trying next candidate."
-          done
+          {
+            echo "pr=$TARGET_PR"
+            echo "head_ref=$HEAD_REF"
+            echo "head_sha=$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "can_trigger=false" >> "$GITHUB_OUTPUT"
-          echo "::warning::Bot trigger token is unavailable or invalid; skipping authenticated CI trigger."
-
-      - name: Trigger CI for PRs
-        if: steps.loop-check.outputs.skip != 'true' && steps.find-prs.outputs.prs != '' && steps.token-check.outputs.can_trigger == 'true'
+      - name: Inspect current CI checks
+        id: checks
+        shell: bash
         env:
-          GH_TOKEN: ${{ env.BOT_TRIGGER_TOKEN }}
+          HEAD_SHA: ${{ steps.target.outputs.head_sha }}
         run: |
-          for pr in ${{ steps.find-prs.outputs.prs }}; do
-            echo "Triggering CI for PR #$pr"
-            branch=$(gh pr view "$pr" --json headRefName --jq '.headRefName') || {
-              echo "::warning::Cannot resolve head branch for PR #$pr; skipping."
-              continue
-            }
+          set -euo pipefail
 
-            # Method 1: Try to trigger workflow_dispatch on ci-standard
-            # Method 2: If workflow_dispatch fails, add empty commit to trigger
-            if ! gh workflow run ci-standard.yml \
-              --ref "$branch" \
-              2>/dev/null; then
-              echo "workflow_dispatch failed, trying empty commit method"
+          if [ "$FORCE" = "true" ]; then
+            echo "should_trigger=true" >> "$GITHUB_OUTPUT"
+            echo "reason=forced" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-              git fetch origin "$branch"
-              git checkout "$branch"
+          check_names=$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
+              --jq '.check_runs[].name'
+          )
 
-              # Configure git identity for commit
-              git config user.name "github-actions[bot]"
-              git config user.email "github-actions[bot]@users.noreply.github.com"
-              # Create empty commit with special marker
-              git commit --allow-empty -m "chore: trigger CI checks [bot-ci-trigger]
+          if echo "$check_names" | grep -qE '^(quality-gate|ci-standard|CI Standard)$'; then
+            echo "should_trigger=false" >> "$GITHUB_OUTPUT"
+            echo "reason=expected-check-present" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_trigger=true" >> "$GITHUB_OUTPUT"
+            echo "reason=expected-check-missing" >> "$GITHUB_OUTPUT"
+          fi
 
-              This empty commit triggers CI for bot-created PR.
-              Loop prevention marker: $(date +%s)"
+      - name: Trigger CI
+        if: steps.checks.outputs.should_trigger == 'true'
+        shell: bash
+        env:
+          HEAD_REF: ${{ steps.target.outputs.head_ref }}
+        run: |
+          set -euo pipefail
 
-              git push origin "$branch"
-            fi
-
-            echo "CI triggered for PR #$pr"
-
-            # Small delay between PRs
-            sleep 5
-          done
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/ci-standard.yml/dispatches" \
+            -f "ref=$HEAD_REF"
 
       - name: Summary
         if: always()
+        shell: bash
         run: |
-          echo "## Bot CI Trigger Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          if [ "${{ steps.loop-check.outputs.skip }}" == "true" ]; then
-            echo "**Skipped**: Loop prevention triggered" >> $GITHUB_STEP_SUMMARY
-          elif [ -z "${{ steps.find-prs.outputs.prs }}" ]; then
-            echo "**No action needed**: All bot PRs have CI checks" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ steps.token-check.outputs.can_trigger }}" != "true" ]; then
-            echo "**Detected PRs**: ${{ steps.find-prs.outputs.prs }} (CI trigger skipped: bot token unavailable or invalid)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "**Triggered CI for PRs**: ${{ steps.find-prs.outputs.prs }}" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Bot CI Trigger Summary"
+            echo ""
+            echo "- PR: #${{ steps.target.outputs.pr || inputs.pr_number }}"
+            echo "- Triggered: ${{ steps.checks.outputs.should_trigger || 'false' }}"
+            echo "- Reason: ${{ steps.checks.outputs.reason || 'not-evaluated' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,14 +39,8 @@
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-<<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
-=======
-| **Spec Version** | 1.0.468 |
-| **Last Spec Update** | 2026-07-25 |
-
-> > > > > > > origin/codex/pyqt6-launcher-functional-qa
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 
 ## 2. Purpose & Mission
 
@@ -77,6 +71,13 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Replaced the Bot CI trigger workflow's backlog-scanning
+  recovery path for issue #8240. The workflow is now bounded to a single PR from
+  either a bot-authored pull request event or explicit `workflow_dispatch`
+  `pr_number`, inspects expected CI checks through REST for that PR head SHA,
+  dispatches `ci-standard.yml` through REST, fails loudly on trigger errors,
+  and no longer uses scheduled PR discovery, GraphQL-backed `gh pr checks`, or
+  empty commits to mutate PR branches.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains
@@ -2151,7 +2152,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 | 2026-05-27 | 1.0.197 | perf: replace qvel**2 with qvel*qvel in MuJoCo power flow (`power_flow.py`). |
 | 2026-05-26 | 1.0.194 | Folded remaining API/security/realtime/logging PR scope into the post-#6181 consolidation branch: `FitResult` now exposes explicit `fit_succeeded` and `solver_status` fields, the `.gitignore` secrets guard has an importable CI helper plus tests, and logging redaction preserves delimiters while redacting quoted, JSON, and comma-containing secret values. |
 | 2026-05-26 | 1.0.193 | Folded duplicate performance PRs into the consolidated branch: cached common factorial values in the signal toolkit, normalized signal import arrays with `np.asarray`, preserved `body_marker` when Drake constraint penalties are added, and replaced selected temporary product reductions with `np.einsum` or `np.vdot` in motion-matching visualization, work, and energy calculations. |
-| 2026-05-23 | 1.0.186 | Refined the standalone Sidekick CLI contract in `src/shared/python/sidekick/__main__.py` so `python -m sidekick` defaults to `gui`, mistyped flags get closest-match suggestions, GUI imports remain deferred until dispatch, `--data-dir` is resolved to an absolute path, and `gui` now delegates through `sidekick.launcher_factory` using the standalone window/session-store configuration on current `main`. Expanded `tests/unit/sidekick/test_cli.py` to cover implicit-gui parsing, bad-flag suggestions, headless `run` parsing, handler error paths, and launcher delegation. |
+| 2026-05-23 | 1.0.186 | Refined the standalone Sidekick CLI contract exposed by the `sidekick` console script in `pyproject.toml` so `python -m sidekick` defaults to `gui`, mistyped flags get closest-match suggestions, GUI imports remain deferred until dispatch, `--data-dir` is resolved to an absolute path, and `gui` now delegates through `sidekick.launcher_factory` using the standalone window/session-store configuration on current `main`. Expanded `tests/unit/sidekick/test_cli.py` to cover implicit-gui parsing, bad-flag suggestions, headless `run` parsing, handler error paths, and launcher delegation. |
 | 2026-05-23 | 1.0.186 | Tightened `src/shared/python/training/config.py` validation so boolean values are rejected for integer training caps such as `max_epochs` and `max_steps`; regression coverage lives in `tests/unit/training/test_config.py`. |
 | 2026-05-31 | 1.0.192 | Added the CC-19 single-trial MAP estimator surface in `src/shared/python/estimation/`: cubic-Hermite spline trajectory coefficients with analytic derivatives, ordered shared parameter blocks with free length parameters and bounded inertia corrections, deterministic least-squares solve wiring, and focused unit coverage for objective determinism and parameter sharing. |
 | 2026-05-23 | 1.0.187 | Closed the file-size budget grandfathering gap by requiring tracked baseline entries for oversized files in `scripts/config/file_size_budget.json`; untracked oversized files now fail `scripts/ci/check_file_size_budget.py`, with regression coverage in `tests/scripts/wave9_scripts_b/test_check_file_size_budget.py`. |
@@ -2162,7 +2163,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 | 2026-05-22 | 1.0.182 | Documented the motion-pipeline REST contract for `POST /api/v1/motion-pipeline/run` and its preprocessing-step boolean coercion rule so `PipelineRequest` preserves Pydantic handling of `enabled` values like `"false"` when converting into `PipelineConfig`; regression coverage lives in `tests/unit/motion_pipeline/orchestrator/test_api.py`. |
 | 2026-05-24 | 1.0.188 | Deferred realtime WebSocket backend resolution until first explicit start/use and made `WSPubSub.start()` launch the Python backend even when the instance was created with `autostart=False`; added focused regression coverage in `tests/shared/realtime/test_ws_pubsub.py`. |
 | 2026-05-23 | 1.0.181 | Sanitized error payloads for the chat websocket connection to prevent leaks. Added standalone Sidekick foundation (CLI entry point, PyQt window shell, and session store) per epic #5979. |
-| 2026-05-22 | 1.0.181 | Added the standalone Sidekick CLI scaffold in `src/shared/python/sidekick/__main__.py` with an implicit `gui` default, closest-match suggestions for mistyped flags, early path validation for `run`, deferred GUI imports for headless parsing, and focused regression coverage in `tests/unit/sidekick/test_cli.py`. Tightened `scripts/ci/check_error_handling_ratchet.py` so the `asyncio.gather(...)` anti-pattern scan now balances multiline argument lists before deciding whether `return_exceptions=` is present, and added matching regression coverage in `tests/unit/scripts/test_error_handling_ratchet.py` for both compliant and violating multiline gather calls. |
+| 2026-05-22 | 1.0.181 | Added the standalone Sidekick CLI scaffold behind the `sidekick` console script in `pyproject.toml` with an implicit `gui` default, closest-match suggestions for mistyped flags, early path validation for `run`, deferred GUI imports for headless parsing, and focused regression coverage in `tests/unit/sidekick/test_cli.py`. Tightened `scripts/ci/check_error_handling_ratchet.py` so the `asyncio.gather(...)` anti-pattern scan now balances multiline argument lists before deciding whether `return_exceptions=` is present, and added matching regression coverage in `tests/unit/scripts/test_error_handling_ratchet.py` for both compliant and violating multiline gather calls. |
 | 2026-05-22 | 1.0.180 | Landed the pure-Python foundation for the Idiot-Proof UX epic (#5968): `src/shared/python/ux/` adds the `FieldMetadata` registry, `ProvenanceRecord`/`ProvenanceValue`, `PreflightCheck`/`Severity`/`run_preflight()`, and the `UserFacingError` envelope, all with full Design-by-Contract validation; seeded `src/shared/python/ux/config/field_metadata.yaml` and `src/shared/python/ux/config/error_messages.yaml`; added `scripts/ci/check_ux_coverage_ratchet.py` plus baseline at 714 unwrapped inputs (62 QSpinBox + 221 QDoubleSpinBox + 217 QComboBox + 70 QSlider + 94 QLineEdit + 35 `<input>` + 14 `<select>` + 1 `<textarea>`); documented the workflow in `docs/ux/field_metadata.md`; 68 unit tests in `tests/unit/ux/`. Sanitized unexpected `src/api/routes/simulation_ws.py` runtime errors before they reach WebSocket clients while preserving traceback-bearing server logs, and added direct regression coverage for the generic error payload contract. Re-baselined `scripts/config/module_size_budget_baseline.json` from 10 stale exceptions (sizes 3-5x overstated, 7 files since decomposed) down to the 3 modules that genuinely exceed 1,500 lines today, and added `validate_baseline_truthfulness` to `scripts/check_module_size_budget.py` as a CI ratchet against future fraudulent baselines. Refs #5922. |
 | 2026-05-23 | 1.0.180 | ⚡ Bolt: Optimize mechanical work metric calculations using einsum and vdot |
 | 2026-05-22 | 1.0.179 | Aligned the module-size quality gate with current launcher and shared-chat legacy debt by adding owned, expiring exceptions for `src/launchers/launcher_ui_setup.py` and `src/shared/python/chat/_chat_dock_widget_qt.py`, and raising the active module-size exception cap to 10 while preserving the 1,500-line budget for new untracked modules. |

--- a/docs/development/ci_workflow_map.md
+++ b/docs/development/ci_workflow_map.md
@@ -66,7 +66,6 @@ PR-quality signal.
 | `nightly-cross-engine.yml`    | Scheduled cross-engine physics validation.                                           |
 | `stale-cleanup.yml`           | Stale issue and PR maintenance.                                                      |
 | `vendor-freshness.yml`        | Vendored submodule freshness checks and optional bumping.                            |
-| `Bot-CI-Trigger.yml`          | Scheduled/manual CI retrigger support for bot-authored PRs.                          |
 | `Jules-Comment-Processor.yml` | Scheduled or dispatched review-comment processing.                                   |
 | `Jules-PR-Cleanup.yml`        | Scheduled or dispatched PR cleanup.                                                  |
 | `Jules-PR-Compiler.yml`       | Scheduled or dispatched PR consolidation.                                            |
@@ -81,6 +80,7 @@ ordinary PR review.
 | Workflow file                    | Purpose                                                          |
 | -------------------------------- | ---------------------------------------------------------------- |
 | `auto-update-prs.yml`            | Rebase/update open PRs after `main` changes.                     |
+| `Bot-CI-Trigger.yml`             | Bounded single-PR CI retrigger support for bot-authored PRs.     |
 | `pr-auto-labeler.yml`            | Applies scope and size labels to PRs.                            |
 | `PR-Comment-Responder.yml`       | Collects PR comments for downstream processing.                  |
 | `Comment-to-Issue-Converter.yml` | Converts actionable review comments into issues.                 |

--- a/tests/unit/scripts/test_bot_ci_trigger_bounded.py
+++ b/tests/unit/scripts/test_bot_ci_trigger_bounded.py
@@ -1,0 +1,38 @@
+"""Regression tests for the Bot CI trigger workflow budget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "Bot-CI-Trigger.yml"
+
+
+def test_bot_ci_trigger_has_no_backlog_polling_or_empty_commit_fallback() -> None:
+    """The CI trigger workflow must stay bounded to one explicit PR."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    forbidden_patterns = [
+        "schedule:",
+        "gh pr list",
+        "gh pr checks",
+        "git commit --allow-empty",
+        "git push origin",
+        "continue-on-error: true",
+    ]
+
+    for pattern in forbidden_patterns:
+        assert pattern not in workflow
+
+
+def test_bot_ci_trigger_uses_bounded_rest_inspection() -> None:
+    """Current CI status inspection should use REST for one PR head SHA."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repos/$GITHUB_REPOSITORY/pulls/$TARGET_PR" in workflow
+    assert "commits/$HEAD_SHA/check-runs?per_page=100" in workflow
+    assert "actions/workflows/ci-standard.yml/dispatches" in workflow


### PR DESCRIPTION
## Summary
- Replace Bot-CI-Trigger backlog polling with a single-PR bounded trigger path.
- Use REST for PR resolution, check-run inspection, and ci-standard workflow dispatch.
- Remove the scheduled scan, `gh pr checks`/`gh pr list`, empty-commit fallback, and job-level `continue-on-error`.
- Add focused regression coverage and update SPEC/CI workflow map documentation.

Closes #8240

## Validation
- `python -m pytest tests/unit/scripts/test_bot_ci_trigger_bounded.py -q`
- `python -m ruff format --check tests/unit/scripts/test_bot_ci_trigger_bounded.py`
- `python -m ruff check tests/unit/scripts/test_bot_ci_trigger_bounded.py`
- Workflow YAML parse for `.github/workflows/Bot-CI-Trigger.yml`
- Forbidden-pattern search for `gh pr checks`, `gh pr list`, `git commit --allow-empty`, `git push origin`, `continue-on-error: true`, and `schedule:`
- `python scripts/check_spec_paths.py`
- `python scripts/ci/check_version_consistency.py`

Pre-push note: static hooks passed; `pytest-unit` was skipped during push to honor the issue-wave instruction to avoid broad local test suites.