### PR TITLE
Fix #8248: timeout multipart API fetches

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,11 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Extended the shared frontend API timeout contract to
+  multipart uploads. `apiFetchForm()` now composes caller cancellation with the
+  default deadline, normalizes timeout/abort errors like JSON requests, and
+  shares HTTP error extraction with `apiFetch()` so upload panels cannot remain
+  indefinitely loading on stalled backend responses (#8248).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/ui/src/api/fetch.ts
+++ b/ui/src/api/fetch.ts
@@ -16,7 +16,7 @@
  *   });
  */
 
-import { getApiBase } from './backend';
+import { getApiBase } from "./backend";
 
 /**
  * Default request timeout (issue #8080).
@@ -56,10 +56,37 @@ function buildSignal(
   }
   // `AbortSignal.any` is available in every browser the app targets; fall back
   // to the timeout alone if a test environment lacks it.
-  if (typeof AbortSignal.any === 'function') {
+  if (typeof AbortSignal.any === "function") {
     return AbortSignal.any([callerSignal, timeoutSignal]);
   }
   return timeoutSignal;
+}
+
+function requestError(err: unknown, path: string, timeoutMs: number): Error {
+  if (err instanceof DOMException && err.name === "TimeoutError") {
+    return new Error(`Request timed out after ${timeoutMs}ms — ${path}`);
+  }
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return new Error(`Request aborted — ${path}`);
+  }
+  return new Error(
+    err instanceof Error ? err.message : `Network error for ${path}`,
+  );
+}
+
+async function responseError(response: Response, path: string): Promise<Error> {
+  let detail: string | undefined;
+  try {
+    const body = (await response.json()) as Record<string, unknown>;
+    if (typeof body.detail === "string") {
+      detail = body.detail;
+    }
+  } catch {
+    // Body was not valid JSON — that's fine, fall through to generic message.
+  }
+  return new Error(
+    detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`,
+  );
 }
 
 /**
@@ -80,7 +107,7 @@ export async function apiFetch<T>(
   const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
 
   const mergedInit: RequestInit = {
-    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
     ...requestInit,
     signal: buildSignal(timeoutMs, requestInit.signal),
   };
@@ -89,30 +116,11 @@ export async function apiFetch<T>(
   try {
     response = await fetch(url, mergedInit);
   } catch (err) {
-    if (err instanceof DOMException && err.name === 'TimeoutError') {
-      throw new Error(`Request timed out after ${timeoutMs}ms — ${path}`);
-    }
-    if (err instanceof DOMException && err.name === 'AbortError') {
-      throw new Error(`Request aborted — ${path}`);
-    }
-    // Network-level error (no response at all)
-    throw new Error(
-      err instanceof Error ? err.message : `Network error for ${path}`,
-    );
+    throw requestError(err, path, timeoutMs);
   }
 
   if (!response.ok) {
-    // Attempt to extract a FastAPI-style `detail` field
-    let detail: string | undefined;
-    try {
-      const body = (await response.json()) as Record<string, unknown>;
-      if (typeof body.detail === 'string') {
-        detail = body.detail;
-      }
-    } catch {
-      // Body was not valid JSON — that's fine, fall through to generic message
-    }
-    throw new Error(detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`);
+    throw await responseError(response, path);
   }
 
   return response.json() as Promise<T>;
@@ -151,31 +159,32 @@ export async function apiFetchParsed<T>(
  *
  * @param path - API path
  * @param formData - FormData payload
+ * @param init - Optional `RequestInit` options plus `timeoutMs` (#8248)
  * @returns Parsed JSON body typed as `T`
  */
-export async function apiFetchForm<T>(path: string, formData: FormData): Promise<T> {
+export async function apiFetchForm<T>(
+  path: string,
+  formData: FormData,
+  init?: ApiFetchInit,
+): Promise<T> {
   const url = `${getApiBase()}${path}`;
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
+  const formInit: RequestInit = {
+    ...requestInit,
+    method: "POST",
+    body: formData,
+    signal: buildSignal(timeoutMs, requestInit.signal),
+  };
 
   let response: Response;
   try {
-    response = await fetch(url, { method: 'POST', body: formData });
+    response = await fetch(url, formInit);
   } catch (err) {
-    throw new Error(
-      err instanceof Error ? err.message : `Network error for ${path}`,
-    );
+    throw requestError(err, path, timeoutMs);
   }
 
   if (!response.ok) {
-    let detail: string | undefined;
-    try {
-      const body = (await response.json()) as Record<string, unknown>;
-      if (typeof body.detail === 'string') {
-        detail = body.detail;
-      }
-    } catch {
-      // ignore
-    }
-    throw new Error(detail ?? `HTTP ${response.status} ${response.statusText} — ${path}`);
+    throw await responseError(response, path);
   }
 
   return response.json() as Promise<T>;

--- a/ui/src/api/fetchTimeout.test.ts
+++ b/ui/src/api/fetchTimeout.test.ts
@@ -7,8 +7,8 @@
  * That is what left Motion Capture on "Loading sources..." indefinitely.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiFetch, DEFAULT_TIMEOUT_MS } from './fetch';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiFetch, apiFetchForm, DEFAULT_TIMEOUT_MS } from "./fetch";
 
 function jsonResponse(body: unknown): Response {
   return {
@@ -26,103 +26,155 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('apiFetch timeout (#8080)', () => {
-  it('passes an AbortSignal by default so a request cannot hang forever', async () => {
+describe("apiFetch timeout (#8080)", () => {
+  it("passes an AbortSignal by default so a request cannot hang forever", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal("fetch", fetchMock);
 
-    await apiFetch('/api/anything');
+    await apiFetch("/api/anything");
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it('exposes a sane default timeout', () => {
+  it("exposes a sane default timeout", () => {
     expect(DEFAULT_TIMEOUT_MS).toBeGreaterThan(0);
     expect(DEFAULT_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
   });
 
   it('rejects with a recognisable "timed out" message', async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError')),
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException("The operation timed out.", "TimeoutError"),
+        ),
     );
 
-    await expect(apiFetch('/api/slow')).rejects.toThrow(/timed out/i);
+    await expect(apiFetch("/api/slow")).rejects.toThrow(/timed out/i);
   });
 
-  it('reports the configured timeout value in the message', async () => {
+  it("reports the configured timeout value in the message", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new DOMException('timeout', 'TimeoutError')),
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("timeout", "TimeoutError")),
     );
 
-    await expect(apiFetch('/api/slow', { timeoutMs: 250 })).rejects.toThrow(/250ms/);
+    await expect(apiFetch("/api/slow", { timeoutMs: 250 })).rejects.toThrow(
+      /250ms/,
+    );
   });
 
-  it('actually aborts a never-answering request within the timeout', async () => {
+  it("actually aborts a never-answering request within the timeout", async () => {
     // The signal is the only thing that can end this request.
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn().mockImplementation(
         (_url: string, init: RequestInit) =>
           new Promise((_resolve, reject) => {
-            init.signal?.addEventListener('abort', () => {
-              reject(new DOMException('aborted', 'TimeoutError'));
+            init.signal?.addEventListener("abort", () => {
+              reject(new DOMException("aborted", "TimeoutError"));
             });
           }),
       ),
     );
 
-    await expect(apiFetch('/api/hangs', { timeoutMs: 50 })).rejects.toThrow(
+    await expect(apiFetch("/api/hangs", { timeoutMs: 50 })).rejects.toThrow(
       /timed out/i,
     );
   });
 
-  it('distinguishes a caller abort from a timeout', async () => {
+  it("distinguishes a caller abort from a timeout", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError')),
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("aborted", "AbortError")),
     );
 
-    await expect(apiFetch('/api/cancelled')).rejects.toThrow(/aborted/i);
+    await expect(apiFetch("/api/cancelled")).rejects.toThrow(/aborted/i);
   });
 
-  it('allows disabling the timeout with timeoutMs: 0', async () => {
+  it("allows disabling the timeout with timeoutMs: 0", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal("fetch", fetchMock);
 
-    await apiFetch('/api/streaming', { timeoutMs: 0 });
+    await apiFetch("/api/streaming", { timeoutMs: 0 });
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeUndefined();
   });
 
-  it('honours a caller-supplied signal alongside the timeout', async () => {
+  it("honours a caller-supplied signal alongside the timeout", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal("fetch", fetchMock);
     const controller = new AbortController();
 
-    await apiFetch('/api/thing', { signal: controller.signal });
+    await apiFetch("/api/thing", { signal: controller.signal });
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(init.signal).not.toBe(controller.signal);
   });
 
-  it('does not disturb normal success or HTTP-error handling', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ value: 7 })));
-    await expect(apiFetch<{ value: number }>('/api/ok')).resolves.toEqual({ value: 7 });
+  it("does not disturb normal success or HTTP-error handling", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ value: 7 })),
+    );
+    await expect(apiFetch<{ value: number }>("/api/ok")).resolves.toEqual({
+      value: 7,
+    });
 
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn().mockResolvedValue({
         ok: false,
         status: 405,
-        statusText: 'Method Not Allowed',
-        json: () => Promise.resolve({ detail: 'Method Not Allowed' }),
+        statusText: "Method Not Allowed",
+        json: () => Promise.resolve({ detail: "Method Not Allowed" }),
       } as unknown as Response),
     );
-    await expect(apiFetch('/api/bad')).rejects.toThrow('Method Not Allowed');
+    await expect(apiFetch("/api/bad")).rejects.toThrow("Method Not Allowed");
+  });
+});
+
+describe("apiFetchForm timeout (#8248)", () => {
+  it("passes an AbortSignal by default so form uploads cannot hang forever", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ uploaded: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetchForm("/api/upload", new FormData());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("normalizes form upload timeout errors with the path and deadline", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("timeout", "TimeoutError")),
+    );
+
+    await expect(
+      apiFetchForm("/api/upload", new FormData(), { timeoutMs: 250 }),
+    ).rejects.toThrow(/timed out after 250ms.*\/api\/upload/i);
+  });
+
+  it("honours a caller-supplied signal alongside the form timeout", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ uploaded: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    await apiFetchForm("/api/upload", new FormData(), {
+      signal: controller.signal,
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal).not.toBe(controller.signal);
   });
 });


### PR DESCRIPTION
## Summary
- extend the shared frontend timeout/cancellation contract to `apiFetchForm()`
- reuse common request-error and FastAPI-detail extraction paths for JSON and multipart helpers
- add Vitest coverage for default upload signals, timeout message normalization, and caller-provided abort signals
- update SPEC.md for the #8248 API timeout hardening

Closes #8248

## Validation
- RED: `npm run test:run -- src/api/fetchTimeout.test.ts` failed 3 new #8248 tests before the implementation (`apiFetchForm` passed no signal and normalized timeout as generic network error)
- `npm run test:run -- src/api/fetchTimeout.test.ts`
- `npm run type-check`
- `npx eslint src/api/fetch.ts src/api/fetchTimeout.test.ts`
- `npx prettier --write src/api/fetch.ts src/api/fetchTimeout.test.ts ../SPEC.md`
- `git diff --check`
- `git -c http.https://github.com/.extraheader= push -u origin fix/8248-api-fetch-timeout` (pre-push: prettier and repo configured changed-file gates)

## Validation caveat
- `npm run lint` from `ui/` currently fails on pre-existing `CanonicalCoreShell.tsx` React lint violations unrelated to this change. Filed #8260 with the exact baseline failure and remediation plan.