### PR TITLE
Fix #8260: restore Canonical Core UI lint baseline

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,9 +40,10 @@
 | **Current Version**     | 2.1.1                                              |
 
 <<<<<<< HEAD
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-07-28 |
 =======
+
 | **Spec Version** | 1.0.468 |
 | **Last Spec Update** | 2026-07-25 |
 
@@ -77,6 +78,11 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-07-28** - Restored the clean UI lint baseline by moving
+  canonical-core status parsing into a non-component API module and changing
+  the Canonical Core shell mount effect to load status through an async
+  effect-local path instead of synchronously invoking a state-setting callback
+  (#8260).
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains

--- a/ui/src/api/canonicalCoreStatus.ts
+++ b/ui/src/api/canonicalCoreStatus.ts
@@ -1,0 +1,56 @@
+type CanonicalCoreMode = "estimation" | "comparison";
+
+/** Mirrors `CanonicalCoreStatus` in `src/api/routes/canonical_core.py`. */
+export interface CanonicalCoreStatus {
+  tool_id: string;
+  mode: string;
+  name: string;
+  description: string;
+  web_route: string;
+  capabilities: string[];
+  available: boolean;
+  reason: string;
+  next_step: string;
+}
+
+export const CANONICAL_CORE_FALLBACK_TITLE: Record<CanonicalCoreMode, string> =
+  {
+    estimation: "Canonical-Core Estimation",
+    comparison: "Canonical-Core Comparison",
+  };
+
+/**
+ * Validate the status payload at runtime.
+ *
+ * The backend ships separately from the UI, so a shape mismatch must surface
+ * as the page's error state rather than as a render-time TypeError.
+ *
+ * @param raw - Parsed JSON body.
+ * @returns The validated status.
+ * @throws Error when a required field is missing or mistyped.
+ */
+export function parseCanonicalCoreStatus(raw: unknown): CanonicalCoreStatus {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("Canonical-core status response was not an object");
+  }
+  const body = raw as Record<string, unknown>;
+  if (typeof body.mode !== "string" || body.mode.length === 0) {
+    throw new Error('Canonical-core status response is missing "mode"');
+  }
+  if (typeof body.available !== "boolean") {
+    throw new Error('Canonical-core status response is missing "available"');
+  }
+  return {
+    tool_id: typeof body.tool_id === "string" ? body.tool_id : "",
+    mode: body.mode,
+    name: typeof body.name === "string" ? body.name : "",
+    description: typeof body.description === "string" ? body.description : "",
+    web_route: typeof body.web_route === "string" ? body.web_route : "",
+    capabilities: Array.isArray(body.capabilities)
+      ? body.capabilities.filter((c): c is string => typeof c === "string")
+      : [],
+    available: body.available,
+    reason: typeof body.reason === "string" ? body.reason : "",
+    next_step: typeof body.next_step === "string" ? body.next_step : "",
+  };
+}

--- a/ui/src/pages/CanonicalCoreShell.test.tsx
+++ b/ui/src/pages/CanonicalCoreShell.test.tsx
@@ -13,42 +13,40 @@
  * service cannot be reached.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-vi.mock('@/api/fetch', () => ({
+vi.mock("@/api/fetch", () => ({
   apiFetch: vi.fn(),
   apiFetchForm: vi.fn(),
 }));
 
-import { apiFetch } from '@/api/fetch';
-import {
-  CanonicalCoreShellPage,
-  parseCanonicalCoreStatus,
-} from './CanonicalCoreShell';
+import { apiFetch } from "@/api/fetch";
+import { parseCanonicalCoreStatus } from "@/api/canonicalCoreStatus";
+import { CanonicalCoreShellPage } from "./CanonicalCoreShell";
 
 const mockedApiFetch = vi.mocked(apiFetch);
 
 const UNAVAILABLE_ESTIMATION = {
-  tool_id: 'canonical_core_estimation',
-  mode: 'estimation',
-  name: 'Canonical-Core Estimation',
-  description: 'Workspace entry point for CC-19 estimation services.',
-  web_route: '/tools/canonical-core/estimation',
-  capabilities: ['canonical_core', 'estimation'],
+  tool_id: "canonical_core_estimation",
+  mode: "estimation",
+  name: "Canonical-Core Estimation",
+  description: "Workspace entry point for CC-19 estimation services.",
+  web_route: "/tools/canonical-core/estimation",
+  capabilities: ["canonical_core", "estimation"],
   available: false,
-  reason: 'The canonical-core estimation service is not implemented yet.',
-  next_step: 'Track CC-19 for the estimation service.',
+  reason: "The canonical-core estimation service is not implemented yet.",
+  next_step: "Track CC-19 for the estimation service.",
 };
 
 beforeEach(() => {
   mockedApiFetch.mockReset();
 });
 
-describe('canonical-core unavailable state (#8081)', () => {
-  it.each(['estimation', 'comparison'] as const)(
-    'renders reason and next step for %s',
+describe("canonical-core unavailable state (#8081)", () => {
+  it.each(["estimation", "comparison"] as const)(
+    "renders reason and next step for %s",
     async (mode) => {
       mockedApiFetch.mockResolvedValue({
         ...UNAVAILABLE_ESTIMATION,
@@ -59,112 +57,128 @@ describe('canonical-core unavailable state (#8081)', () => {
 
       render(<CanonicalCoreShellPage mode={mode} />);
 
-      const panel = await screen.findByTestId('canonical-core-unavailable');
-      expect(panel).toHaveTextContent('Workspace not available yet');
+      const panel = await screen.findByTestId("canonical-core-unavailable");
+      expect(panel).toHaveTextContent("Workspace not available yet");
       expect(panel).toHaveTextContent(`canonical-core ${mode} service`);
-      expect(panel).toHaveTextContent('Next step');
+      expect(panel).toHaveTextContent("Next step");
       expect(panel).toHaveTextContent(`Track the ${mode} service issue.`);
     },
   );
 
-  it('queries the status route for the mode it renders', async () => {
-    mockedApiFetch.mockResolvedValue({ ...UNAVAILABLE_ESTIMATION, mode: 'comparison' });
+  it("queries the status route for the mode it renders", async () => {
+    mockedApiFetch.mockResolvedValue({
+      ...UNAVAILABLE_ESTIMATION,
+      mode: "comparison",
+    });
 
     render(<CanonicalCoreShellPage mode="comparison" />);
 
-    await screen.findByTestId('canonical-core-unavailable');
+    await screen.findByTestId("canonical-core-unavailable");
     expect(mockedApiFetch).toHaveBeenCalledWith(
-      '/api/tools/canonical-core/comparison/status',
+      "/api/tools/canonical-core/comparison/status",
     );
   });
 
-  it('renders capabilities reported by the service', async () => {
+  it("renders capabilities reported by the service", async () => {
     mockedApiFetch.mockResolvedValue(UNAVAILABLE_ESTIMATION);
 
     render(<CanonicalCoreShellPage mode="estimation" />);
 
-    const caps = await screen.findByTestId('canonical-core-capabilities');
-    expect(caps).toHaveTextContent('canonical_core');
-    expect(caps).toHaveTextContent('estimation');
+    const caps = await screen.findByTestId("canonical-core-capabilities");
+    expect(caps).toHaveTextContent("canonical_core");
+    expect(caps).toHaveTextContent("estimation");
   });
 });
 
-describe('canonical-core service error state (#8081)', () => {
-  it('shows an actionable error with retry when the service is unreachable', async () => {
-    mockedApiFetch.mockRejectedValue(new Error('API route not found'));
+describe("canonical-core service error state (#8081)", () => {
+  it("shows an actionable error with retry when the service is unreachable", async () => {
+    mockedApiFetch.mockRejectedValue(new Error("API route not found"));
 
     render(<CanonicalCoreShellPage mode="estimation" />);
 
-    const alert = await screen.findByTestId('canonical-core-error');
-    expect(alert).toHaveTextContent('Canonical-core service unreachable');
-    expect(alert).toHaveTextContent('API route not found');
+    const alert = await screen.findByTestId("canonical-core-error");
+    expect(alert).toHaveTextContent("Canonical-core service unreachable");
+    expect(alert).toHaveTextContent("API route not found");
     expect(alert).toHaveTextContent(/API server is running/i);
-    expect(screen.getByTestId('canonical-core-retry')).toBeInTheDocument();
-    expect(screen.queryByTestId('canonical-core-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId("canonical-core-retry")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("canonical-core-loading"),
+    ).not.toBeInTheDocument();
   });
 
-  it('retry re-issues the request and recovers', async () => {
+  it("retry re-issues the request and recovers", async () => {
     const user = userEvent.setup();
     mockedApiFetch
-      .mockRejectedValueOnce(new Error('Data service unreachable'))
+      .mockRejectedValueOnce(new Error("Data service unreachable"))
       .mockResolvedValueOnce(UNAVAILABLE_ESTIMATION);
 
     render(<CanonicalCoreShellPage mode="estimation" />);
-    await screen.findByTestId('canonical-core-error');
+    await screen.findByTestId("canonical-core-error");
 
-    await user.click(screen.getByTestId('canonical-core-retry'));
+    await user.click(screen.getByTestId("canonical-core-retry"));
 
     await waitFor(() => {
-      expect(screen.getByTestId('canonical-core-unavailable')).toBeInTheDocument();
+      expect(
+        screen.getByTestId("canonical-core-unavailable"),
+      ).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('canonical-core-error')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("canonical-core-error"),
+    ).not.toBeInTheDocument();
   });
 
-  it('treats a malformed payload as an error, not a blank shell', async () => {
+  it("treats a malformed payload as an error, not a blank shell", async () => {
     mockedApiFetch.mockResolvedValue({ unexpected: true });
 
     render(<CanonicalCoreShellPage mode="estimation" />);
 
-    const alert = await screen.findByTestId('canonical-core-error');
+    const alert = await screen.findByTestId("canonical-core-error");
     expect(alert).toHaveTextContent(/missing "mode"/i);
   });
 });
 
-describe('canonical-core available state (#8081)', () => {
-  it('renders the workspace once a service reports available', async () => {
+describe("canonical-core available state (#8081)", () => {
+  it("renders the workspace once a service reports available", async () => {
     mockedApiFetch.mockResolvedValue({
       ...UNAVAILABLE_ESTIMATION,
       available: true,
-      reason: '',
-      next_step: '',
+      reason: "",
+      next_step: "",
     });
 
     render(<CanonicalCoreShellPage mode="estimation" />);
 
-    expect(await screen.findByTestId('canonical-core-available')).toHaveTextContent(
-      'Service available',
-    );
-    expect(screen.queryByTestId('canonical-core-unavailable')).not.toBeInTheDocument();
+    expect(
+      await screen.findByTestId("canonical-core-available"),
+    ).toHaveTextContent("Service available");
+    expect(
+      screen.queryByTestId("canonical-core-unavailable"),
+    ).not.toBeInTheDocument();
   });
 });
 
-describe('parseCanonicalCoreStatus', () => {
-  it('accepts a well-formed payload', () => {
-    expect(parseCanonicalCoreStatus(UNAVAILABLE_ESTIMATION).mode).toBe('estimation');
+describe("parseCanonicalCoreStatus", () => {
+  it("accepts a well-formed payload", () => {
+    expect(parseCanonicalCoreStatus(UNAVAILABLE_ESTIMATION).mode).toBe(
+      "estimation",
+    );
   });
 
   it.each([
     [null, /not an object/i],
-    ['a string', /not an object/i],
+    ["a string", /not an object/i],
     [{ available: false }, /missing "mode"/i],
-    [{ mode: '' , available: false }, /missing "mode"/i],
-    [{ mode: 'estimation' }, /missing "available"/i],
-  ])('rejects %j', (raw, pattern) => {
+    [{ mode: "", available: false }, /missing "mode"/i],
+    [{ mode: "estimation" }, /missing "available"/i],
+  ])("rejects %j", (raw, pattern) => {
     expect(() => parseCanonicalCoreStatus(raw)).toThrow(pattern as RegExp);
   });
 
-  it('tolerates a missing capabilities list', () => {
-    const parsed = parseCanonicalCoreStatus({ mode: 'estimation', available: false });
+  it("tolerates a missing capabilities list", () => {
+    const parsed = parseCanonicalCoreStatus({
+      mode: "estimation",
+      available: false,
+    });
     expect(parsed.capabilities).toEqual([]);
   });
 });

--- a/ui/src/pages/CanonicalCoreShell.tsx
+++ b/ui/src/pages/CanonicalCoreShell.tsx
@@ -16,103 +16,81 @@
  * and available (the workspace, once a service exists).
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { apiFetch } from '@/api/fetch';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { apiFetch } from "@/api/fetch";
+import {
+  CANONICAL_CORE_FALLBACK_TITLE,
+  type CanonicalCoreStatus,
+  parseCanonicalCoreStatus,
+} from "@/api/canonicalCoreStatus";
 
-type CanonicalCoreMode = 'estimation' | 'comparison';
+type CanonicalCoreMode = "estimation" | "comparison";
 
-type LoadStatus = 'loading' | 'ready' | 'error';
-
-/** Mirrors `CanonicalCoreStatus` in `src/api/routes/canonical_core.py`. */
-export interface CanonicalCoreStatus {
-  tool_id: string;
-  mode: string;
-  name: string;
-  description: string;
-  web_route: string;
-  capabilities: string[];
-  available: boolean;
-  reason: string;
-  next_step: string;
-}
+type LoadStatus = "loading" | "ready" | "error";
 
 interface CanonicalCoreShellPageProps {
   mode: CanonicalCoreMode;
 }
 
-const FALLBACK_TITLE: Record<CanonicalCoreMode, string> = {
-  estimation: 'Canonical-Core Estimation',
-  comparison: 'Canonical-Core Comparison',
-};
-
-/**
- * Validate the status payload at runtime.
- *
- * The backend ships separately from the UI, so a shape mismatch must surface
- * as the page's error state rather than as a render-time TypeError.
- *
- * @param raw - Parsed JSON body.
- * @returns The validated status.
- * @throws Error when a required field is missing or mistyped.
- */
-export function parseCanonicalCoreStatus(raw: unknown): CanonicalCoreStatus {
-  if (typeof raw !== 'object' || raw === null) {
-    throw new Error('Canonical-core status response was not an object');
-  }
-  const body = raw as Record<string, unknown>;
-  if (typeof body.mode !== 'string' || body.mode.length === 0) {
-    throw new Error('Canonical-core status response is missing "mode"');
-  }
-  if (typeof body.available !== 'boolean') {
-    throw new Error('Canonical-core status response is missing "available"');
-  }
-  return {
-    tool_id: typeof body.tool_id === 'string' ? body.tool_id : '',
-    mode: body.mode,
-    name: typeof body.name === 'string' ? body.name : '',
-    description: typeof body.description === 'string' ? body.description : '',
-    web_route: typeof body.web_route === 'string' ? body.web_route : '',
-    capabilities: Array.isArray(body.capabilities)
-      ? body.capabilities.filter((c): c is string => typeof c === 'string')
-      : [],
-    available: body.available,
-    reason: typeof body.reason === 'string' ? body.reason : '',
-    next_step: typeof body.next_step === 'string' ? body.next_step : '',
-  };
-}
-
 export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
   const [status, setStatus] = useState<CanonicalCoreStatus | null>(null);
-  const [loadStatus, setLoadStatus] = useState<LoadStatus>('loading');
+  const [loadStatus, setLoadStatus] = useState<LoadStatus>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const route = useMemo(() => `/tools/canonical-core/${mode}`, [mode]);
 
+  const fetchStatusReport = useCallback(async () => {
+    const raw = await apiFetch<unknown>(
+      `/api/tools/canonical-core/${mode}/status`,
+    );
+    return parseCanonicalCoreStatus(raw);
+  }, [mode]);
+
   const loadStatusReport = useCallback(async () => {
-    setLoadStatus('loading');
+    setLoadStatus("loading");
     setLoadError(null);
     try {
-      const raw = await apiFetch<unknown>(
-        `/api/tools/canonical-core/${mode}/status`,
-      );
-      setStatus(parseCanonicalCoreStatus(raw));
-      setLoadStatus('ready');
+      setStatus(await fetchStatusReport());
+      setLoadStatus("ready");
     } catch (err) {
       setStatus(null);
-      setLoadStatus('error');
+      setLoadStatus("error");
       setLoadError(
         err instanceof Error
           ? err.message
-          : 'Failed to reach the canonical-core service',
+          : "Failed to reach the canonical-core service",
       );
     }
-  }, [mode]);
+  }, [fetchStatusReport]);
 
   useEffect(() => {
-    void loadStatusReport();
-  }, [loadStatusReport]);
+    let isMounted = true;
 
-  const title = status?.name || FALLBACK_TITLE[mode];
+    async function loadInitialStatusReport() {
+      try {
+        const nextStatus = await fetchStatusReport();
+        if (!isMounted) return;
+        setStatus(nextStatus);
+        setLoadStatus("ready");
+      } catch (err) {
+        if (!isMounted) return;
+        setStatus(null);
+        setLoadStatus("error");
+        setLoadError(
+          err instanceof Error
+            ? err.message
+            : "Failed to reach the canonical-core service",
+        );
+      }
+    }
+
+    void loadInitialStatusReport();
+    return () => {
+      isMounted = false;
+    };
+  }, [fetchStatusReport]);
+
+  const title = status?.name || CANONICAL_CORE_FALLBACK_TITLE[mode];
 
   return (
     <main className="min-h-screen bg-gray-950 text-gray-100">
@@ -129,7 +107,7 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
           )}
         </header>
 
-        {loadStatus === 'loading' && (
+        {loadStatus === "loading" && (
           <div
             className="rounded-md border border-gray-800 bg-gray-900 p-5 text-sm text-gray-300"
             data-testid="canonical-core-loading"
@@ -138,7 +116,7 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
           </div>
         )}
 
-        {loadStatus === 'error' && (
+        {loadStatus === "error" && (
           <div
             className="space-y-3 rounded-md border border-red-500/40 bg-red-950/30 p-5"
             data-testid="canonical-core-error"
@@ -148,7 +126,7 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
               Canonical-core service unreachable
             </h2>
             <p className="break-words text-sm leading-6 text-red-200/80">
-              {loadError ?? 'The service did not respond.'}
+              {loadError ?? "The service did not respond."}
             </p>
             <p className="text-sm leading-6 text-gray-400">
               Check that the API server is running, then retry.
@@ -164,7 +142,7 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
           </div>
         )}
 
-        {loadStatus === 'ready' && status && !status.available && (
+        {loadStatus === "ready" && status && !status.available && (
           <div
             className="space-y-3 rounded-md border border-amber-500/40 bg-amber-950/20 p-5"
             data-testid="canonical-core-unavailable"
@@ -186,7 +164,7 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
           </div>
         )}
 
-        {loadStatus === 'ready' && status?.available && (
+        {loadStatus === "ready" && status?.available && (
           <div
             className="rounded-md border border-emerald-500/40 bg-emerald-950/20 p-5"
             data-testid="canonical-core-available"
@@ -209,14 +187,19 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
             </p>
           </section>
           <section className="rounded-md border border-gray-800 bg-gray-900 p-5">
-            <h2 className="text-sm font-semibold text-gray-100">Capabilities</h2>
+            <h2 className="text-sm font-semibold text-gray-100">
+              Capabilities
+            </h2>
             {status && status.capabilities.length > 0 ? (
               <ul
                 className="mt-3 space-y-1 text-sm leading-6 text-gray-300"
                 data-testid="canonical-core-capabilities"
               >
                 {status.capabilities.map((capability) => (
-                  <li key={capability} className="font-mono text-xs text-cyan-200">
+                  <li
+                    key={capability}
+                    className="font-mono text-xs text-cyan-200"
+                  >
                     {capability}
                   </li>
                 ))}
@@ -229,7 +212,9 @@ export function CanonicalCoreShellPage({ mode }: CanonicalCoreShellPageProps) {
           </section>
           <section className="rounded-md border border-gray-800 bg-gray-900 p-5">
             <h2 className="text-sm font-semibold text-gray-100">Route</h2>
-            <p className="mt-3 break-words font-mono text-sm text-cyan-200">{route}</p>
+            <p className="mt-3 break-words font-mono text-sm text-cyan-200">
+              {route}
+            </p>
           </section>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- move canonical-core status parsing/types/fallback title into a non-component API module
- refactor the initial status load effect to await the API request before setting state, with an unmount guard
- keep the explicit retry path and existing unavailable/error/available UI behavior intact
- update SPEC.md for the restored UI lint baseline

Closes #8260

## Validation
- RED: `npm run lint` failed on `CanonicalCoreShell.tsx` with `react-refresh/only-export-components` and `react-hooks/set-state-in-effect`
- `npm run test:run -- src/pages/CanonicalCoreShell.test.tsx`
- `npm run lint`
- `npm run type-check`
- `npx prettier --write ui/src/api/canonicalCoreStatus.ts ui/src/pages/CanonicalCoreShell.tsx ui/src/pages/CanonicalCoreShell.test.tsx SPEC.md`
- `git diff --check`
- `git -c http.https://github.com/.extraheader= push -u origin fix/8260-canonical-core-lint` (pre-push changed-file gates)