### PR TITLE
Fix #8193: lazy-load API service exports

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,8 +40,8 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
@@ -1925,6 +1925,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-28 | 1.0.480 | Made the `src.api.services` package initializer lazy so importing launcher service boundaries no longer eagerly loads unrelated analysis, chat, simulation, or optional backend stacks (#8193). |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |
 | 2026-07-27 | 1.0.477 | Made the standalone Sidekick package workflow build its sdist and wheel as separate operations. The sdist remains a published source artifact, while the wheel is now assembled directly from the recursive checkout that owns the pinned Tools gitlink instead of being rebuilt from an sdist that intentionally excludes `vendor/`; focused workflow coverage prevents a combined `python -m build` regression. |

--- a/src/api/services/__init__.py
+++ b/src/api/services/__init__.py
@@ -1,9 +1,18 @@
 """API business-logic services."""
 
-from .analysis_service import AnalysisService
-from .chat_service import ChatService
-from .launcher_service import LauncherService
-from .simulation_service import SimulationService, SimulationStats
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    "AnalysisService": ("src.api.services.analysis_service", "AnalysisService"),
+    "ChatService": ("src.api.services.chat_service", "ChatService"),
+    "LauncherService": ("src.api.services.launcher_service", "LauncherService"),
+    "SimulationService": ("src.api.services.simulation_service", "SimulationService"),
+    "SimulationStats": ("src.api.services.simulation_service", "SimulationStats"),
+}
 
 __all__: list[str] = [
     "AnalysisService",
@@ -12,3 +21,16 @@ __all__: list[str] = [
     "SimulationService",
     "SimulationStats",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve concrete services when callers request them."""
+    if not isinstance(name, str):
+        raise TypeError(f"attribute name must be a str, not {type(name)!r}")
+
+    if name not in _LAZY_ATTRS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_path, attr = _LAZY_ATTRS[name]
+    module: ModuleType = importlib.import_module(module_path)
+    return getattr(module, attr)

--- a/tests/unit/api/test_api_lazy_imports.py
+++ b/tests/unit/api/test_api_lazy_imports.py
@@ -20,6 +20,8 @@ Contract locked in by these tests:
 from __future__ import annotations
 
 import importlib
+import json
+import subprocess
 import sys
 from types import ModuleType
 from unittest import mock
@@ -53,6 +55,8 @@ _SQLALCHEMY_NAMES = [
     "sqlalchemy.ext",
     "sqlalchemy.ext.declarative",
 ]
+
+pytestmark = pytest.mark.unit
 
 
 def _evict_api_modules() -> dict[str, ModuleType]:
@@ -166,6 +170,50 @@ class TestHeavySubmodulesFailGracefullyWithoutSQLAlchemy:
                 assert isinstance(services, ModuleType)
         finally:
             _restore_api_modules(saved)
+
+    def test_import_services_package_is_quiet_and_does_not_load_services(
+        self,
+    ) -> None:
+        """``import src.api.services`` must not import concrete services eagerly."""
+        code = (
+            "import json, sys\n"
+            "import src.api.services\n"
+            "loaded = sorted(k for k in sys.modules if k.startswith('src.api.services.'))\n"
+            "print(json.dumps({'loaded': loaded}))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+        assert result.stderr == ""
+        assert result.stdout.startswith("{"), result.stdout
+        data = json.loads(result.stdout)
+        assert data["loaded"] == []
+
+    def test_services_launcher_export_resolves_only_launcher_service(self) -> None:
+        """The public service export remains lazy and backwards compatible."""
+        code = (
+            "import json, sys\n"
+            "from src.api.services import LauncherService\n"
+            "loaded = sorted(k for k in sys.modules if k.startswith('src.api.services.'))\n"
+            "print(json.dumps({'name': LauncherService.__name__, 'loaded': loaded}))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+        data = json.loads(result.stdout)
+        assert result.stderr == ""
+        assert data == {
+            "name": "LauncherService",
+            "loaded": ["src.api.services.launcher_service"],
+        }
 
     def test_get_current_user_raises_without_sqlalchemy(self) -> None:
         """``src.api.get_current_user`` is re-exported from auth; must raise."""


### PR DESCRIPTION
## Summary
- make `src.api.services` resolve concrete service exports lazily instead of importing every service in the package initializer
- preserve backwards-compatible exports such as `from src.api.services import LauncherService`
- add subprocess regressions proving the services package import is quiet and does not load concrete service modules eagerly
- update SPEC.md for the #8193 import-boundary fix

## Validation
- RED: `py -3.13 -m pytest tests\unit\api\test_api_lazy_imports.py::TestHeavySubmodulesFailGracefullyWithoutSQLAlchemy::test_import_services_package_is_quiet_and_does_not_load_services -q`
- `py -3.13 -m pytest tests\unit\api\test_api_lazy_imports.py -q`
- `py -3.13 -m pytest tests\unit\api\test_api_lazy_imports.py tests\architecture\test_circular_dependencies.py::TestApiDoesNotImportLaunchers tests\unit\api\services\test_launcher_service.py -q`
- `py -3.13 -c "import src.api.services.launcher_service"`
- `py -3.13 -m ruff format src\api\services\__init__.py tests\unit\api\test_api_lazy_imports.py`
- `py -3.13 -m ruff check src\api\services\__init__.py tests\unit\api\test_api_lazy_imports.py`
- `pre-commit run prettier --files SPEC.md`
- `git diff --check`
- pre-push hook suite on push: ruff, ruff format, formatter guidance, no wildcard imports, no debug statements, no print in src, prettier, mypy, bandit, pytest-unit

Closes #8193