### PR TITLE
Fix #8257: preserve URDF topology roots

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,11 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Hardened URDF model parsing so visual-less topology links
+  participate in root-link detection and joint endpoints must reference
+  declared links before the API returns model data. Renderable geometry remains
+  limited to links with visual elements, but the kinematic root now reflects the
+  declared URDF topology (#8257).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/src/api/routes/models.py
+++ b/src/api/routes/models.py
@@ -329,6 +329,13 @@ def _parse_urdf_links(
     return links
 
 
+def _parse_urdf_link_names(root: Any) -> list[str]:
+    """Parse all declared URDF link names, including visual-less topology nodes."""
+    if root is None:
+        raise ValueError("root must be provided")
+    return [link_elem.get("name", "unnamed") for link_elem in root.findall("link")]
+
+
 def _parse_urdf_joint_element(joint_elem: Any) -> URDFJointDescriptor:
     """Parse a single URDF <joint> element into a joint descriptor.
 
@@ -397,25 +404,43 @@ def _parse_urdf_joints(root: Any) -> tuple[list[URDFJointDescriptor], set[str]]:
     return joints, child_links
 
 
-def _find_root_link(links: list[URDFLinkGeometry], child_links: set[str]) -> str:
+def _validate_urdf_joint_links(
+    joints: list[URDFJointDescriptor], declared_link_names: set[str]
+) -> None:
+    """Ensure every joint endpoint references a declared URDF link."""
+    if joints is None:
+        raise ValueError("joints must be provided")
+    if declared_link_names is None:
+        raise ValueError("declared_link_names must be provided")
+    for joint in joints:
+        missing = [
+            link_name
+            for link_name in (joint.parent_link, joint.child_link)
+            if link_name not in declared_link_names
+        ]
+        if missing:
+            missing_list = ", ".join(missing)
+            raise ValueError(
+                f"Joint {joint.name!r} references undeclared link(s): {missing_list}"
+            )
+
+
+def _find_root_link(link_names: list[str], child_links: set[str]) -> str:
     """Identify the root link (not a child of any joint).
 
     Args:
-        links: Parsed link geometry descriptors.
+        link_names: All declared URDF link names, including visual-less links.
         child_links: Set of link names that appear as children in joints.
 
     Returns:
         Name of the root link, or "base" if none can be determined.
     """
-    if links is None:
-        raise ValueError("links must be provided")
-    all_link_names = {link.link_name for link in links}
-    root_candidates = all_link_names - child_links
-    return (
-        next(iter(root_candidates))
-        if root_candidates
-        else (links[0].link_name if links else "base")
-    )
+    if link_names is None:
+        raise ValueError("link_names must be provided")
+    for link_name in link_names:
+        if link_name not in child_links:
+            return link_name
+    return link_names[0] if link_names else "base"
 
 
 def _parse_urdf(urdf_content: str) -> URDFModelResponse:
@@ -443,9 +468,11 @@ def _parse_urdf(urdf_content: str) -> URDFModelResponse:
 
     model_name = root.get("name", "unknown")
     materials = _parse_urdf_materials(root)
+    link_names = _parse_urdf_link_names(root)
     links = _parse_urdf_links(root, materials)
     joints, child_links = _parse_urdf_joints(root)
-    root_link = _find_root_link(links, child_links)
+    _validate_urdf_joint_links(joints, set(link_names))
+    root_link = _find_root_link(link_names, child_links)
 
     return URDFModelResponse(
         model_name=model_name,

--- a/tests/api/test_phase3_api.py
+++ b/tests/api/test_phase3_api.py
@@ -592,6 +592,58 @@ class TestURDFParser:
         </robot>"""
         result = _parse_urdf(urdf)
         assert result.joints[0].joint_type == "fixed"
+        assert result.root_link == "world"
+        assert [link.link_name for link in result.links] == ["base"]
+
+    def test_parse_visual_less_intermediate_link_keeps_topology_root(self) -> None:
+        """Visual-less topology links still participate in root detection."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="visual_child_test">
+          <link name="world"/>
+          <link name="mount"/>
+          <link name="sensor">
+            <visual>
+              <geometry><sphere radius="0.05"/></geometry>
+            </visual>
+          </link>
+          <joint name="world_to_mount" type="fixed">
+            <parent link="world"/>
+            <child link="mount"/>
+          </joint>
+          <joint name="mount_to_sensor" type="fixed">
+            <parent link="mount"/>
+            <child link="sensor"/>
+          </joint>
+        </robot>"""
+
+        result = _parse_urdf(urdf)
+
+        assert result.root_link == "world"
+        assert [link.link_name for link in result.links] == ["sensor"]
+        assert [(joint.parent_link, joint.child_link) for joint in result.joints] == [
+            ("world", "mount"),
+            ("mount", "sensor"),
+        ]
+
+    def test_parse_joint_rejects_links_not_declared_in_topology(self) -> None:
+        """Every parsed joint endpoint must reference a declared URDF link."""
+        from src.api.routes.models import _parse_urdf
+
+        urdf = """<robot name="dangling_joint_test">
+          <link name="base">
+            <visual>
+              <geometry><box size="1 1 1"/></geometry>
+            </visual>
+          </link>
+          <joint name="missing_child" type="fixed">
+            <parent link="base"/>
+            <child link="ghost"/>
+          </joint>
+        </robot>"""
+
+        with pytest.raises(ValueError, match="ghost"):
+            _parse_urdf(urdf)
 
     def test_parse_invalid_xml(self) -> None:
         """Invalid XML raises ValueError."""


### PR DESCRIPTION
## Summary
- parse declared URDF link names separately from renderable visual geometry
- compute `root_link` from full topology, including visual-less world/base links
- reject joints whose parent or child endpoint is not a declared link
- add focused parser regressions for visual-less root/intermediate topology and dangling joint links
- update SPEC.md for the #8257 parser hardening

Closes #8257

## Validation
- RED: new focused parser tests failed on current behavior (`root_link` returned `base`/`sensor`; dangling `ghost` child was accepted)
- `py -3.13 -m pytest tests\api\test_phase3_api.py::TestURDFParser::test_parse_fixed_joint tests\api\test_phase3_api.py::TestURDFParser::test_parse_visual_less_intermediate_link_keeps_topology_root tests\api\test_phase3_api.py::TestURDFParser::test_parse_joint_rejects_links_not_declared_in_topology -q`
- `py -3.13 -m pytest tests\api\test_phase3_api.py -q`
- `py -3.13 -m ruff format src\api\routes\models.py tests\api\test_phase3_api.py`
- `py -3.13 -m ruff check src\api\routes\models.py tests\api\test_phase3_api.py`
- `npx prettier --write SPEC.md`
- `git diff --check`
- `git -c http.https://github.com/.extraheader= push -u origin fix/8257-urdf-root-links` (pre-push: ruff, ruff format, formatter guidance, wildcard/debug/print guards, prettier, mypy, bandit, pytest-unit)