### PR TITLE
Fix #8197: report symbolic solver unavailable state

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,8 +40,8 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
@@ -1925,6 +1925,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Corrected symbolic solver unavailable responses so solve, derivative, and simplify calls report `available=false` whenever SymPy is disabled instead of inheriting the import-time response-model default (#8197). |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/src/shared/python/calc_backend/routers/symbolic_solver.py
+++ b/src/shared/python/calc_backend/routers/symbolic_solver.py
@@ -117,7 +117,8 @@ def solve_equation(request: SymbolicSolveRequest) -> SymbolicSolveResponse:
     """Solve a symbolic equation for a specified variable."""
     if not SYMPY_AVAILABLE:
         return SymbolicSolveResponse(
-            error="SymPy is not available. Install with: pip install sympy"
+            available=False,
+            error="SymPy is not available. Install with: pip install sympy",
         )
 
     try:
@@ -165,7 +166,8 @@ def compute_derivative(
     """Compute the symbolic derivative of an expression."""
     if not SYMPY_AVAILABLE:
         return SymbolicDerivativeResponse(
-            error="SymPy is not available. Install with: pip install sympy"
+            available=False,
+            error="SymPy is not available. Install with: pip install sympy",
         )
 
     try:
@@ -186,7 +188,8 @@ def simplify_expression(request: SymbolicSimplifyRequest) -> SymbolicSimplifyRes
     """Simplify a symbolic expression."""
     if not SYMPY_AVAILABLE:
         return SymbolicSimplifyResponse(
-            error="SymPy is not available. Install with: pip install sympy"
+            available=False,
+            error="SymPy is not available. Install with: pip install sympy",
         )
 
     try:


### PR DESCRIPTION
## Summary
- make symbolic solve, derivative, and simplify unavailable responses explicitly return `available=false` when SymPy is disabled
- update SPEC.md for the #8197 contract change

## Validation
- `py -3.13 -m pytest src\shared\python\calc_backend\tests\test_symbolic_solver.py::TestSymbolicSolve::test_solve_returns_unavailable_when_sympy_missing src\shared\python\calc_backend\tests\test_symbolic_solver.py::TestSymbolicDerivative::test_derivative_returns_unavailable_when_sympy_missing src\shared\python\calc_backend\tests\test_symbolic_solver.py::TestSymbolicSimplify::test_simplify_returns_unavailable_when_sympy_missing -q`
- `py -3.13 -m pytest src\shared\python\calc_backend\tests\test_symbolic_solver.py -q`
- `$env:TOOLS_REPO_PATH='C:\Users\diete\Repositories\Tools'; py -3.13 -m pytest tests\unit\repo_hygiene\test_tools_child_copy_contract.py -q`
- `py -3.13 -m ruff format src\shared\python\calc_backend\routers\symbolic_solver.py`
- `py -3.13 -m ruff check src\shared\python\calc_backend\routers\symbolic_solver.py src\shared\python\calc_backend\tests\test_symbolic_solver.py`
- `pre-commit run prettier --files SPEC.md`
- `git diff --check`
- pre-push hook suite on push: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, prettier, mypy, bandit, pytest-unit

Closes #8197