### PR TITLE
Fix #8190: hide launcher hidden tiles

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,8 +40,8 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
@@ -1925,6 +1925,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Aligned launcher tile catalog API visibility with the manifest contract so `/launcher/tiles` excludes hidden aliases by default and `/launcher/tiles/{tile_id}` returns 404 for hidden entries (#8190). |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/src/api/routes/launcher.py
+++ b/src/api/routes/launcher.py
@@ -70,13 +70,13 @@ async def get_manifest() -> dict[str, Any]:
 
 @router.get("/tiles")
 async def get_tiles() -> list[dict[str, Any]]:
-    """Get all launcher tiles in display order.
+    """Get visible launcher tiles in display order.
 
     Returns:
-        List of tile dictionaries.
+        List of visible tile dictionaries.
     """
     manifest = _get_manifest()
-    return [t.to_dict() for t in manifest.tiles]
+    return [t.to_dict() for t in manifest.visible_tiles]
 
 
 @router.get("/tiles/{tile_id}")
@@ -98,7 +98,7 @@ async def get_tile(tile_id: str) -> dict[str, Any]:
     """
     manifest = _get_manifest()
     tile = manifest.get_tile(tile_id)
-    if tile is None:
+    if tile is None or tile.hidden:
         raise HTTPException(status_code=404, detail=f"Tile not found: {tile_id}")
     return tile.to_dict()
 

--- a/tests/unit/api/test_routes_launcher.py
+++ b/tests/unit/api/test_routes_launcher.py
@@ -4,7 +4,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.api.routes import launcher as launcher_routes
 from src.api.routes.launcher import router
+from src.config.launcher_manifest_loader import LauncherManifest, LauncherTile
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
@@ -19,6 +23,43 @@ def app() -> FastAPI:
 def client(app: FastAPI) -> TestClient:
     """Create a test client."""
     return TestClient(app)
+
+
+@pytest.fixture
+def hidden_tile_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a manifest with one visible tile and one hidden alias."""
+    manifest = LauncherManifest(
+        version="test",
+        description="visibility fixture",
+        tiles=(
+            LauncherTile(
+                id="visible_tool",
+                name="Visible Tool",
+                description="Shown in public launcher catalog endpoints",
+                category="tool",
+                type="special_app",
+                path="src/tools/visible_tool/__main__.py",
+                logo="visible.svg",
+                status="ready",
+                order=1,
+            ),
+            LauncherTile(
+                id="hidden_alias",
+                name="Hidden Alias",
+                description="Legacy alias hidden from public launcher catalog endpoints",
+                category="tool",
+                type="special_app",
+                path="src/tools/hidden_alias/__main__.py",
+                logo="hidden.svg",
+                status="ready",
+                order=2,
+                hidden=True,
+                hidden_reason="Legacy alias",
+                hidden_owner="launcher-team",
+            ),
+        ),
+    )
+    monkeypatch.setitem(launcher_routes._launcher_state, "manifest", manifest)
 
 
 def test_get_manifest(client: TestClient) -> None:
@@ -39,6 +80,17 @@ def test_get_tiles(client: TestClient) -> None:
     assert len(data) > 0
 
 
+def test_get_tiles_excludes_hidden_entries_by_default(
+    client: TestClient, hidden_tile_manifest: None
+) -> None:
+    """Public tile listing uses the same visible-tile contract as the manifest."""
+    response = client.get("/launcher/tiles")
+    assert response.status_code == 200
+
+    tile_ids = {tile["id"] for tile in response.json()}
+    assert tile_ids == {"visible_tool"}
+
+
 def test_get_tile_found(client: TestClient) -> None:
     """Test getting a specific tile."""
     # Assuming "mujoco" or something similar exists
@@ -54,6 +106,14 @@ def test_get_tile_found(client: TestClient) -> None:
 def test_get_tile_not_found(client: TestClient) -> None:
     """Test getting a non-existent tile."""
     response = client.get("/launcher/tiles/unknown_tile_id")
+    assert response.status_code == 404
+
+
+def test_get_tile_returns_not_found_for_hidden_entries_by_default(
+    client: TestClient, hidden_tile_manifest: None
+) -> None:
+    """Hidden aliases are not addressable through the public tile detail route."""
+    response = client.get("/launcher/tiles/hidden_alias")
     assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary
- filter `/launcher/tiles` through the manifest `visible_tiles` contract
- return 404 for hidden tile IDs on `/launcher/tiles/{tile_id}`
- add isolated API route tests for hidden-tile listing/detail behavior and update SPEC.md

## Validation
- RED: `py -3.13 -m pytest tests\unit\api\test_routes_launcher.py::test_get_tiles_excludes_hidden_entries_by_default tests\unit\api\test_routes_launcher.py::test_get_tile_returns_not_found_for_hidden_entries_by_default -q`
- GREEN: `py -3.13 -m pytest tests\unit\api\test_routes_launcher.py::test_get_tiles_excludes_hidden_entries_by_default tests\unit\api\test_routes_launcher.py::test_get_tile_returns_not_found_for_hidden_entries_by_default -q`
- `py -3.13 -m pytest tests\unit\api\test_routes_launcher.py -q`
- `py -3.13 -m ruff format src\api\routes\launcher.py tests\unit\api\test_routes_launcher.py`
- `py -3.13 -m ruff check src\api\routes\launcher.py tests\unit\api\test_routes_launcher.py`
- `pre-commit run prettier --files SPEC.md`
- `git diff --check`
- pre-push hook suite on push: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, prettier, mypy, bandit, pytest-unit

## Note
- The prefixed full-app tests `tests\api\test_launcher_api.py::{test_get_tiles,test_get_tile_by_id,test_get_tile_not_found}` currently fail at the auth layer with 401 before reaching launcher route behavior; the direct route tests cover this route module without that existing app-auth setup requirement.

Closes #8190