### PR TITLE
Fix #8250: validate ball roll physics contracts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,10 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened putting-green ball-roll physics contracts so invalid
+  ball mass/radius, unknown integrators, non-positive or non-finite timesteps,
+  and invalid simulation horizons fail fast with `ValueError` instead of silent
+  non-physical integration (#8250).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/engines/physics_engines/putting_green/python/ball_roll_physics.py
+++ b/src/engines/physics_engines/putting_green/python/ball_roll_physics.py
@@ -129,6 +129,9 @@ class BallRollPhysics:
     # Spin threshold for pure rolling determination
     SPIN_VELOCITY_RATIO_TOLERANCE = 0.05
 
+    # Supported time-integration schemes.
+    ALLOWED_INTEGRATORS = frozenset({"euler", "rk4", "verlet"})
+
     def __init__(
         self,
         turf: TurfProperties | None = None,
@@ -146,19 +149,43 @@ class BallRollPhysics:
             ball_radius: Ball radius [m]
             integrator: Integration method ("euler", "rk4", "verlet")
         """
-        if ball_mass is None:
-            raise ValueError("ball_mass must be provided")
         self.green = green
         self.turf = turf or (green.turf if green else TurfProperties())
-        self.ball_mass = ball_mass
-        self.ball_radius = ball_radius
-        self.integrator = integrator
+        self.ball_mass = self._validate_positive_finite("ball_mass", ball_mass)
+        self.ball_radius = self._validate_positive_finite("ball_radius", ball_radius)
+        self.integrator = self._validate_integrator(integrator)
 
         # Ball moment of inertia (solid sphere)
-        self._moment_of_inertia = (2.0 / 5.0) * ball_mass * ball_radius**2
+        self._moment_of_inertia = (2.0 / 5.0) * self.ball_mass * self.ball_radius**2
 
         # Previous acceleration for Verlet integration
         self._prev_acceleration: np.ndarray | None = None
+
+    @staticmethod
+    def _validate_positive_finite(name: str, value: float) -> float:
+        """Return ``value`` as float after enforcing a finite positive contract."""
+        if value is None:
+            raise ValueError(f"{name} must be provided")
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a finite positive number") from exc
+        if not math.isfinite(numeric) or numeric <= 0.0:
+            raise ValueError(f"{name} must be a finite positive number")
+        return numeric
+
+    @classmethod
+    def _validate_integrator(cls, integrator: str) -> str:
+        """Validate the configured integration scheme name."""
+        if integrator not in cls.ALLOWED_INTEGRATORS:
+            allowed = ", ".join(sorted(cls.ALLOWED_INTEGRATORS))
+            raise ValueError(f"integrator must be one of: {allowed}")
+        return integrator
+
+    @classmethod
+    def _validate_dt(cls, dt: float) -> float:
+        """Validate a simulation timestep in seconds."""
+        return cls._validate_positive_finite("dt", dt)
 
     def determine_roll_mode(self, state: BallState) -> RollMode:
         """Determine current rolling mode from state.
@@ -415,6 +442,7 @@ class BallRollPhysics:
         """
         if state is None:
             raise ValueError("state must be provided")
+        dt = self._validate_dt(dt)
         if self.integrator == "rk4":
             return self._step_rk4(state, dt)
         if self.integrator == "verlet":
@@ -425,6 +453,7 @@ class BallRollPhysics:
         """Euler integration step."""
         if state is None:
             raise ValueError("state must be provided")
+        dt = self._validate_dt(dt)
         mode = self.determine_roll_mode(state)
 
         if mode == RollMode.STOPPED:
@@ -473,6 +502,7 @@ class BallRollPhysics:
 
         if state is None:
             raise ValueError("state must be provided")
+        dt = self._validate_dt(dt)
 
         def derivatives(
             pos: np.ndarray, vel: np.ndarray
@@ -511,6 +541,7 @@ class BallRollPhysics:
         # Current acceleration
         if state is None:
             raise ValueError("state must be provided")
+        dt = self._validate_dt(dt)
         accel = self.compute_total_acceleration(state)
 
         # Update position
@@ -557,6 +588,8 @@ class BallRollPhysics:
         """
         if initial_state is None:
             raise ValueError("initial_state must be provided")
+        max_time = self._validate_positive_finite("max_time", max_time)
+        dt = self._validate_dt(dt)
         positions = [initial_state.position.copy()]
         velocities = [initial_state.velocity.copy()]
         spins = [initial_state.spin.copy()]

--- a/tests/unit/engines/putting_green/test_ball_roll_physics.py
+++ b/tests/unit/engines/putting_green/test_ball_roll_physics.py
@@ -18,6 +18,8 @@ from src.engines.physics_engines.putting_green.python.turf_properties import (
     TurfProperties,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestRollMode:
     """Tests for RollMode enumeration."""
@@ -143,6 +145,23 @@ class TestBallRollPhysics:
         assert np.isclose(physics.ball_mass, 0.04593, atol=0.001)  # kg
         assert np.isclose(physics.ball_radius, 0.02135, atol=0.001)  # m
 
+    @pytest.mark.parametrize("ball_mass", [None, 0.0, -0.1, np.nan, np.inf])
+    def test_constructor_rejects_invalid_ball_mass(self, ball_mass: float) -> None:
+        """Ball mass is a public physics precondition."""
+        with pytest.raises(ValueError, match="ball_mass"):
+            BallRollPhysics(ball_mass=ball_mass)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("ball_radius", [None, 0.0, -0.1, np.nan, np.inf])
+    def test_constructor_rejects_invalid_ball_radius(self, ball_radius: float) -> None:
+        """Ball radius must fail at construction, not inside numeric formulas."""
+        with pytest.raises(ValueError, match="ball_radius"):
+            BallRollPhysics(ball_radius=ball_radius)  # type: ignore[arg-type]
+
+    def test_constructor_rejects_unknown_integrator(self) -> None:
+        """Integrator names must not silently fall back to Euler."""
+        with pytest.raises(ValueError, match="integrator"):
+            BallRollPhysics(integrator="rk_4")
+
     def test_initial_roll_mode_determination(self, physics: BallRollPhysics) -> None:
         """Should determine correct initial roll mode."""
         # High spin relative to velocity = sliding
@@ -234,6 +253,22 @@ class TestBallRollPhysics:
 
         # Position should have advanced
         assert new_state.position[0] > state.position[0]
+
+    @pytest.mark.parametrize("integrator", ["euler", "rk4", "verlet"])
+    @pytest.mark.parametrize("dt", [None, 0.0, -0.1, np.nan, np.inf])
+    def test_step_rejects_invalid_dt_for_all_integrators(
+        self, integrator: str, dt: float
+    ) -> None:
+        """A public step cannot accept non-finite or non-positive timesteps."""
+        physics = BallRollPhysics(integrator=integrator)
+        state = BallState(
+            position=np.array([0.0, 0.0]),
+            velocity=np.array([1.0, 0.0]),
+            spin=np.zeros(3),
+        )
+
+        with pytest.raises(ValueError, match="dt"):
+            physics.step(state, dt=dt)  # type: ignore[arg-type]
 
     def test_ball_decelerates_to_stop(self, physics: BallRollPhysics) -> None:
         """Ball should eventually stop due to friction."""
@@ -343,6 +378,34 @@ class TestBallRollPhysics:
         initial_speed = np.linalg.norm(initial_state.velocity)
         final_speed = np.linalg.norm(final_vel)
         assert final_speed < initial_speed * 0.1
+
+    @pytest.mark.parametrize("dt", [None, 0.0, -0.1, np.nan, np.inf])
+    def test_simulate_putt_rejects_invalid_dt(
+        self, physics: BallRollPhysics, dt: float
+    ) -> None:
+        """Complete trajectory simulation enforces timestep preconditions."""
+        initial_state = BallState(
+            position=np.array([0.0, 0.0]),
+            velocity=np.array([1.0, 0.0]),
+            spin=np.zeros(3),
+        )
+
+        with pytest.raises(ValueError, match="dt"):
+            physics.simulate_putt(initial_state, dt=dt)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("max_time", [None, 0.0, -1.0, np.nan, np.inf])
+    def test_simulate_putt_rejects_invalid_max_time(
+        self, physics: BallRollPhysics, max_time: float
+    ) -> None:
+        """Complete trajectory simulation enforces bounded time horizons."""
+        initial_state = BallState(
+            position=np.array([0.0, 0.0]),
+            velocity=np.array([1.0, 0.0]),
+            spin=np.zeros(3),
+        )
+
+        with pytest.raises(ValueError, match="max_time"):
+            physics.simulate_putt(initial_state, max_time=max_time)  # type: ignore[arg-type]
 
     def test_simulate_with_hole(self, physics_with_green: BallRollPhysics) -> None:
         """Should detect when ball goes in hole."""


### PR DESCRIPTION
## Summary
- enforce finite positive contracts for ball mass, ball radius, timestep, and simulation horizon
- reject unknown integration schemes instead of silently falling through to Euler behavior
- add unit regression coverage for invalid constructor, step, and simulate_putt inputs
- update SPEC.md for the #8250 contract hardening

Closes #8250

## Validation
- RED: new invalid-input tests failed before the fix; negative simulate_putt dt hung until pytest timeout, matching the issue report
- py -3.13 -m pytest tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_constructor_rejects_invalid_ball_mass tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_constructor_rejects_invalid_ball_radius tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_constructor_rejects_unknown_integrator tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_step_rejects_invalid_dt_for_all_integrators tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_simulate_putt_rejects_invalid_dt tests\unit\engines\putting_green\test_ball_roll_physics.py::TestBallRollPhysics::test_simulate_putt_rejects_invalid_max_time -q
- py -3.13 -m pytest tests\unit\engines\putting_green\test_ball_roll_physics.py -q
- py -3.13 -m ruff format src\engines\physics_engines\putting_green\python\ball_roll_physics.py tests\unit\engines\putting_green\test_ball_roll_physics.py
- py -3.13 -m ruff check src\engines\physics_engines\putting_green\python\ball_roll_physics.py tests\unit\engines\putting_green\test_ball_roll_physics.py
- npx prettier --write SPEC.md
- git diff --check
- git -c http.https://github.com/.extraheader= push -u origin fix/8250-ball-roll-contracts (pre-push: ruff, ruff format, formatter guidance, wildcard/debug/print guards, prettier, mypy, bandit, pytest-unit)