### PR TITLE
Launch monitor analytics and interdependency workbench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,32 @@ plot_cartesian_delta_summary, summarize_for_pr_comment}` —
   (`load_club_target_excel.m` line 53: `CM_TO_METRES = 0.01`) is the
   source of truth — see `MATLAB_GOLF_MODEL_GUIDE.md`.
 
+### Launch Monitor Analytics
+
+`src/shared/python/launch_monitor/` is the canonical vendor-neutral shot-data
+stack. Use it for TrackMan, Foresight, FlightScope, Garmin, SkyTrak, Uneekor,
+Full Swing, Rapsodo, GSPro/Open Connect, or generic tabular imports instead of
+adding a one-off CSV reader.
+
+- `import_session` and `detect_profile` — format/header discovery, unit
+  normalization, raw-column retention, and SHA-256 provenance.
+- `LaunchMonitorProject` — multi-session aggregation, portable persistence,
+  and durable treatment audit records.
+- `apply_treatment` — structured filters, missing/duplicate/outlier flags, and
+  explicitly labeled identity-derived metrics.
+- `compute_correlations`, `compute_pca`, `compute_vif`, and
+  `fit_predictive_model` — interdependency and predictive analysis with
+  leakage warnings and reproducible splits.
+- `compare_monitors`, `analyze_dispersion`, and `analyze_trend` — matched or
+  descriptive monitor comparison, shot-pattern ellipses, and longitudinal
+  change analysis.
+- `src/tools/launch_monitor_analytics/` — the PyQt6 workbench; keep new
+  analysis logic in the headless shared package.
+
+See ADR 0031 and `docs/user_guide/launch_monitor_analytics.md`. Correlation and
+predictive performance do not establish causality; unmatched monitor
+comparisons are not calibration evidence.
+
 ### Logging / config
 
 - `src/shared/python/logging_pkg/logging_config.get_logger(__name__)`

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,8 +39,8 @@
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-| **Spec Version** | 1.0.479 |
-| **Last Spec Update** | 2026-07-27 |
+| **Spec Version** | 1.0.480 |
+| **Last Spec Update** | 2026-08-04 |
 
 ## 2. Purpose & Mission
 
@@ -71,6 +71,15 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-08-04** - Added the vendor-neutral Launch Monitor Analytics workbench
+  (#8342). A canonical, unit-normalized shot schema and provenance-preserving
+  import pipeline aggregate common TrackMan, Foresight, FlightScope, Garmin,
+  SkyTrak, Uneekor, Full Swing, Rapsodo, and GSPro/Open Connect exports, with a
+  generic mapping fallback. The PyQt6 workbench provides auditable treatment,
+  correlation and partial-correlation mapping, regularized regression and an
+  optional shallow neural network, matched-monitor agreement, dispersion, and
+  actual-time longitudinal trend analysis. Associations and predictions are
+  explicitly non-causal; unmatched monitor comparisons are descriptive only.
 - **2026-07-27** - Corrected classic PyQt6 Diagnostics provider-manifest
   validation (#8121). The parent `models.yaml` check now validates only its 46
   directly declared tiles, while the separate runtime registry check retains
@@ -1409,6 +1418,7 @@ UpstreamDrift/
 │   ├── tools/                      # Embeddable tool tabs (model_explorer,
 │   │                               # ball_flight_gui, putting_green_gui,
 │   │                               # swing_flight_pipeline, pose_studio,
+│   │                               # launch_monitor_analytics,
 │   │                               # video_analyzer, sidekick, …) plus
 │   │                               # headless analysis CLIs (drift_control,
 │   │                               # contraction)
@@ -1416,6 +1426,7 @@ UpstreamDrift/
 │       ├── engine_core/            # EngineManager/Registry/probes/capabilities
 │       ├── launcher_embed/         # EmbeddableTool contract + registry (ADR-0013)
 │       ├── physics/                # Ball flight models, impact, swing→flight pipeline
+│       ├── launch_monitor/         # Canonical shot import, treatment, and analytics
 │       ├── motion_pipeline/        # Mocap ingestion (C3D/TRC/BVH), IK backends
 │       ├── model_generation/       # URDF/MJCF parsing, Frankenstein editor (VENDORED)
 │       ├── sidekick/               # Shared tools library + agent layer (VENDORED)
@@ -1456,6 +1467,7 @@ UpstreamDrift/
 | Rust Physics Kernels     | `rust_core/upstream-physics/`            | High-performance compiled physics routines for critical paths, including initial flexible shaft FEM element primitives |
 | Configuration Manager    | `src/config/`                            | Centralized configuration loading, validation, and environment management                   |
 | Analysis Tool CLIs       | `src/tools/drift_control/`, `src/tools/contraction/` | Headless AffineDrift-compatible drift/control, contraction, and Floquet analysis tools |
+| Launch Monitor Analytics | `src/tools/launch_monitor_analytics/`, `src/shared/python/launch_monitor/` | PyQt6 and headless vendor-neutral launch-monitor import, dependency, model, agreement, dispersion, and trend analysis |
 | Shared Utilities         | `src/shared/`                            | Cross-engine validators, helpers, and exception definitions                                 |
 | Workspace Metadata       | `src/shared/python/workspace/`           | Project/session/dataset metadata store and CC-4 HDF5 result browser view models            |
 | URDF Models              | `shared/models/`                         | Canonical model definitions (URDF format) for golf swings, human body, pendulums            |
@@ -1578,6 +1590,7 @@ Engine tier metadata is declared in each in-scope engine package with
 | ------------------------ | ------------- | ------------------------------- | -------------------------------------------------------- |
 | Biomechanical Models     | URDF          | `shared/models/`                | URDF 1.0 standard with custom muscle actuator extensions |
 | Motion Capture Data      | C3D, BVH, TRC | External mocap systems or files | Standard formats with marker sets and frame data         |
+| Launch Monitor Sessions  | CSV, TSV, TXT, XLS, XLSX, JSON | Common launch-monitor exports or user-mapped files | Canonical shot schema with source columns, unit/status metadata, and import manifest |
 | Optimization Constraints | JSON          | User input or configuration     | Custom constraint schema in `src/config/`                |
 | Control Parameters       | YAML/JSON     | Configuration files or API      | Engine-specific parameter maps validated against schemas |
 
@@ -1590,6 +1603,7 @@ Engine tier metadata is declared in each in-scope engine package with
 | IK/ID Solutions          | JSON/MATLAB            | API response or file        | Joint angles (IK) and joint torques (ID) with confidence metrics   |
 | Optimized Trajectories   | URDF/MATLAB            | File export                 | Trajectory-optimized model definitions with optimal control inputs |
 | Visualization Data       | JSON (Three.js format) | GUI or web client           | 3D geometry, animation keyframes, and rendering parameters         |
+| Launch Monitor Analytics | CSV/JSON/project bundle | GUI or file export | Treated observations, provenance manifests, association/model results, dispersion, and trend summaries |
 
 ### Configuration
 

--- a/docs/adr/0031-launch-monitor-canonical-shot-schema.md
+++ b/docs/adr/0031-launch-monitor-canonical-shot-schema.md
@@ -1,0 +1,85 @@
+# ADR 0031: Canonical Launch Monitor Shot Schema
+
+- Status: Accepted
+- Date: 2026-08-04
+- Decision Makers: UpstreamDrift Maintainers
+- Related Issues/PRs: [#8342](https://github.com/D-sorganization/UpstreamDrift/issues/8342)
+
+## Context
+
+Launch-monitor exports differ by vendor, device, software version, locale,
+selected report, and subscription entitlement. Several fields also differ in
+meaning: a vendor may measure a value, estimate it, derive it from other fields,
+or omit it. A narrow dataclass containing only shared fields would discard the
+vendor-specific variables that make interdependency research valuable. A raw
+table alone would make cross-vendor analysis unsafe because units and naming
+would remain ambiguous.
+
+The research questions are observational. Correlation, regularized regression,
+feature importance, and shallow neural networks can reveal predictive structure,
+but cannot identify causal impact physics without an experimental design.
+Identity-derived variables also create deterministic leakage. For example,
+smash factor contains ball speed by definition.
+
+## Decision
+
+Use a two-layer, wide shot table:
+
+1. Canonical columns use stable names and units from `METRICS` in
+   `src/shared/python/launch_monitor/schema.py`. Speeds are m/s, distances are
+   metres, angles are radians, spin is rad/s, and time is seconds.
+2. Every original field is retained as `source::<exact header>`. The import
+   manifest records the original header, source unit, unit evidence, SHA-256,
+   source row, profile, and warnings.
+
+Reported canonical values carry a `status::<metric>` column. The initial status
+vocabulary is `reported`, `measured`, `estimated`, `derived`, and `unknown`.
+`reported` is deliberately conservative when an export does not reveal whether
+the vendor measured or estimated the value.
+
+Vendor adapters are header-fingerprint profiles layered over a generic mapping
+workflow. They are not rigid parsers that claim all historical releases use one
+layout. Unknown fields survive import. Users can override the profile, mapping,
+unit, sign multiplier, and measurement status before committing an import.
+
+The project file stores original imported sessions and a durable treatment audit
+log. Treatment produces a separate analysis view; it does not overwrite raw
+sessions. Matched-shot cross-monitor comparisons are distinct from unmatched,
+descriptive comparisons.
+
+## Alternatives Considered
+
+1. One dataclass per vendor: rejected because it fragments aggregation and
+   duplicates analysis logic.
+2. Only a lowest-common-denominator schema: rejected because it discards rare
+   club-delivery, putting, and vendor-quality fields.
+3. Store only raw exports and map at analysis time: rejected because unit and
+   convention errors would be repeated throughout the analysis stack.
+4. Treat all reported values as measured: rejected because several devices and
+   configurations estimate some metrics, and export files do not always expose
+   that distinction.
+
+## Consequences
+
+- Positive: imports are auditable, extensible, loss-minimizing, and safe to
+  aggregate across sessions.
+- Positive: headless analysis does not depend on PyQt6; MLP support imports
+  scikit-learn lazily.
+- Positive: deterministic identities and derivations can be marked and excluded
+  from predictors.
+- Negative: project tables are wider than a lowest-common-denominator table.
+- Negative: a new or localized export can require mapping review even when its
+  vendor is recognized.
+- Follow-up: add verified profiles when maintainers receive legally shareable,
+  versioned sample exports; do not infer private protocols.
+
+## Validation
+
+- Vendor-shaped fixtures cover TrackMan, Foresight, FlightScope, Garmin,
+  SkyTrak, and Uneekor header families.
+- Unit, provenance, raw-field preservation, project persistence, filtering,
+  derivation status, statistics, predictive models, monitor comparison,
+  dispersion, trends, and PyQt6 embed behavior have focused tests.
+- The launcher manifest and feature-parity registry include the workbench.
+- Ruff, format, file/module size, focused tests, and offscreen GUI rendering are
+  required before merge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,30 +11,31 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 
 ## Index
 
-| ADR                                                | Title                                                           | Status   | Date       |
-| -------------------------------------------------- | --------------------------------------------------------------- | -------- | ---------- |
-| [0001](0001-fastapi-local-first-api.md)            | FastAPI for Local-First API Design                              | Accepted | 2026-02-18 |
-| [0002](0002-physics-engine-plugin-architecture.md) | Physics Engine Plugin Architecture                              | Accepted | 2026-02-18 |
-| [0003](0003-websocket-realtime-simulation.md)      | WebSocket Protocol for Real-Time Simulation                     | Accepted | 2026-02-18 |
-| [0004](0004-launcher-provider-migration.md)        | Launcher Provider Migration Modes and Legacy Deprecation Policy | Accepted | 2026-04-08 |
-| [0005](0005-rust-tools-core-git-dependency.md)     | Pin `tools-core` as a Git Dependency                            | Accepted | 2026-04-23 |
-| [0006](0006-multi-source-motion-targets.md)        | Multi-Source Motion Targets                                     | Accepted | 2026-05-08 |
-| [0007](0007-motion-pipeline-architecture.md)       | Motion Pipeline Architecture (CIR)                              | Proposed | 2026-05-08 |
-| [0012](0012-canonical-pose-interchange.md)         | Canonical Pose Interchange                                      | Accepted | 2026-05-09 |
-| [0013](0013-launcher-composability.md)             | Launcher Composability — Embeddable-tool contract and IPC layer | Accepted | 2026-05-09 |
-| [0017](0017-sidekick-agentic-action-layer.md)      | Sidekick agentic action layer                                   | Accepted | 2026-05-22 |
-| [0018](0018-standalone-sidekick.md)                | Standalone Sidekick Application                                 | Accepted | 2026-05-23 |
-| [0019](0019-mission-drift-calculators.md)          | Mission-Drift Calculators                                       | Accepted | 2026-04-25 |
-| [0020](0020-canonical-urdf-subsystem.md)           | Canonical URDF subsystem                                        | Accepted | 2026-05-08 |
-| [0021](0021-container-strategy.md)                 | Container Strategy — Three-Dockerfile Policy                    | Accepted | 2026-05-25 |
-| [0022](0022-chat-sidekick-boundary.md)             | Chat Sidekick Boundary                                          | Accepted | 2026-06-12 |
-| [0023](0023-mujoco-warp-backend.md)                | MuJoCo Warp GPU + MuJoCo CPU backends behind one Protocol       | Accepted | 2026-05-29 |
-| [0024](0024-differentiable-backend.md)             | Differentiable backend — MJX (JAX) vs custom Warp kernels       | Accepted | 2026-05-29 |
-| [0025](0025-jaxsim-backend-home.md)                | JaxSim Backend Home                                             | Accepted | 2026-05-30 |
-| [0026](0026-canonical-dynamic-state-v2.md)         | Canonical Dynamic State v2                                      | Accepted | 2026-05-31 |
-| [0027](0027-canonical-viewport-backend.md)         | Canonical 3D Viewport Backend                                   | Accepted | 2026-05-31 |
-| [0028](0028-react-tauri-launcher-parity.md)        | React/Tauri launcher parity model                               | Accepted | 2026-06-10 |
-| [0030](0030-c3d-viewer-renderer-backend.md)        | C3D Viewer Renderer Backend                                     | Accepted | 2026-06-10 |
+| ADR                                                  | Title                                                           | Status   | Date       |
+| ---------------------------------------------------- | --------------------------------------------------------------- | -------- | ---------- |
+| [0001](0001-fastapi-local-first-api.md)              | FastAPI for Local-First API Design                              | Accepted | 2026-02-18 |
+| [0002](0002-physics-engine-plugin-architecture.md)   | Physics Engine Plugin Architecture                              | Accepted | 2026-02-18 |
+| [0003](0003-websocket-realtime-simulation.md)        | WebSocket Protocol for Real-Time Simulation                     | Accepted | 2026-02-18 |
+| [0004](0004-launcher-provider-migration.md)          | Launcher Provider Migration Modes and Legacy Deprecation Policy | Accepted | 2026-04-08 |
+| [0005](0005-rust-tools-core-git-dependency.md)       | Pin `tools-core` as a Git Dependency                            | Accepted | 2026-04-23 |
+| [0006](0006-multi-source-motion-targets.md)          | Multi-Source Motion Targets                                     | Accepted | 2026-05-08 |
+| [0007](0007-motion-pipeline-architecture.md)         | Motion Pipeline Architecture (CIR)                              | Proposed | 2026-05-08 |
+| [0012](0012-canonical-pose-interchange.md)           | Canonical Pose Interchange                                      | Accepted | 2026-05-09 |
+| [0013](0013-launcher-composability.md)               | Launcher Composability — Embeddable-tool contract and IPC layer | Accepted | 2026-05-09 |
+| [0017](0017-sidekick-agentic-action-layer.md)        | Sidekick agentic action layer                                   | Accepted | 2026-05-22 |
+| [0018](0018-standalone-sidekick.md)                  | Standalone Sidekick Application                                 | Accepted | 2026-05-23 |
+| [0019](0019-mission-drift-calculators.md)            | Mission-Drift Calculators                                       | Accepted | 2026-04-25 |
+| [0020](0020-canonical-urdf-subsystem.md)             | Canonical URDF subsystem                                        | Accepted | 2026-05-08 |
+| [0021](0021-container-strategy.md)                   | Container Strategy — Three-Dockerfile Policy                    | Accepted | 2026-05-25 |
+| [0022](0022-chat-sidekick-boundary.md)               | Chat Sidekick Boundary                                          | Accepted | 2026-06-12 |
+| [0023](0023-mujoco-warp-backend.md)                  | MuJoCo Warp GPU + MuJoCo CPU backends behind one Protocol       | Accepted | 2026-05-29 |
+| [0024](0024-differentiable-backend.md)               | Differentiable backend — MJX (JAX) vs custom Warp kernels       | Accepted | 2026-05-29 |
+| [0025](0025-jaxsim-backend-home.md)                  | JaxSim Backend Home                                             | Accepted | 2026-05-30 |
+| [0026](0026-canonical-dynamic-state-v2.md)           | Canonical Dynamic State v2                                      | Accepted | 2026-05-31 |
+| [0027](0027-canonical-viewport-backend.md)           | Canonical 3D Viewport Backend                                   | Accepted | 2026-05-31 |
+| [0028](0028-react-tauri-launcher-parity.md)          | React/Tauri launcher parity model                               | Accepted | 2026-06-10 |
+| [0030](0030-c3d-viewer-renderer-backend.md)          | C3D Viewer Renderer Backend                                     | Accepted | 2026-06-10 |
+| [0031](0031-launch-monitor-canonical-shot-schema.md) | Canonical Launch Monitor Shot Schema                            | Accepted | 2026-08-04 |
 
 Note: ADR 0013 was amended on 2026-05-31 to document the CC-32
 canonical-core app-shell registry reuse of the embeddable-tool contract.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,3 +9,7 @@ Documentation for `shared.python`.
 ## [Engines](engines.md)
 
 Documentation for engine-specific APIs.
+
+## [Launch Monitor Analytics](launch_monitor_analytics.md)
+
+Vendor-neutral shot-data import, treatment, relationship mapping, predictive models, monitor comparison, dispersion, and trend services.

--- a/docs/api/launch_monitor_analytics.md
+++ b/docs/api/launch_monitor_analytics.md
@@ -1,0 +1,91 @@
+# Launch Monitor Analytics API
+
+The headless API lives in `src.shared.python.launch_monitor` and imports without
+PyQt6. The shallow MLP loads scikit-learn only when requested.
+
+## Import and Aggregate
+
+```python
+from src.shared.python.launch_monitor import LaunchMonitorProject, import_session
+
+project = LaunchMonitorProject("Player Study")
+project.add_session(import_session("trackman-session.csv"))
+project.add_session(import_session("garmin-session.csv"))
+shots = project.combined_shots()
+project.save("player-study.lmproject")
+```
+
+Use `ImportOptions` and `ColumnMapping` to override detection, mapping, units,
+sign multipliers, or measurement status. `detect_profile(headers)` returns the
+selected profile, confidence, matched fingerprints, and alternatives.
+
+## Treat and Filter
+
+```python
+from src.shared.python.launch_monitor import FilterRule, TreatmentConfig, apply_treatment
+
+treated = apply_treatment(
+    shots,
+    TreatmentConfig(
+        required_metrics=("club_speed", "ball_speed"),
+        outlier_metrics=("club_speed", "ball_speed"),
+        filters=(FilterRule("club", "eq", "7 Iron"),),
+        exclude_flagged=True,
+    ),
+)
+project.record_actions(treated.audit_log)
+```
+
+Input frames are not mutated. `TreatmentResult` contains the analysis view,
+row-level flags, and serializable audit actions.
+
+## Relationships and Multivariate Diagnostics
+
+```python
+from src.shared.python.launch_monitor import compute_correlations, compute_pca, compute_vif
+
+metrics = ("club_speed", "ball_speed", "attack_angle", "carry_distance")
+relations = compute_correlations(
+    treated.data,
+    metrics=metrics,
+    method="spearman",
+    controls=("attack_angle",),
+)
+pca = compute_pca(treated.data, metrics=metrics)
+vif = compute_vif(treated.data, metrics=metrics)
+```
+
+`CorrelationResult` contains coefficient, raw p-value, adjusted p-value, sample
+count, optional partial-correlation matrices, derived metrics, and screened
+`DependencyEdge` records.
+
+## Predictive Models
+
+```python
+from src.shared.python.launch_monitor import fit_predictive_model
+
+model = fit_predictive_model(
+    treated.data,
+    target="carry_distance",
+    features=("ball_speed", "launch_angle", "spin_rate"),
+    model="ridge",
+    group_column="session_id",
+    random_seed=42,
+)
+```
+
+Supported model names are `linear`, `ridge`, `lasso`, `elastic_net`, and `mlp`.
+The return value includes held-out metrics, predictions/residuals, coefficients
+where available, split counts, and the recipe seed.
+
+## Agreement, Dispersion, and Trends
+
+- `compare_monitors(...)` distinguishes matched-shot agreement from unmatched
+  descriptive comparison.
+- `analyze_dispersion(...)` computes robust center, covariance ellipse, area,
+  and radial metrics.
+- `analyze_trend(...)` computes time-based slopes, rolling/EWMA series, and
+  candidate step changes.
+
+All public functions validate required columns and minimum sample sizes with
+descriptive `ValueError` messages.

--- a/docs/development/feature_parity_matrix.md
+++ b/docs/development/feature_parity_matrix.md
@@ -7,7 +7,7 @@ Generated from [`src/config/feature_parity.json`](../../src/config/feature_parit
 The PyQt6 desktop app is the canonical model; the web app must match
 (epic #7462, registry mechanism #7445).
 
-**Summary:** 16 parity · 9 gap · 13 exempt (11 pending decision in #7460).
+**Summary:** 16 parity · 10 gap · 13 exempt (11 pending decision in #7460).
 
 | Feature | Status | PyQt6 | API | Web | Tracking |
 | --- | --- | --- | --- | --- | --- |
@@ -43,6 +43,7 @@ The PyQt6 desktop app is the canonical model; the web app must match
 | `tools.character_builder`<br>Character Builder (humanoid URDF generation) | 🔴 gap | `src/shared/python/model_generation/cli/main.py` | `src/api/routes/character_builder.py` | `ui/src/pages/CharacterBuilder.tsx` | #7448 |
 | `tools.data_explorer`<br>Data Explorer (import/filter/visualize datasets) | 🔴 gap | — | `src/api/routes/data_explorer.py` | `ui/src/pages/DataExplorer.tsx` | #7448 |
 | `tools.dataset_generator`<br>Swing dataset generation and import | ✅ parity | — | `src/api/routes/dataset.py` | `ui/src/pages/DatasetGenerator.tsx` | — |
+| `tools.launch_monitor_analytics`<br>Launch-monitor import, interdependency analysis, monitor comparison, dispersion, and longitudinal trends | 🔴 gap | `src/tools/launch_monitor_analytics/gui.py` | — | — | #8342 |
 | `tools.matlab_suite`<br>MATLAB/Simscape model suite | ⚪ exempt | `src/launchers/matlab_suite_dialog.py` | — | — | Requires a local MATLAB installation; desktop-only candidate pending #7460. — **pending decision (#7460)** |
 | `tools.model_explorer`<br>Model Explorer (browse/select/build URDF-MJCF) | 🔴 gap | `src/tools/model_explorer/launch_model_explorer.py` | `src/api/routes/model_explorer.py` | `ui/src/pages/ModelExplorer.tsx` | #7448 |
 | `tools.pose_editing`<br>Pose Studio interactive pose editing | ⚪ exempt | `src/tools/pose_studio/__main__.py` | — | — | Interactive 3D pose editing; desktop-only candidate pending #7460. — **pending decision (#7460)** |
@@ -74,6 +75,7 @@ Tiles from `src/config/launcher_manifest.json` mapped to registry entries:
 | `force_overlays` | `simulation.controls_wiring` |
 | `golf_simulation_suite` | `simulation.golf_suite_batch` |
 | `injury_analysis` | `biomech.exercise_injury_dashboards` |
+| `launch_monitor_analytics` | `tools.launch_monitor_analytics` |
 | `matlab_unified` | `tools.matlab_suite` |
 | `model_explorer` | `tools.model_explorer` |
 | `motion_capture` | `mocap.breadth` |

--- a/docs/strategic/FEATURE_EXPANSION_ROADMAP.md
+++ b/docs/strategic/FEATURE_EXPANSION_ROADMAP.md
@@ -864,6 +864,14 @@ class SwingVariabilityAnalyzer:
 
 ### 9.1 Launch Monitor Integration
 
+**Implementation status (2026-08-04):** The vendor-neutral import, project,
+treatment, statistical-analysis, monitor-comparison, dispersion, trend, and
+PyQt6 workbench foundation is implemented under
+`src/shared/python/launch_monitor/` and
+`src/tools/launch_monitor_analytics/` (epic #8342). Header profiles are
+version-tolerant mapping aids; the generic mapping workflow remains the safety
+net for localized or newly changed exports.
+
 **Purpose**: Import data from popular launch monitors for validation and analysis.
 
 **Supported Formats**:

--- a/docs/user_guide/README.md
+++ b/docs/user_guide/README.md
@@ -7,3 +7,4 @@ This section provides everything you need to know to use the Golf Modeling Suite
 - **[Installation](installation.md)**: Detailed setup instructions for Python and MATLAB environments.
 - **[Getting Started](getting_started.md)**: Step-by-step guide to running simulations.
 - **[Launchers](launchers.md)**: Explanation of the different ways to launch the suite.
+- **[Launch Monitor Analytics](launch_monitor_analytics.md)**: Multi-vendor shot-data harmonization, dependency mapping, monitor comparison, dispersion, and trends.

--- a/docs/user_guide/launch_monitor_analytics.md
+++ b/docs/user_guide/launch_monitor_analytics.md
@@ -1,0 +1,147 @@
+# Launch Monitor Analytics
+
+Launch Monitor Analytics is a local PyQt6 workbench for aggregating shot data,
+studying impact-parameter interdependence, comparing measurement systems, and
+tracking a player's dispersion and trends over time.
+
+Run it directly:
+
+```powershell
+python -m src.tools.launch_monitor_analytics
+```
+
+Or open **Launch Monitor Analytics** from the UpstreamDrift launcher.
+
+## Supported Data Sources
+
+The workbench reads CSV, TSV, XLS/XLSX, and JSON record files. It includes
+header profiles for TrackMan, Foresight Sports, FlightScope, Garmin Golf,
+SkyTrak, Uneekor, Full Swing, Rapsodo, and GSPro/Open Connect, plus a generic
+mapping profile.
+
+Support means that known header families can be mapped into the canonical
+schema; it does not mean every vendor release, locale, report configuration, or
+subscription tier has an identical export. Always review the detected profile,
+column mappings, units, and sign convention in the import dialog. Unknown
+columns are retained rather than discarded.
+
+### Evidence and Current Boundaries
+
+| Ecosystem                           | Officially Documented Capability                                                                                                                                                                                                                                           | Current Adapter Evidence                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| TrackMan TPS                        | [CSV export](https://support.trackmangolf.com/hc/en-us/articles/12985883274139-Shot-Analysis-How-To-Export-A-CSV-File-From-TPS) and [parameter definitions](https://support.trackmangolf.com/hc/en-us/articles/5089892383515-Practice-Trackman-Data-Parameter-Definitions) | Tested representative header fixture; actual versions can vary                    |
+| Foresight FSX                       | [Configurable CSV export](https://golf.foresightsports.com/sites/default/files/downloads/2021/FSX_UserManual_v2-4.pdf)                                                                                                                                                     | Tested representative header fixture                                              |
+| Garmin Golf                         | [Approach R10/R50 CSV export](https://support.garmin.com/en-AU/?faq=pit4ClEw6f019Cbs3Uhw59)                                                                                                                                                                                | Tested representative header fixture                                              |
+| FlightScope                         | [Published club and ball parameters](https://flightscope.com/pages/flightscope-data-parameters)                                                                                                                                                                            | Tested representative header fixture; exact export layout needs versioned samples |
+| Uneekor                             | Official device manuals list available ball/club metrics                                                                                                                                                                                                                   | Tested representative header fixture; exact export layout needs versioned samples |
+| SkyTrak, Full Swing, Rapsodo, GSPro | Product-dependent tabular or connector data                                                                                                                                                                                                                                | Header profile plus generic mapping; verify each source before analysis           |
+
+The repository fixtures are synthetic and vendor-shaped. They are not vendor
+validation data and cannot establish measurement accuracy or equivalence.
+
+## Workflow
+
+### 1. Import and Review
+
+1. Open **Sessions** and choose **Import Files...**.
+2. Review the detected vendor and confidence.
+3. Check every canonical mapping and source unit. Select **retain only** when a
+   field should remain available without being normalized.
+4. Add player, session, device model, and software-version metadata.
+5. Repeat for every session or monitor.
+
+The project retains the original source header/value, file SHA-256, source row,
+profile, units, unit evidence, and warnings. Save a `.lmproject` file to preserve
+all sessions and the treatment audit log.
+
+### 2. Build an Analysis View
+
+Use **Data Treatment** to:
+
+- require metrics needed for the planned analysis;
+- flag duplicate shot identifiers;
+- flag robust outliers with a modified-Z threshold;
+- add structured filters by player, club, session, monitor, time, tag, or value;
+- calculate identity-derived fields such as smash factor, face-to-path, and roll
+  distance only where their inputs exist;
+- exclude flagged rows from the analysis view without changing imported data.
+
+Every derivation, filter, flag, and exclusion is recorded. A flagged observation
+is not automatically a bad measurement: review source context before exclusion.
+
+### 3. Map Relationships
+
+In **Relationships**, select two or more metrics and choose Pearson, Spearman, or
+Kendall correlation. Optional controls residualize selected confounders before
+partial correlation. Results include pair counts, p-values, Benjamini-Hochberg
+adjustment, derived-variable markings, and screened network edges. **Run PCA and
+VIF Diagnostics** to inspect latent structure and multicollinearity.
+
+Analyze important strata separately:
+
+- one monitor and one club;
+- the same monitor across sessions;
+- one session across clubs;
+- each monitor separately before pooling;
+- the full treated dataset only after checking composition.
+
+Pooling can create or reverse an association when club, player, or monitor mix
+changes.
+
+### 4. Fit Predictive Models
+
+The **Models** workspace supports linear, ridge, lasso, elastic-net, and an
+optional shallow MLP. Select a grouped holdout (normally session) when repeated
+shots within a session are related. The workbench reports held-out R², MAE, and
+RMSE plus coefficients for linear models and actual-vs-predicted residual views.
+
+The leakage guard rejects a target appearing directly or through a registered
+identity-derived predictor. A high score shows prediction within the tested
+split; it does not show causation or guarantee transport to a new player,
+monitor, environment, or club.
+
+### 5. Compare Monitors
+
+For defensible bias, scale, and agreement analysis, import paired measurements
+of the same shots and select their match identifier. The workbench reports mean
+bias, standard deviation of differences, 95% limits of agreement, slope,
+intercept, and correlation.
+
+Without a match identifier, only distribution summaries and a standardized
+effect size are produced. Those results can be confounded by different players,
+clubs, environments, and session composition and must not be described as
+calibration.
+
+### 6. Analyze Dispersion and Trends
+
+**Dispersion** accepts any forward/lateral coordinate pair and reports a robust
+center, mean bias, 95% covariance ellipse, ellipse area, radial RMSE, median
+radial error, and 90th-percentile radial error. Group by monitor, session, or
+club to distinguish systematic aim bias from precision.
+
+**Trends** uses actual observation time, not row number. It reports ordinary and
+Theil-Sen slopes, a p-value, rolling center/variation, EWMA, early/late means,
+and ranked candidate step changes. Candidate changes are prompts for review,
+not automatic proof of a swing change.
+
+## Units and Direction Conventions
+
+Canonical numeric storage uses m/s, m, rad, rad/s, and s. The metric registry
+also specifies familiar display units. A header unit overrides the profile
+default; an explicit user mapping overrides both. The import manifest records
+which source supplied the unit assumption.
+
+Direction signs are preserved unless an explicit mapping multiplier changes
+them. Vendors do not universally use the same left/right reference or player
+handedness convention. Do not pool directional fields until the target line,
+handedness, and sign convention have been checked.
+
+## Publication Checklist
+
+- Export the canonical analysis view and reproducibility manifest.
+- Report source profiles, device/software versions, sample counts, missingness,
+  filters, exclusions, grouping, random seed, and validation split.
+- Mark derived and vendor-estimated variables.
+- Use matched shots for agreement claims.
+- Describe correlations and model results as associations or predictions, never
+  as causal effects without an appropriate experiment.

--- a/src/config/feature_parity.json
+++ b/src/config/feature_parity.json
@@ -255,6 +255,16 @@
       "reason": "Vendored Tools desktop GUI (vendor/ud-tools src/rate_of_closure); web surface is served by the Tools repo's own build, not UpstreamDrift.",
       "tiles": ["rate_of_closure"]
     },
+    "tools.launch_monitor_analytics": {
+      "title": "Launch-monitor import, interdependency analysis, monitor comparison, dispersion, and longitudinal trends",
+      "pyqt": "src/tools/launch_monitor_analytics/gui.py",
+      "api": null,
+      "web": null,
+      "status": "gap",
+      "issue": 8342,
+      "tiles": ["launch_monitor_analytics"],
+      "notes": "The PyQt6 research workbench is canonical; API and React/Tauri parity are tracked in epic #8342."
+    },
     "analysis.analysis_tools_api": {
       "title": "Analysis Tools REST endpoints (swing metrics, biomechanics)",
       "pyqt": null,

--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -945,6 +945,30 @@
       }
     },
     {
+      "id": "launch_monitor_analytics",
+      "name": "Launch Monitor Analytics",
+      "description": "Harmonize multi-vendor shot data, map impact-parameter dependencies, compare monitors, and track dispersion and trends.",
+      "category": "tool",
+      "type": "special_app",
+      "path": "src/tools/launch_monitor_analytics/__main__.py",
+      "logo": "data_explorer.svg",
+      "status": "ready",
+      "capabilities": [
+        "launch_monitor_import",
+        "session_aggregation",
+        "correlation_network",
+        "regression",
+        "neural_network",
+        "monitor_comparison",
+        "dispersion",
+        "longitudinal_trends"
+      ],
+      "order": 47,
+      "web": {
+        "mode": "native-window"
+      }
+    },
+    {
       "id": "starting_pose_matcher",
       "name": "Starting-Pose Matcher (legacy)",
       "description": "Legacy alias for the motion-target preview tile. Hidden by default; kept for one release so saved layouts continue to resolve.",

--- a/src/config/models.yaml
+++ b/src/config/models.yaml
@@ -418,6 +418,26 @@ models:
       status: "ready"
       default_launch: "tab"
 
+  - id: "launch_monitor_analytics"
+    name: "Launch Monitor Analytics"
+    description: "Harmonize multi-vendor shot data, map impact-parameter dependencies, compare monitors, and track dispersion and trends"
+    type: "special_app"
+    path: "src/tools/launch_monitor_analytics/__main__.py"
+    capabilities:
+      - "launch_monitor_import"
+      - "session_aggregation"
+      - "correlation_network"
+      - "regression"
+      - "neural_network"
+      - "monitor_comparison"
+      - "dispersion"
+      - "longitudinal_trends"
+    launcher:
+      category: "tool"
+      logo: "assets/data_explorer_modern.png"
+      status: "ready"
+      default_launch: "tab"
+
   - id: "rate_of_closure"
     name: "Rate of Closure Impact Explorer"
     description: "Quantifies how a rotating clubhead's impact-point delivery differs from the tracked reference point (COM or geometric center)"

--- a/src/launchers/embedded_tool_bootstrap.py
+++ b/src/launchers/embedded_tool_bootstrap.py
@@ -46,6 +46,7 @@ FALLBACK_ADAPTER_MODULES = (
     "src.tools.terrain_engine._embed_adapter",
     "src.tools.golf_simulation_suite._embed_adapter",
     "src.tools.simulation_backends_launcher._embed_adapter",
+    "src.tools.launch_monitor_analytics._embed_adapter",
     "engines.Simscape_Multibody_Models.3D_Golf_Model.python.src.apps._embed_adapter",
 )
 

--- a/src/shared/python/launch_monitor/__init__.py
+++ b/src/shared/python/launch_monitor/__init__.py
@@ -1,0 +1,102 @@
+"""Vendor-neutral launch-monitor ingestion and analytics.
+
+The package keeps PyQt6 and scikit-learn optional. Importing this façade needs
+only the core scientific/data dependencies; the shallow MLP imports
+scikit-learn lazily when selected.
+"""
+
+from src.shared.python.launch_monitor.comparison import (
+    MonitorComparisonResult,
+    MonitorSummary,
+    PairwiseMonitorComparison,
+    compare_monitors,
+)
+from src.shared.python.launch_monitor.dispersion import (
+    DispersionResult,
+    analyze_dispersion,
+)
+from src.shared.python.launch_monitor.importer import import_session
+from src.shared.python.launch_monitor.modeling import (
+    PredictiveModelResult,
+    fit_predictive_model,
+)
+from src.shared.python.launch_monitor.multivariate import (
+    PCAResult,
+    VIFResult,
+    compute_pca,
+    compute_vif,
+)
+from src.shared.python.launch_monitor.profiles import (
+    PROFILES,
+    ImportProfile,
+    ProfileDetection,
+    detect_profile,
+    normalize_header,
+)
+from src.shared.python.launch_monitor.project import LaunchMonitorProject
+from src.shared.python.launch_monitor.relationships import (
+    CorrelationResult,
+    DependencyEdge,
+    compute_correlations,
+)
+from src.shared.python.launch_monitor.schema import (
+    IDENTITY_COLUMNS,
+    METRICS,
+    ColumnMapping,
+    ImportedSession,
+    ImportManifest,
+    ImportOptions,
+    MetricDefinition,
+    numeric_metric_columns,
+)
+from src.shared.python.launch_monitor.trends import (
+    ChangeCandidate,
+    TrendResult,
+    analyze_trend,
+)
+from src.shared.python.launch_monitor.treatment import (
+    TreatmentConfig,
+    TreatmentResult,
+    FilterRule,
+    apply_treatment,
+)
+
+__all__ = [
+    "IDENTITY_COLUMNS",
+    "METRICS",
+    "PROFILES",
+    "ChangeCandidate",
+    "ColumnMapping",
+    "CorrelationResult",
+    "DependencyEdge",
+    "DispersionResult",
+    "ImportManifest",
+    "ImportOptions",
+    "ImportProfile",
+    "ImportedSession",
+    "LaunchMonitorProject",
+    "MetricDefinition",
+    "MonitorComparisonResult",
+    "MonitorSummary",
+    "PairwiseMonitorComparison",
+    "PredictiveModelResult",
+    "PCAResult",
+    "ProfileDetection",
+    "TreatmentConfig",
+    "TreatmentResult",
+    "FilterRule",
+    "TrendResult",
+    "VIFResult",
+    "analyze_dispersion",
+    "analyze_trend",
+    "apply_treatment",
+    "compare_monitors",
+    "compute_correlations",
+    "compute_pca",
+    "compute_vif",
+    "detect_profile",
+    "fit_predictive_model",
+    "import_session",
+    "normalize_header",
+    "numeric_metric_columns",
+]

--- a/src/shared/python/launch_monitor/comparison.py
+++ b/src/shared/python/launch_monitor/comparison.py
@@ -1,0 +1,147 @@
+"""Matched and descriptive cross-monitor comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class MonitorSummary:
+    monitor: str
+    sample_count: int
+    mean: float
+    standard_deviation: float
+    median: float
+
+
+@dataclass(frozen=True)
+class PairwiseMonitorComparison:
+    reference: str
+    comparator: str
+    matched: bool
+    sample_count: int
+    mean_bias: float
+    standard_deviation_bias: float
+    lower_limit: float
+    upper_limit: float
+    slope: float
+    intercept: float
+    correlation: float
+    warning: str | None
+
+
+@dataclass(frozen=True)
+class MonitorComparisonResult:
+    metric: str
+    summaries: tuple[MonitorSummary, ...]
+    pairwise: tuple[PairwiseMonitorComparison, ...]
+
+
+def compare_monitors(
+    frame: pd.DataFrame,
+    *,
+    metric: str,
+    monitor_column: str = "monitor_vendor",
+    match_column: str | None = None,
+    reference_monitor: str | None = None,
+) -> MonitorComparisonResult:
+    """Compare monitor distributions or matched-shot measurement behavior."""
+    required = {metric, monitor_column}
+    if match_column:
+        required.add(match_column)
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Columns not present: {sorted(missing)}")
+    clean = frame[list(required)].copy()
+    clean[metric] = pd.to_numeric(clean[metric], errors="coerce")
+    clean = clean.dropna(subset=[metric, monitor_column])
+    monitors = sorted(clean[monitor_column].astype(str).unique())
+    if len(monitors) < 2:
+        raise ValueError("At least two monitors are required")
+    reference = reference_monitor or monitors[0]
+    if reference not in monitors:
+        raise ValueError(f"Reference monitor not present: {reference}")
+    summaries = tuple(
+        MonitorSummary(
+            monitor,
+            int(len(values)),
+            float(values.mean()),
+            float(values.std(ddof=1)),
+            float(values.median()),
+        )
+        for monitor in monitors
+        for values in [clean.loc[clean[monitor_column].astype(str) == monitor, metric]]
+    )
+    pairwise: list[PairwiseMonitorComparison] = []
+    for comparator in monitors:
+        if comparator == reference:
+            continue
+        if match_column:
+            selected = clean[
+                clean[monitor_column].astype(str).isin([reference, comparator])
+            ]
+            pivot = selected.pivot_table(
+                index=match_column,
+                columns=monitor_column,
+                values=metric,
+                aggfunc="mean",
+            ).dropna(subset=[reference, comparator])
+            if len(pivot) < 3:
+                raise ValueError(
+                    f"At least three matched pairs are required for {reference} vs {comparator}"
+                )
+            x = pivot[reference].to_numpy(float)
+            y = pivot[comparator].to_numpy(float)
+            difference = y - x
+            slope, intercept = np.polyfit(x, y, 1)
+            bias = float(difference.mean())
+            std_bias = float(difference.std(ddof=1))
+            pairwise.append(
+                PairwiseMonitorComparison(
+                    reference,
+                    comparator,
+                    True,
+                    len(pivot),
+                    bias,
+                    std_bias,
+                    bias - 1.96 * std_bias,
+                    bias + 1.96 * std_bias,
+                    float(slope),
+                    float(intercept),
+                    float(np.corrcoef(x, y)[0, 1]),
+                    None,
+                )
+            )
+        else:
+            reference_values = clean.loc[
+                clean[monitor_column].astype(str) == reference, metric
+            ].to_numpy(float)
+            comparator_values = clean.loc[
+                clean[monitor_column].astype(str) == comparator, metric
+            ].to_numpy(float)
+            bias = float(comparator_values.mean() - reference_values.mean())
+            pooled = np.sqrt(
+                (reference_values.var(ddof=1) + comparator_values.var(ddof=1)) / 2
+            )
+            effect = bias / pooled if pooled > 0 else float("nan")
+            pairwise.append(
+                PairwiseMonitorComparison(
+                    reference,
+                    comparator,
+                    False,
+                    min(len(reference_values), len(comparator_values)),
+                    bias,
+                    float("nan"),
+                    float("nan"),
+                    float("nan"),
+                    float("nan"),
+                    float("nan"),
+                    float(effect),
+                    "Unmatched comparison is descriptive and may be confounded by "
+                    "player, club, environment, and session composition.",
+                )
+            )
+    return MonitorComparisonResult(metric, summaries, tuple(pairwise))

--- a/src/shared/python/launch_monitor/dispersion.py
+++ b/src/shared/python/launch_monitor/dispersion.py
@@ -1,0 +1,69 @@
+"""Target-relative shot-dispersion statistics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class DispersionResult:
+    """Robust center, covariance ellipse, and radial-error summary."""
+
+    sample_count: int
+    center_forward: float
+    center_lateral: float
+    mean_forward: float
+    mean_lateral: float
+    ellipse_major: float
+    ellipse_minor: float
+    ellipse_angle_rad: float
+    area_95: float
+    radial_rmse: float
+    radial_p50: float
+    radial_p90: float
+
+
+def analyze_dispersion(
+    frame: pd.DataFrame,
+    *,
+    forward: str = "carry_distance",
+    lateral: str = "lateral_carry",
+) -> DispersionResult:
+    """Compute a 95% covariance ellipse and robust dispersion metrics."""
+    missing = {forward, lateral} - set(frame.columns)
+    if missing:
+        raise ValueError(f"Dispersion columns not present: {sorted(missing)}")
+    values = frame[[forward, lateral]].apply(pd.to_numeric, errors="coerce").dropna()
+    if len(values) < 3:
+        raise ValueError("At least three complete shots are required for dispersion")
+    points = values.to_numpy(float)
+    robust_center = np.median(points, axis=0)
+    mean_center = np.mean(points, axis=0)
+    covariance = np.cov(points, rowvar=False, ddof=1)
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    order = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[order], 0.0)
+    eigenvectors = eigenvectors[:, order]
+    chi_square_95 = 5.991464547
+    radii = np.sqrt(eigenvalues * chi_square_95)
+    major, minor = 2 * radii
+    vector = eigenvectors[:, 0]
+    angle = float(np.arctan2(vector[1], vector[0]))
+    radial = np.linalg.norm(points - robust_center, axis=1)
+    return DispersionResult(
+        len(points),
+        float(robust_center[0]),
+        float(robust_center[1]),
+        float(mean_center[0]),
+        float(mean_center[1]),
+        float(major),
+        float(minor),
+        angle,
+        float(np.pi * radii[0] * radii[1]),
+        float(np.sqrt(np.mean(radial**2))),
+        float(np.quantile(radial, 0.5)),
+        float(np.quantile(radial, 0.9)),
+    )

--- a/src/shared/python/launch_monitor/importer.py
+++ b/src/shared/python/launch_monitor/importer.py
@@ -1,0 +1,268 @@
+"""Multi-format launch-monitor session importer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from src.shared.python.launch_monitor.profiles import PROFILES, detect_profile
+from src.shared.python.launch_monitor.schema import (
+    IDENTITY_COLUMNS,
+    METRICS,
+    ColumnMapping,
+    ImportedSession,
+    ImportManifest,
+    ImportOptions,
+)
+
+_UNIT_ALIASES = {
+    "mph": "mph",
+    "mi/h": "mph",
+    "kph": "km/h",
+    "kmh": "km/h",
+    "km/h": "km/h",
+    "mps": "m/s",
+    "m/s": "m/s",
+    "yd": "yd",
+    "yds": "yd",
+    "yard": "yd",
+    "yards": "yd",
+    "ft": "ft",
+    "feet": "ft",
+    "foot": "ft",
+    "in": "in",
+    "inch": "in",
+    "inches": "in",
+    "mm": "mm",
+    "cm": "cm",
+    "m": "m",
+    "deg": "deg",
+    "degree": "deg",
+    "degrees": "deg",
+    "rad": "rad",
+    "radian": "rad",
+    "radians": "rad",
+    "rpm": "rpm",
+    "rps": "rps",
+    "s": "s",
+    "sec": "s",
+    "second": "s",
+    "seconds": "s",
+    "1": "1",
+}
+
+
+def _read_source(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(path, sep=None, engine="python")
+    if suffix in {".tsv", ".txt"}:
+        return pd.read_csv(path, sep="\t")
+    if suffix in {".xlsx", ".xls"}:
+        return pd.read_excel(path)
+    if suffix == ".json":
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+        if isinstance(payload, list):
+            return pd.json_normalize(payload, sep=".")
+        if isinstance(payload, dict):
+            for key in ("shots", "Shots", "records", "Records"):
+                records = payload.get(key)
+                if isinstance(records, list):
+                    return pd.json_normalize(records, sep=".")
+            return pd.json_normalize([payload], sep=".")
+        raise ValueError("JSON source must contain an object or list of shot records")
+    raise ValueError(
+        f"Unsupported launch-monitor file type '{suffix}'. "
+        "Supported: CSV, TSV, XLSX, XLS, JSON."
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _unit_from_header(header: str) -> str | None:
+    candidates = re.findall(r"\(([^)]+)\)|\[([^]]+)\]", header.lower())
+    flattened = [part for pair in candidates for part in pair if part]
+    flattened.extend(
+        re.findall(
+            r"(?:^|\s)(mph|kph|kmh|m/s|mps|rpm|rps|yds?|ft|mm|cm|deg|rad|sec|s)$",
+            header.lower(),
+        )
+    )
+    for candidate in reversed(flattened):
+        normalized = candidate.strip().lower()
+        if normalized in _UNIT_ALIASES:
+            return _UNIT_ALIASES[normalized]
+    return None
+
+
+def _convert(values: pd.Series, source_unit: str, canonical_unit: str) -> pd.Series:
+    numeric = pd.to_numeric(values, errors="coerce")
+    unit = _UNIT_ALIASES.get(source_unit.lower(), source_unit.lower())
+    if canonical_unit == "1":
+        if unit != "1":
+            raise ValueError(f"Cannot convert unit '{source_unit}' to dimensionless")
+        return numeric
+    if canonical_unit == "m/s":
+        factors = {"m/s": 1.0, "mph": 0.44704, "km/h": 1 / 3.6}
+    elif canonical_unit == "m":
+        factors = {
+            "m": 1.0,
+            "yd": 0.9144,
+            "ft": 0.3048,
+            "in": 0.0254,
+            "cm": 0.01,
+            "mm": 0.001,
+        }
+    elif canonical_unit == "rad":
+        factors = {"rad": 1.0, "deg": np.pi / 180.0}
+    elif canonical_unit == "rad/s":
+        factors = {"rad/s": 1.0, "rpm": 2 * np.pi / 60.0, "rps": 2 * np.pi}
+    elif canonical_unit == "s":
+        factors = {"s": 1.0}
+    else:
+        raise ValueError(f"Unsupported canonical unit: {canonical_unit}")
+    if unit not in factors:
+        raise ValueError(f"Cannot convert unit '{source_unit}' to '{canonical_unit}'")
+    return numeric * factors[unit]
+
+
+def _combine_timestamp(raw: pd.DataFrame, mapped: dict[str, pd.Series]) -> pd.Series:
+    if "captured_at" in mapped:
+        return pd.to_datetime(mapped["captured_at"], errors="coerce", utc=True)
+    if "date" in mapped and "time" in mapped:
+        combined = mapped["date"].astype(str) + " " + mapped["time"].astype(str)
+        return pd.to_datetime(combined, errors="coerce", utc=True)
+    if "date" in mapped:
+        return pd.to_datetime(mapped["date"], errors="coerce", utc=True)
+    return pd.Series(pd.NaT, index=raw.index, dtype="datetime64[ns, UTC]")
+
+
+def _resolve_mappings(
+    headers: list[str], options: ImportOptions
+) -> tuple[str, tuple[ColumnMapping, ...]]:
+    profile_id = options.profile_id or detect_profile(headers).profile_id
+    if profile_id not in PROFILES:
+        raise ValueError(f"Unknown import profile: {profile_id}")
+    auto = list(PROFILES[profile_id].mappings_for(headers))
+    overrides = {mapping.source_column: mapping for mapping in options.mappings}
+    mappings = [overrides.pop(mapping.source_column, mapping) for mapping in auto]
+    mappings.extend(overrides.values())
+    targets: set[str] = set()
+    deduplicated: list[ColumnMapping] = []
+    for mapping in reversed(mappings):
+        if mapping.target_column in targets:
+            continue
+        targets.add(mapping.target_column)
+        deduplicated.append(mapping)
+    return profile_id, tuple(reversed(deduplicated))
+
+
+def import_session(
+    source: str | Path,
+    options: ImportOptions | None = None,
+) -> ImportedSession:
+    """Import one launch-monitor export into canonical shot records."""
+    path = Path(source).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"Launch-monitor source does not exist: {path}")
+    config = options or ImportOptions()
+    raw = _read_source(path)
+    if raw.empty:
+        raise ValueError(f"Launch-monitor source contains no rows: {path}")
+    headers = [str(column) for column in raw.columns]
+    profile_id, mappings = _resolve_mappings(headers, config)
+    profile = PROFILES[profile_id]
+    digest = _sha256(path)
+    session_id = f"{profile_id}-{digest[:16]}"
+    output = pd.DataFrame(index=raw.index)
+    output["session_id"] = session_id
+    output["source_row"] = np.arange(2, len(raw) + 2)
+    output["monitor_vendor"] = profile.vendor
+    output["monitor_model"] = config.monitor_model or ""
+    output["software_version"] = config.software_version or ""
+    output["player"] = config.player or ""
+    output["tags"] = ", ".join(config.tags)
+    mapped_identity: dict[str, pd.Series] = {}
+    metric_sources: dict[str, str] = {}
+    source_units: dict[str, str] = {}
+    unit_evidence: dict[str, str] = {}
+    warnings: list[str] = []
+    for mapping in mappings:
+        if mapping.source_column not in raw.columns:
+            warnings.append(f"Mapped source column not found: {mapping.source_column}")
+            continue
+        source_values = raw[mapping.source_column]
+        target = mapping.target_column
+        if target in METRICS:
+            definition = METRICS[target]
+            header_unit = _unit_from_header(mapping.source_column)
+            source_unit = (
+                mapping.source_unit or header_unit or profile.default_units[target]
+            )
+            evidence = (
+                "mapping"
+                if mapping.source_unit
+                else "header"
+                if header_unit
+                else "profile-default"
+            )
+            try:
+                converted = _convert(
+                    source_values, source_unit, definition.canonical_unit
+                )
+            except ValueError as exc:
+                warnings.append(f"{target}: {exc}")
+                continue
+            output[target] = converted * mapping.multiplier
+            output[f"status::{target}"] = mapping.measurement_status
+            metric_sources[target] = mapping.source_column
+            source_units[target] = source_unit
+            unit_evidence[target] = evidence
+        else:
+            mapped_identity[target] = source_values
+            if target in IDENTITY_COLUMNS and target not in {
+                "session_id",
+                "source_row",
+            }:
+                output[target] = source_values
+    output["captured_at"] = _combine_timestamp(raw, mapped_identity)
+    if "shot_id" not in output or output["shot_id"].isna().all():
+        output["shot_id"] = [f"{session_id}:{row}" for row in output["source_row"]]
+    else:
+        output["shot_id"] = output["shot_id"].astype(str)
+    for source_column in headers:
+        output[f"source::{source_column}"] = raw[source_column].to_numpy(copy=True)
+    imported_at = datetime.now(UTC).isoformat()
+    manifest = ImportManifest(
+        source_path=str(path),
+        file_sha256=digest,
+        profile_id=profile_id,
+        vendor=profile.vendor,
+        imported_at=imported_at,
+        row_count=len(output),
+        source_columns=tuple(headers),
+        metric_sources=metric_sources,
+        source_units=source_units,
+        unit_evidence=unit_evidence,
+        warnings=tuple(warnings),
+    )
+    return ImportedSession(
+        session_id=session_id,
+        name=config.session_name or path.stem,
+        shots=output.reset_index(drop=True),
+        manifest=manifest,
+        source_path=path,
+        metadata={"imported_at": imported_at},
+    )

--- a/src/shared/python/launch_monitor/modeling.py
+++ b/src/shared/python/launch_monitor/modeling.py
@@ -1,0 +1,221 @@
+"""Reproducible regression and optional shallow-neural-network models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from src.shared.python.launch_monitor.schema import METRICS
+
+
+@dataclass(frozen=True)
+class PredictiveModelResult:
+    """Model recipe, held-out metrics, coefficients, and predictions."""
+
+    model: str
+    target: str
+    features: tuple[str, ...]
+    metrics: dict[str, float]
+    coefficients: dict[str, float] | None
+    predictions: pd.DataFrame
+    random_seed: int
+    train_count: int
+    test_count: int
+
+
+def _validate_no_leakage(target: str, features: tuple[str, ...]) -> None:
+    if target in features:
+        raise ValueError("Target leakage: target cannot also be a feature")
+    leaking: list[str] = []
+    for feature in features:
+        definition = METRICS.get(feature)
+        if definition and target in definition.derived_from:
+            leaking.append(feature)
+    target_definition = METRICS.get(target)
+    if target_definition:
+        leaking.extend(
+            feature for feature in features if feature in target_definition.derived_from
+        )
+    if leaking:
+        raise ValueError(
+            "Identity-derived target leakage detected in features: "
+            + ", ".join(sorted(set(leaking)))
+        )
+
+
+def _split_indices(
+    frame: pd.DataFrame,
+    random_seed: int,
+    test_fraction: float,
+    group_column: str | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(random_seed)
+    if group_column:
+        if group_column not in frame:
+            raise ValueError(f"Group column not present: {group_column}")
+        groups = frame[group_column].astype(str).unique()
+        if len(groups) < 2:
+            raise ValueError("Grouped split requires at least two groups")
+        shuffled = rng.permutation(groups)
+        n_test_groups = max(1, min(len(groups) - 1, round(len(groups) * test_fraction)))
+        test_groups = set(shuffled[:n_test_groups])
+        test_mask = frame[group_column].astype(str).isin(test_groups).to_numpy()
+        return np.flatnonzero(~test_mask), np.flatnonzero(test_mask)
+    indices = rng.permutation(len(frame))
+    n_test = max(1, min(len(frame) - 1, round(len(frame) * test_fraction)))
+    return indices[n_test:], indices[:n_test]
+
+
+def _coordinate_descent(
+    x: np.ndarray,
+    y: np.ndarray,
+    l1: float,
+    l2: float,
+    iterations: int = 4000,
+    tolerance: float = 1e-9,
+) -> np.ndarray:
+    coefficients = np.zeros(x.shape[1], dtype=float)
+    squared = np.sum(x * x, axis=0)
+    for _ in range(iterations):
+        previous = coefficients.copy()
+        for column in range(x.shape[1]):
+            residual = y - x @ coefficients + x[:, column] * coefficients[column]
+            rho = float(x[:, column] @ residual)
+            threshold = l1 * len(x)
+            if rho < -threshold:
+                numerator = rho + threshold
+            elif rho > threshold:
+                numerator = rho - threshold
+            else:
+                numerator = 0.0
+            coefficients[column] = numerator / (squared[column] + l2 * len(x))
+        if np.max(np.abs(coefficients - previous)) < tolerance:
+            break
+    return coefficients
+
+
+def _fit_numpy_model(
+    model: str, x_train: np.ndarray, y_train: np.ndarray
+) -> tuple[np.ndarray, float]:
+    intercept = float(np.mean(y_train))
+    centered = y_train - intercept
+    if model == "linear":
+        coefficients = np.linalg.lstsq(x_train, centered, rcond=None)[0]
+    elif model == "ridge":
+        alpha = 1.0
+        gram = x_train.T @ x_train + alpha * np.eye(x_train.shape[1])
+        coefficients = np.linalg.solve(gram, x_train.T @ centered)
+    elif model == "lasso":
+        coefficients = _coordinate_descent(x_train, centered, l1=0.01, l2=0.0)
+    elif model == "elastic_net":
+        coefficients = _coordinate_descent(x_train, centered, l1=0.005, l2=0.01)
+    else:
+        raise ValueError("model must be linear, ridge, lasso, elastic_net, or mlp")
+    return coefficients, intercept
+
+
+def fit_predictive_model(
+    frame: pd.DataFrame,
+    *,
+    target: str,
+    features: tuple[str, ...] | list[str],
+    model: str = "ridge",
+    random_seed: int = 42,
+    test_fraction: float = 0.25,
+    group_column: str | None = None,
+) -> PredictiveModelResult:
+    """Fit a standardized model and score a held-out deterministic split."""
+    selected = tuple(features)
+    if not selected:
+        raise ValueError("At least one feature is required")
+    if not 0 < test_fraction < 1:
+        raise ValueError("test_fraction must be between zero and one")
+    _validate_no_leakage(target, selected)
+    required = [target, *selected]
+    if group_column:
+        required.append(group_column)
+    missing = set(required) - set(frame.columns)
+    if missing:
+        raise ValueError(f"Columns not present: {sorted(missing)}")
+    clean = frame[required].copy()
+    clean[target] = pd.to_numeric(clean[target], errors="coerce")
+    for feature in selected:
+        clean[feature] = pd.to_numeric(clean[feature], errors="coerce")
+    clean = clean.dropna(subset=[target, *selected]).reset_index(drop=False)
+    if len(clean) < max(12, len(selected) * 4):
+        raise ValueError("Insufficient complete rows for predictive modeling")
+    train_idx, test_idx = _split_indices(
+        clean, random_seed, test_fraction, group_column
+    )
+    x = clean[list(selected)].to_numpy(float)
+    y = clean[target].to_numpy(float)
+    mean = x[train_idx].mean(axis=0)
+    scale = x[train_idx].std(axis=0)
+    scale[scale == 0] = 1.0
+    standardized = (x - mean) / scale
+
+    coefficient_map: dict[str, float] | None
+    if model == "mlp":
+        try:
+            from sklearn.neural_network import MLPRegressor
+        except ImportError as exc:
+            raise ImportError(
+                "The shallow MLP requires the analysis extra: "
+                "pip install upstream-drift[analysis]"
+            ) from exc
+        estimator = MLPRegressor(
+            hidden_layer_sizes=(max(4, len(selected) * 2),),
+            activation="relu",
+            solver="lbfgs",
+            alpha=0.01,
+            max_iter=2000,
+            random_state=random_seed,
+        )
+        target_mean = float(y[train_idx].mean())
+        target_scale = float(y[train_idx].std()) or 1.0
+        estimator.fit(
+            standardized[train_idx], (y[train_idx] - target_mean) / target_scale
+        )
+        predicted = (
+            estimator.predict(standardized[test_idx]) * target_scale + target_mean
+        )
+        coefficient_map = None
+    else:
+        coefficients, intercept = _fit_numpy_model(
+            model, standardized[train_idx], y[train_idx]
+        )
+        predicted = intercept + standardized[test_idx] @ coefficients
+        coefficient_map = {
+            feature: float(value)
+            for feature, value in zip(selected, coefficients, strict=True)
+        }
+    actual = y[test_idx]
+    residual = actual - predicted
+    ss_res = float(np.sum(residual**2))
+    ss_total = float(np.sum((actual - actual.mean()) ** 2))
+    metrics = {
+        "r2": 1.0 - ss_res / ss_total if ss_total > 0 else float("nan"),
+        "mae": float(np.mean(np.abs(residual))),
+        "rmse": float(np.sqrt(np.mean(residual**2))),
+    }
+    predictions = pd.DataFrame(
+        {
+            "row_index": clean.iloc[test_idx]["index"].to_numpy(),
+            "actual": actual,
+            "predicted": predicted,
+            "residual": residual,
+        }
+    ).sort_values("row_index", ignore_index=True)
+    return PredictiveModelResult(
+        model,
+        target,
+        selected,
+        metrics,
+        coefficient_map,
+        predictions,
+        random_seed,
+        len(train_idx),
+        len(test_idx),
+    )

--- a/src/shared/python/launch_monitor/multivariate.py
+++ b/src/shared/python/launch_monitor/multivariate.py
@@ -1,0 +1,104 @@
+"""PCA and multicollinearity diagnostics for launch-monitor metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class PCAResult:
+    """Standardized principal-component decomposition."""
+
+    metrics: tuple[str, ...]
+    explained_variance_ratio: pd.Series
+    loadings: pd.DataFrame
+    scores: pd.DataFrame
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class VIFResult:
+    """Variance-inflation factors for selected predictors."""
+
+    values: pd.Series
+    sample_count: int
+    warning_metrics: tuple[str, ...]
+
+
+def _complete_standardized(
+    frame: pd.DataFrame, metrics: tuple[str, ...]
+) -> tuple[pd.DataFrame, np.ndarray]:
+    if len(metrics) < 2:
+        raise ValueError("At least two metrics are required")
+    missing = set(metrics) - set(frame.columns)
+    if missing:
+        raise ValueError(f"Metrics not present: {sorted(missing)}")
+    complete = frame[list(metrics)].apply(pd.to_numeric, errors="coerce").dropna()
+    if len(complete) < max(5, len(metrics) + 1):
+        raise ValueError("Insufficient complete rows for multivariate analysis")
+    values = complete.to_numpy(float)
+    standard_deviation = values.std(axis=0, ddof=1)
+    if np.any(standard_deviation == 0):
+        constants = [
+            metric
+            for metric, std in zip(metrics, standard_deviation, strict=True)
+            if std == 0
+        ]
+        raise ValueError(f"Constant metrics cannot be analyzed: {constants}")
+    standardized = (values - values.mean(axis=0)) / standard_deviation
+    return complete, standardized
+
+
+def compute_pca(
+    frame: pd.DataFrame, *, metrics: tuple[str, ...] | list[str]
+) -> PCAResult:
+    """Compute PCA with deterministic SVD and conventional loadings."""
+    selected = tuple(metrics)
+    complete, standardized = _complete_standardized(frame, selected)
+    left, singular, right_transpose = np.linalg.svd(standardized, full_matrices=False)
+    eigenvalues = singular**2 / (len(standardized) - 1)
+    explained = eigenvalues / eigenvalues.sum()
+    component_names = [f"PC{index + 1}" for index in range(len(selected))]
+    loadings = pd.DataFrame(
+        right_transpose.T * np.sqrt(eigenvalues),
+        index=selected,
+        columns=component_names,
+    )
+    scores = pd.DataFrame(
+        left * singular,
+        index=complete.index,
+        columns=component_names,
+    )
+    return PCAResult(
+        selected,
+        pd.Series(explained, index=component_names, name="explained_variance_ratio"),
+        loadings,
+        scores,
+        len(complete),
+    )
+
+
+def compute_vif(
+    frame: pd.DataFrame, *, metrics: tuple[str, ...] | list[str]
+) -> VIFResult:
+    """Compute variance-inflation factors from auxiliary regressions."""
+    selected = tuple(metrics)
+    complete, standardized = _complete_standardized(frame, selected)
+    values: dict[str, float] = {}
+    for index, metric in enumerate(selected):
+        target = standardized[:, index]
+        predictors = np.delete(standardized, index, axis=1)
+        design = np.column_stack([np.ones(len(predictors)), predictors])
+        fitted = design @ np.linalg.lstsq(design, target, rcond=None)[0]
+        residual_sum = float(np.sum((target - fitted) ** 2))
+        total_sum = float(np.sum((target - target.mean()) ** 2))
+        r_squared = 1.0 - residual_sum / total_sum if total_sum > 0 else 1.0
+        values[metric] = (
+            float("inf") if r_squared >= 1 - 1e-12 else 1.0 / (1.0 - r_squared)
+        )
+    series = pd.Series(values, name="vif")
+    warnings = tuple(series.index[series >= 5.0])
+    return VIFResult(series, len(complete), warnings)

--- a/src/shared/python/launch_monitor/profiles.py
+++ b/src/shared/python/launch_monitor/profiles.py
@@ -1,0 +1,255 @@
+"""Header-fingerprint launch-monitor import profiles."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+from src.shared.python.launch_monitor.schema import ColumnMapping, METRICS
+
+
+def normalize_header(value: str) -> str:
+    """Normalize a source header for alias matching while retaining its meaning."""
+    expanded = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", str(value))
+    text = re.sub(r"\([^)]*\)|\[[^]]*\]", " ", expanded.lower())
+    text = re.sub(
+        r"\b(mph|kmh|kph|mps|rpm|yards?|yds?|yd|feet|foot|ft|inches|inch|in|degrees?|deg|radians?|rad|seconds?|sec|s)\b",
+        " ",
+        text,
+    )
+    return re.sub(r"[^a-z0-9]+", " ", text).strip()
+
+
+COMMON_ALIASES: Final[dict[str, tuple[str, ...]]] = {
+    "shot_id": ("shot", "shot number", "shot no", "shot id"),
+    "club": ("club", "club name"),
+    "player": ("player", "player name"),
+    "date": ("date", "shot date"),
+    "time": ("time", "shot time"),
+    "captured_at": ("timestamp", "date time", "datetime", "captured at"),
+    "club_speed": ("club speed", "club head speed", "clubhead speed", "chs"),
+    "ball_speed": ("ball speed", "launch speed"),
+    "attack_angle": ("attack angle", "angle of attack", "aoa"),
+    "club_path": ("club path", "path"),
+    "face_angle": ("face angle", "face to target", "club face"),
+    "face_to_path": ("face to path", "face path"),
+    "dynamic_loft": ("dynamic loft",),
+    "dynamic_lie": ("dynamic lie",),
+    "spin_loft": ("spin loft",),
+    "swing_direction": ("swing direction", "horizontal swing plane"),
+    "swing_plane": ("swing plane", "vertical swing plane"),
+    "low_point_distance": ("low point", "low point distance"),
+    "impact_height": ("impact height", "face impact height"),
+    "impact_offset": ("impact offset", "face impact offset"),
+    "launch_angle": ("launch angle", "vertical launch", "vla"),
+    "launch_direction": (
+        "launch direction",
+        "horizontal launch",
+        "horizontal launch angle",
+        "hla",
+        "side angle",
+    ),
+    "spin_rate": ("spin rate", "total spin", "spin"),
+    "back_spin": ("back spin", "backspin"),
+    "side_spin": ("side spin", "sidespin"),
+    "spin_axis": ("spin axis", "axis tilt"),
+    "smash_factor": ("smash factor", "smash"),
+    "carry_distance": ("carry", "carry distance"),
+    "total_distance": ("total", "total distance"),
+    "roll_distance": ("roll", "roll distance", "run"),
+    "lateral_carry": (
+        "carry side",
+        "lateral landing",
+        "carry deviation distance",
+    ),
+    "lateral_total": (
+        "side",
+        "side distance",
+        "offline",
+        "total side",
+        "total deviation distance",
+    ),
+    "apex_height": ("height", "apex", "apex height", "peak height", "max height"),
+    "flight_time": ("flight time", "time aloft"),
+    "descent_angle": ("descent angle", "landing angle", "vertical descent"),
+    "curve": ("curve",),
+    "putt_distance": ("putt distance", "distance"),
+    "skid_distance": ("skid distance",),
+    "roll_speed": ("roll speed",),
+}
+
+
+@dataclass(frozen=True)
+class ImportProfile:
+    """Vendor header profile and unit defaults."""
+
+    profile_id: str
+    vendor: str
+    signatures: tuple[str, ...]
+    aliases: dict[str, tuple[str, ...]]
+    default_units: dict[str, str]
+
+    def mappings_for(self, headers: list[str]) -> tuple[ColumnMapping, ...]:
+        """Return all unambiguous mappings found in ``headers``."""
+        normalized_to_source = {normalize_header(header): header for header in headers}
+        mappings: list[ColumnMapping] = []
+        claimed_sources: set[str] = set()
+        for target, aliases in self.aliases.items():
+            for alias in aliases:
+                source = normalized_to_source.get(normalize_header(alias))
+                if source is None or source in claimed_sources:
+                    continue
+                mappings.append(ColumnMapping(source, target))
+                claimed_sources.add(source)
+                break
+        return tuple(mappings)
+
+
+def _defaults() -> dict[str, str]:
+    values: dict[str, str] = {}
+    for name, definition in METRICS.items():
+        values[name] = {
+            "m/s": "mph",
+            "m": "yd",
+            "rad": "deg",
+            "rad/s": "rpm",
+            "s": "s",
+            "1": "1",
+        }[definition.canonical_unit]
+    return values
+
+
+def _aliases(**overrides: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    aliases = dict(COMMON_ALIASES)
+    aliases.update(overrides)
+    return aliases
+
+
+PROFILES: Final[dict[str, ImportProfile]] = {
+    item.profile_id: item
+    for item in (
+        ImportProfile(
+            "trackman",
+            "TrackMan",
+            ("attack angle", "club path", "face angle", "dynamic loft"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "foresight",
+            "Foresight Sports",
+            ("hla", "vla", "total spin", "offline"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "flightscope",
+            "FlightScope",
+            ("vertical launch", "horizontal launch", "lateral landing", "flight time"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "garmin",
+            "Garmin",
+            ("total deviation distance", "launch direction", "spin axis"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "skytrak",
+            "SkyTrak",
+            ("back spin", "side spin", "max height"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "uneekor",
+            "Uneekor",
+            ("side angle", "side distance", "apex"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "full_swing",
+            "Full Swing",
+            ("club speed", "ball speed", "face to path", "carry distance"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "rapsodo",
+            "Rapsodo",
+            ("smash factor", "launch direction", "shot type"),
+            _aliases(),
+            _defaults(),
+        ),
+        ImportProfile(
+            "gspro",
+            "GSPro / Open Connect",
+            (
+                "ball data speed",
+                "ball data hla",
+                "ball data vla",
+                "ball data back spin",
+            ),
+            _aliases(
+                ball_speed=("ball data speed", "ball speed"),
+                launch_direction=("ball data hla", "hla"),
+                launch_angle=("ball data vla", "vla"),
+                spin_rate=("ball data total spin", "total spin"),
+                back_spin=("ball data back spin", "back spin"),
+                side_spin=("ball data side spin", "side spin"),
+                spin_axis=("ball data spin axis", "spin axis"),
+                club_speed=("club data speed", "club speed"),
+                attack_angle=("club data angle of attack", "angle of attack"),
+                face_angle=("club data face to target", "face to target"),
+                club_path=("club data path", "club path"),
+                dynamic_loft=("club data loft", "dynamic loft"),
+                dynamic_lie=("club data lie", "dynamic lie"),
+                impact_height=("club data vertical face impact", "impact height"),
+                impact_offset=(
+                    "club data horizontal face impact",
+                    "impact offset",
+                ),
+            ),
+            _defaults(),
+        ),
+        ImportProfile("generic", "Generic", (), _aliases(), _defaults()),
+    )
+}
+
+
+@dataclass(frozen=True)
+class ProfileDetection:
+    """Ranked profile detection result."""
+
+    profile_id: str
+    confidence: float
+    matched_signatures: tuple[str, ...]
+    alternatives: tuple[tuple[str, float], ...]
+
+
+def detect_profile(headers: list[str]) -> ProfileDetection:
+    """Detect the most likely vendor profile from header fingerprints."""
+    if not headers:
+        raise ValueError("headers must contain at least one column")
+    normalized = {normalize_header(header) for header in headers}
+    ranked: list[tuple[str, float, tuple[str, ...]]] = []
+    for profile_id, profile in PROFILES.items():
+        if profile_id == "generic":
+            continue
+        matches = tuple(
+            signature
+            for signature in profile.signatures
+            if normalize_header(signature) in normalized
+        )
+        score = len(matches) / len(profile.signatures) if profile.signatures else 0.0
+        ranked.append((profile_id, score, matches))
+    ranked.sort(key=lambda item: (-item[1], item[0]))
+    best_id, best_score, matches = ranked[0]
+    if best_score < 0.5:
+        best_id, best_score, matches = "generic", 0.0, ()
+    alternatives = tuple((profile_id, score) for profile_id, score, _ in ranked[:4])
+    return ProfileDetection(best_id, best_score, matches, alternatives)

--- a/src/shared/python/launch_monitor/project.py
+++ b/src/shared/python/launch_monitor/project.py
@@ -1,0 +1,104 @@
+"""Launch-monitor project/session aggregation and persistence."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from io import StringIO
+from pathlib import Path
+
+import pandas as pd
+
+from src.shared.python.launch_monitor.schema import ImportedSession, ImportManifest
+
+
+class LaunchMonitorProject:
+    """Named collection of imported sessions with deterministic persistence."""
+
+    SCHEMA_VERSION = "launch-monitor-project-1.0"
+
+    def __init__(self, name: str) -> None:
+        if not name.strip():
+            raise ValueError("project name must be non-empty")
+        self.name = name.strip()
+        self.sessions: list[ImportedSession] = []
+        self.audit_log: list[dict[str, object]] = []
+
+    def add_session(self, session: ImportedSession) -> None:
+        """Add a session, rejecting duplicate session identities."""
+        if any(existing.session_id == session.session_id for existing in self.sessions):
+            raise ValueError(f"Session already exists: {session.session_id}")
+        self.sessions.append(session)
+
+    def remove_session(self, session_id: str) -> None:
+        """Remove a session by id."""
+        before = len(self.sessions)
+        self.sessions = [
+            item for item in self.sessions if item.session_id != session_id
+        ]
+        if len(self.sessions) == before:
+            raise ValueError(f"Unknown session: {session_id}")
+
+    def combined_shots(self) -> pd.DataFrame:
+        """Return the union of all source and canonical columns."""
+        if not self.sessions:
+            return pd.DataFrame()
+        return pd.concat(
+            [session.shots for session in self.sessions],
+            ignore_index=True,
+            sort=False,
+        )
+
+    def record_actions(self, actions: tuple[dict[str, object], ...]) -> None:
+        """Append treatment/filter actions to the durable project audit log."""
+        self.audit_log.extend(dict(action) for action in actions)
+
+    def save(self, destination: str | Path) -> Path:
+        """Save the project as a portable JSON document."""
+        path = Path(destination).expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": self.SCHEMA_VERSION,
+            "name": self.name,
+            "audit_log": self.audit_log,
+            "sessions": [
+                {
+                    "session_id": session.session_id,
+                    "name": session.name,
+                    "manifest": asdict(session.manifest),
+                    "metadata": session.metadata,
+                    "shots_table": session.shots.to_json(
+                        orient="table", date_format="iso", index=False
+                    ),
+                }
+                for session in self.sessions
+            ],
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+
+    @classmethod
+    def load(cls, source: str | Path) -> LaunchMonitorProject:
+        """Load and validate a saved project."""
+        path = Path(source).expanduser().resolve()
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("schema_version") != cls.SCHEMA_VERSION:
+            raise ValueError("Unsupported launch-monitor project schema")
+        project = cls(str(payload["name"]))
+        project.audit_log = list(payload.get("audit_log", []))
+        for item in payload.get("sessions", []):
+            manifest_data = dict(item["manifest"])
+            manifest_data["source_columns"] = tuple(manifest_data["source_columns"])
+            manifest_data["warnings"] = tuple(manifest_data.get("warnings", ()))
+            shots = pd.read_json(StringIO(item["shots_table"]), orient="table")
+            project.add_session(
+                ImportedSession(
+                    session_id=str(item["session_id"]),
+                    name=str(item["name"]),
+                    shots=shots,
+                    manifest=ImportManifest(**manifest_data),
+                    source_path=Path(manifest_data["source_path"]),
+                    metadata=dict(item.get("metadata", {})),
+                )
+            )
+        return project

--- a/src/shared/python/launch_monitor/relationships.py
+++ b/src/shared/python/launch_monitor/relationships.py
@@ -1,0 +1,187 @@
+"""Correlation, partial-correlation, and dependency-network analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from src.shared.python.launch_monitor.schema import METRICS
+
+
+@dataclass(frozen=True)
+class DependencyEdge:
+    """One statistically screened dependency-network edge."""
+
+    source: str
+    target: str
+    coefficient: float
+    p_value: float
+    adjusted_p_value: float
+    sample_count: int
+    includes_derived_metric: bool
+
+
+@dataclass(frozen=True)
+class CorrelationResult:
+    """Complete pairwise and optional partial-correlation result."""
+
+    method: str
+    coefficients: pd.DataFrame
+    p_values: pd.DataFrame
+    adjusted_p_values: pd.DataFrame | None
+    pair_counts: pd.DataFrame
+    partial_coefficients: pd.DataFrame | None
+    derived_metrics: tuple[str, ...]
+    edges: tuple[DependencyEdge, ...]
+
+
+def _pair_correlation(
+    x: pd.Series, y: pd.Series, method: str
+) -> tuple[float, float, int]:
+    valid = pd.concat([x, y], axis=1).dropna()
+    count = len(valid)
+    if count < 3 or valid.iloc[:, 0].nunique() < 2 or valid.iloc[:, 1].nunique() < 2:
+        return float("nan"), float("nan"), count
+    left = valid.iloc[:, 0].to_numpy(float)
+    right = valid.iloc[:, 1].to_numpy(float)
+    if method == "pearson":
+        result = stats.pearsonr(left, right)
+    elif method == "spearman":
+        result = stats.spearmanr(left, right)
+    elif method == "kendall":
+        result = stats.kendalltau(left, right)
+    else:
+        raise ValueError("method must be one of: pearson, spearman, kendall")
+    return float(result.statistic), float(result.pvalue), count
+
+
+def _benjamini_hochberg(matrix: pd.DataFrame) -> pd.DataFrame:
+    adjusted = pd.DataFrame(np.nan, index=matrix.index, columns=matrix.columns)
+    matrix_values = matrix.to_numpy(dtype=float)
+    pairs: list[tuple[int, int, float]] = []
+    for i in range(len(matrix)):
+        for j in range(i + 1, len(matrix)):
+            value = matrix_values[i, j]
+            if np.isfinite(value):
+                pairs.append((i, j, float(value)))
+    if not pairs:
+        return adjusted
+    order = np.argsort([item[2] for item in pairs])
+    raw = np.asarray([pairs[index][2] for index in order], dtype=float)
+    ranks = np.arange(1, len(raw) + 1)
+    corrected = np.minimum.accumulate((raw * len(raw) / ranks)[::-1])[::-1]
+    corrected = np.clip(corrected, 0.0, 1.0)
+    for ordered_index, value in zip(order, corrected, strict=True):
+        i, j, _ = pairs[int(ordered_index)]
+        adjusted.iat[i, j] = value
+        adjusted.iat[j, i] = value
+    for index in range(len(adjusted)):
+        adjusted.iat[index, index] = 0.0
+    return adjusted
+
+
+def _residualize(values: pd.Series, controls: pd.DataFrame) -> pd.Series:
+    combined = pd.concat([values, controls], axis=1).dropna()
+    output = pd.Series(np.nan, index=values.index, dtype=float)
+    if len(combined) <= controls.shape[1] + 2:
+        return output
+    y = combined.iloc[:, 0].to_numpy(float)
+    x = combined.iloc[:, 1:].to_numpy(float)
+    design = np.column_stack([np.ones(len(x)), x])
+    coefficients = np.linalg.lstsq(design, y, rcond=None)[0]
+    output.loc[combined.index] = y - design @ coefficients
+    return output
+
+
+def compute_correlations(
+    frame: pd.DataFrame,
+    *,
+    metrics: tuple[str, ...] | list[str],
+    method: str = "pearson",
+    controls: tuple[str, ...] | list[str] = (),
+    edge_threshold: float = 0.3,
+    alpha: float = 0.05,
+) -> CorrelationResult:
+    """Compute pairwise relationships with FDR correction and controls."""
+    selected = tuple(metrics)
+    if len(selected) < 2:
+        raise ValueError("At least two metrics are required")
+    missing = (set(selected) | set(controls)) - set(frame.columns)
+    if missing:
+        raise ValueError(f"Columns not present: {sorted(missing)}")
+    numeric = frame[list(selected)].apply(pd.to_numeric, errors="coerce")
+    coefficients = pd.DataFrame(np.nan, index=selected, columns=selected)
+    p_values = coefficients.copy()
+    pair_counts = pd.DataFrame(0, index=selected, columns=selected, dtype=int)
+    for i, left in enumerate(selected):
+        for j in range(i, len(selected)):
+            right = selected[j]
+            if i == j:
+                count = int(numeric[left].notna().sum())
+                coefficient, p_value = 1.0, 0.0
+            else:
+                coefficient, p_value, count = _pair_correlation(
+                    numeric[left], numeric[right], method
+                )
+            coefficients.iat[i, j] = coefficients.iat[j, i] = coefficient
+            p_values.iat[i, j] = p_values.iat[j, i] = p_value
+            pair_counts.iat[i, j] = pair_counts.iat[j, i] = count
+    adjusted = _benjamini_hochberg(p_values)
+
+    partial: pd.DataFrame | None = None
+    if controls:
+        control_frame = frame[list(controls)].apply(pd.to_numeric, errors="coerce")
+        residuals = {
+            metric: _residualize(numeric[metric], control_frame) for metric in selected
+        }
+        partial = pd.DataFrame(np.nan, index=selected, columns=selected)
+        for i, left in enumerate(selected):
+            for j in range(i, len(selected)):
+                right = selected[j]
+                value = (
+                    1.0
+                    if i == j
+                    else _pair_correlation(residuals[left], residuals[right], method)[0]
+                )
+                partial.iat[i, j] = partial.iat[j, i] = value
+
+    derived = tuple(
+        metric
+        for metric in selected
+        if metric in METRICS and METRICS[metric].derived_from
+    )
+    edges: list[DependencyEdge] = []
+    for i, left in enumerate(selected):
+        for j in range(i + 1, len(selected)):
+            right = selected[j]
+            coefficient = float(coefficients.to_numpy(dtype=float)[i, j])
+            adjusted_p = float(adjusted.to_numpy(dtype=float)[i, j])
+            if not np.isfinite(coefficient) or not np.isfinite(adjusted_p):
+                continue
+            if abs(coefficient) < edge_threshold or adjusted_p > alpha:
+                continue
+            edges.append(
+                DependencyEdge(
+                    left,
+                    right,
+                    coefficient,
+                    float(p_values.to_numpy(dtype=float)[i, j]),
+                    adjusted_p,
+                    int(pair_counts.to_numpy(dtype=int)[i, j]),
+                    left in derived or right in derived,
+                )
+            )
+    edges.sort(key=lambda edge: (-abs(edge.coefficient), edge.source, edge.target))
+    return CorrelationResult(
+        method,
+        coefficients,
+        p_values,
+        adjusted,
+        pair_counts,
+        partial,
+        derived,
+        tuple(edges),
+    )

--- a/src/shared/python/launch_monitor/schema.py
+++ b/src/shared/python/launch_monitor/schema.py
@@ -1,0 +1,195 @@
+"""Canonical launch-monitor metric and session contracts.
+
+Numeric shot metrics use one canonical unit per metric. Raw source columns are
+retained separately by the importer so conversion is reversible and auditable.
+Angles are radians, speeds are metres per second, distances are metres, spin is
+radians per second, and time is seconds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    """Definition of one canonical shot metric."""
+
+    name: str
+    label: str
+    category: str
+    canonical_unit: str
+    display_unit: str
+    derived_from: tuple[str, ...] = ()
+    description: str = ""
+
+
+def _metric(
+    name: str,
+    label: str,
+    category: str,
+    unit: str,
+    display: str,
+    *,
+    derived_from: tuple[str, ...] = (),
+) -> MetricDefinition:
+    return MetricDefinition(name, label, category, unit, display, derived_from)
+
+
+METRICS: Final[dict[str, MetricDefinition]] = {
+    item.name: item
+    for item in (
+        _metric("club_speed", "Club Speed", "club", "m/s", "mph"),
+        _metric("attack_angle", "Attack Angle", "club", "rad", "deg"),
+        _metric("club_path", "Club Path", "club", "rad", "deg"),
+        _metric("face_angle", "Face Angle", "club", "rad", "deg"),
+        _metric(
+            "face_to_path",
+            "Face to Path",
+            "club",
+            "rad",
+            "deg",
+            derived_from=("face_angle", "club_path"),
+        ),
+        _metric("dynamic_loft", "Dynamic Loft", "club", "rad", "deg"),
+        _metric("dynamic_lie", "Dynamic Lie", "club", "rad", "deg"),
+        _metric("spin_loft", "Spin Loft", "club", "rad", "deg"),
+        _metric("swing_direction", "Swing Direction", "club", "rad", "deg"),
+        _metric("swing_plane", "Swing Plane", "club", "rad", "deg"),
+        _metric("low_point_distance", "Low Point", "club", "m", "in"),
+        _metric("impact_height", "Impact Height", "club", "m", "mm"),
+        _metric("impact_offset", "Impact Offset", "club", "m", "mm"),
+        _metric("ball_speed", "Ball Speed", "launch", "m/s", "mph"),
+        _metric("launch_angle", "Launch Angle", "launch", "rad", "deg"),
+        _metric("launch_direction", "Launch Direction", "launch", "rad", "deg"),
+        _metric("spin_rate", "Spin Rate", "launch", "rad/s", "rpm"),
+        _metric("back_spin", "Back Spin", "launch", "rad/s", "rpm"),
+        _metric("side_spin", "Side Spin", "launch", "rad/s", "rpm"),
+        _metric("spin_axis", "Spin Axis", "launch", "rad", "deg"),
+        _metric(
+            "smash_factor",
+            "Smash Factor",
+            "launch",
+            "1",
+            "1",
+            derived_from=("ball_speed", "club_speed"),
+        ),
+        _metric("carry_distance", "Carry Distance", "flight", "m", "yd"),
+        _metric("total_distance", "Total Distance", "flight", "m", "yd"),
+        _metric("roll_distance", "Roll Distance", "flight", "m", "yd"),
+        _metric("lateral_carry", "Lateral Carry", "flight", "m", "yd"),
+        _metric("lateral_total", "Lateral Total", "flight", "m", "yd"),
+        _metric("apex_height", "Apex Height", "flight", "m", "ft"),
+        _metric("flight_time", "Flight Time", "flight", "s", "s"),
+        _metric("descent_angle", "Descent Angle", "flight", "rad", "deg"),
+        _metric("curve", "Curve", "flight", "m", "yd"),
+        _metric("putt_distance", "Putt Distance", "putting", "m", "ft"),
+        _metric("skid_distance", "Skid Distance", "putting", "m", "in"),
+        _metric("roll_speed", "Roll Speed", "putting", "m/s", "mph"),
+    )
+}
+
+IDENTITY_COLUMNS: Final[tuple[str, ...]] = (
+    "shot_id",
+    "session_id",
+    "source_row",
+    "monitor_vendor",
+    "monitor_model",
+    "software_version",
+    "captured_at",
+    "player",
+    "club",
+    "ball",
+    "tags",
+)
+
+
+@dataclass(frozen=True)
+class ColumnMapping:
+    """Map a source column onto a canonical metric or identity field."""
+
+    source_column: str
+    target_column: str
+    source_unit: str | None = None
+    multiplier: float = 1.0
+    measurement_status: str = "reported"
+
+    def __post_init__(self) -> None:
+        if not self.source_column.strip():
+            raise ValueError("source_column must be non-empty")
+        valid = set(METRICS) | set(IDENTITY_COLUMNS) | {"date", "time"}
+        if self.target_column not in valid:
+            raise ValueError(f"Unknown target column: {self.target_column}")
+        if not pd.notna(self.multiplier) or self.multiplier == 0:
+            raise ValueError("multiplier must be finite and non-zero")
+        allowed_statuses = {"reported", "measured", "estimated", "derived", "unknown"}
+        if self.measurement_status not in allowed_statuses:
+            raise ValueError(
+                "measurement_status must be reported, measured, estimated, "
+                "derived, or unknown"
+            )
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    """User-controlled import options."""
+
+    profile_id: str | None = None
+    mappings: tuple[ColumnMapping, ...] = ()
+    session_name: str | None = None
+    player: str | None = None
+    monitor_model: str | None = None
+    software_version: str | None = None
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ImportManifest:
+    """Immutable provenance and mapping record for one source file."""
+
+    source_path: str
+    file_sha256: str
+    profile_id: str
+    vendor: str
+    imported_at: str
+    row_count: int
+    source_columns: tuple[str, ...]
+    metric_sources: dict[str, str]
+    source_units: dict[str, str]
+    unit_evidence: dict[str, str]
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass
+class ImportedSession:
+    """Canonical shots and provenance for one imported session."""
+
+    session_id: str
+    name: str
+    shots: pd.DataFrame
+    manifest: ImportManifest
+    source_path: Path | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must be non-empty")
+        if self.shots.empty:
+            raise ValueError("ImportedSession must contain at least one shot")
+        required = {"shot_id", "session_id", "source_row", "monitor_vendor"}
+        missing = required - set(self.shots.columns)
+        if missing:
+            raise ValueError(f"shots missing required columns: {sorted(missing)}")
+
+
+def numeric_metric_columns(frame: pd.DataFrame) -> list[str]:
+    """Return canonical numeric metric columns present in ``frame``."""
+    return [
+        name
+        for name in METRICS
+        if name in frame.columns and pd.api.types.is_numeric_dtype(frame[name])
+    ]

--- a/src/shared/python/launch_monitor/treatment.py
+++ b/src/shared/python/launch_monitor/treatment.py
@@ -1,0 +1,215 @@
+"""Reproducible launch-monitor data-treatment pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FilterRule:
+    """One structured, auditable subset rule."""
+
+    column: str
+    operator: str
+    value: object
+
+    def __post_init__(self) -> None:
+        allowed = {"eq", "ne", "lt", "le", "gt", "ge", "contains", "in"}
+        if not self.column.strip():
+            raise ValueError("filter column must be non-empty")
+        if self.operator not in allowed:
+            raise ValueError(f"Unsupported filter operator: {self.operator}")
+
+
+@dataclass(frozen=True)
+class TreatmentConfig:
+    """Configuration for non-destructive quality flagging and filtering."""
+
+    required_metrics: tuple[str, ...] = ()
+    duplicate_columns: tuple[str, ...] = ("shot_id",)
+    outlier_metrics: tuple[str, ...] = ()
+    robust_z_threshold: float = 4.5
+    exclude_flagged: bool = False
+    derive_metrics: bool = True
+    filters: tuple[FilterRule, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.robust_z_threshold <= 0 or not np.isfinite(self.robust_z_threshold):
+            raise ValueError("robust_z_threshold must be finite and positive")
+
+
+@dataclass(frozen=True)
+class TreatmentResult:
+    """Treated analysis view, row-level flags, and audit records."""
+
+    data: pd.DataFrame
+    flags: pd.DataFrame
+    audit_log: tuple[dict[str, object], ...]
+
+
+def _robust_outlier_mask(values: pd.Series, threshold: float) -> pd.Series:
+    numeric = pd.to_numeric(values, errors="coerce")
+    median = numeric.median()
+    absolute = (numeric - median).abs()
+    mad = absolute.median()
+    if not np.isfinite(mad) or mad == 0:
+        std = numeric.std(ddof=0)
+        if not np.isfinite(std) or std == 0:
+            return pd.Series(False, index=values.index)
+        return absolute / std > threshold
+    modified_z = 0.67448975 * absolute / mad
+    return modified_z > threshold
+
+
+def _filter_mask(frame: pd.DataFrame, rule: FilterRule) -> pd.Series:
+    if rule.column not in frame:
+        raise ValueError(f"Filter column not present: {rule.column}")
+    values = frame[rule.column]
+    if rule.operator in {"lt", "le", "gt", "ge"}:
+        numeric = pd.to_numeric(values, errors="coerce")
+        try:
+            target = float(str(rule.value))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Filter value for {rule.operator} must be numeric: {rule.value}"
+            ) from exc
+        return {
+            "lt": numeric < target,
+            "le": numeric <= target,
+            "gt": numeric > target,
+            "ge": numeric >= target,
+        }[rule.operator]
+    if rule.operator == "contains":
+        return values.astype(str).str.contains(str(rule.value), case=False, na=False)
+    if rule.operator == "in":
+        accepted = [item.strip() for item in str(rule.value).split(",")]
+        return values.astype(str).isin(accepted)
+    if rule.operator == "eq":
+        return values.astype(str) == str(rule.value)
+    return values.astype(str) != str(rule.value)
+
+
+def _derive_available_metrics(
+    frame: pd.DataFrame,
+) -> tuple[pd.DataFrame, list[dict[str, object]]]:
+    output = frame.copy()
+    actions: list[dict[str, object]] = []
+    recipes = {
+        "smash_factor": ("ball_speed", "club_speed", lambda a, b: a / b),
+        "face_to_path": ("face_angle", "club_path", lambda a, b: a - b),
+        "roll_distance": ("total_distance", "carry_distance", lambda a, b: a - b),
+    }
+    for target, (left, right, operation) in recipes.items():
+        if left not in output or right not in output:
+            continue
+        derived = operation(
+            pd.to_numeric(output[left], errors="coerce"),
+            pd.to_numeric(output[right], errors="coerce"),
+        ).replace([np.inf, -np.inf], np.nan)
+        if target in output:
+            mask = output[target].isna() & derived.notna()
+            output.loc[mask, target] = derived.loc[mask]
+        else:
+            mask = derived.notna()
+            output[target] = derived
+        status_column = f"status::{target}"
+        if status_column not in output:
+            output[status_column] = "unknown"
+        output.loc[mask, status_column] = "derived"
+        count = int(mask.sum())
+        if count:
+            actions.append(
+                {
+                    "action": "derive_metric",
+                    "metric": target,
+                    "inputs": [left, right],
+                    "row_count": count,
+                }
+            )
+    return output, actions
+
+
+def apply_treatment(frame: pd.DataFrame, config: TreatmentConfig) -> TreatmentResult:
+    """Flag data-quality conditions and optionally exclude affected rows."""
+    if frame.empty:
+        raise ValueError("frame must contain at least one shot")
+    working = frame.copy(deep=True)
+    records: list[dict[str, object]] = []
+    flagged_indices: set[object] = set()
+
+    if config.derive_metrics:
+        working, derivation_actions = _derive_available_metrics(working)
+    else:
+        derivation_actions = []
+
+    filter_actions: list[dict[str, object]] = []
+    for rule in config.filters:
+        before = len(working)
+        working = working.loc[_filter_mask(working, rule)].copy()
+        filter_actions.append(
+            {
+                "action": "filter",
+                "column": rule.column,
+                "operator": rule.operator,
+                "value": rule.value,
+                "rows_before": before,
+                "rows_after": len(working),
+            }
+        )
+
+    missing_columns = set(config.required_metrics) - set(working.columns)
+    if missing_columns:
+        raise ValueError(f"Required metrics not present: {sorted(missing_columns)}")
+    if config.required_metrics:
+        mask = working[list(config.required_metrics)].isna().any(axis=1)
+        for index in working.index[mask]:
+            records.append(
+                {"row_index": index, "flag_type": "missing_required", "metric": None}
+            )
+            flagged_indices.add(index)
+
+    duplicates = [name for name in config.duplicate_columns if name in working]
+    if duplicates:
+        mask = working.duplicated(subset=duplicates, keep="first")
+        for index in working.index[mask]:
+            records.append(
+                {
+                    "row_index": index,
+                    "flag_type": "duplicate",
+                    "metric": ",".join(duplicates),
+                }
+            )
+            flagged_indices.add(index)
+
+    for metric in config.outlier_metrics:
+        if metric not in working:
+            raise ValueError(f"Outlier metric not present: {metric}")
+        mask = _robust_outlier_mask(working[metric], config.robust_z_threshold)
+        for index in working.index[mask]:
+            records.append(
+                {"row_index": index, "flag_type": "robust_outlier", "metric": metric}
+            )
+            flagged_indices.add(index)
+
+    flags = pd.DataFrame(records, columns=["row_index", "flag_type", "metric"])
+    if config.exclude_flagged and flagged_indices:
+        working = working.drop(index=list(flagged_indices)).copy()
+    audit: list[dict[str, object]] = [
+        *derivation_actions,
+        *filter_actions,
+        *[
+            {
+                "action": "flag",
+                "flag_type": record["flag_type"],
+                "row_index": record["row_index"],
+                "metric": record["metric"],
+            }
+            for record in records
+        ],
+    ]
+    if config.exclude_flagged:
+        audit.append({"action": "exclude_flagged", "row_count": len(flagged_indices)})
+    return TreatmentResult(working.reset_index(drop=True), flags, tuple(audit))

--- a/src/shared/python/launch_monitor/trends.py
+++ b/src/shared/python/launch_monitor/trends.py
@@ -1,0 +1,110 @@
+"""Longitudinal player-performance trend analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+
+@dataclass(frozen=True)
+class ChangeCandidate:
+    """Candidate step change ranked by standardized before/after difference."""
+
+    captured_at: pd.Timestamp
+    row_index: int
+    before_mean: float
+    after_mean: float
+    effect_size: float
+
+
+@dataclass(frozen=True)
+class TrendResult:
+    """Linear/robust trend, rolling series, EWMA, and change candidates."""
+
+    metric: str
+    sample_count: int
+    slope_per_day: float
+    robust_slope_per_day: float
+    p_value: float
+    earliest_mean: float
+    latest_mean: float
+    rolling: pd.DataFrame
+    change_candidates: tuple[ChangeCandidate, ...]
+
+
+def _change_candidates(
+    times: pd.Series, values: np.ndarray, minimum_segment: int
+) -> tuple[ChangeCandidate, ...]:
+    candidates: list[ChangeCandidate] = []
+    for split in range(minimum_segment, len(values) - minimum_segment + 1):
+        before = values[:split]
+        after = values[split:]
+        pooled = np.sqrt((before.var(ddof=1) + after.var(ddof=1)) / 2)
+        effect = (after.mean() - before.mean()) / pooled if pooled > 0 else 0.0
+        candidates.append(
+            ChangeCandidate(
+                pd.Timestamp(times.iloc[split]),
+                split,
+                float(before.mean()),
+                float(after.mean()),
+                float(effect),
+            )
+        )
+    candidates.sort(key=lambda item: -abs(item.effect_size))
+    return tuple(item for item in candidates[:3] if abs(item.effect_size) >= 0.5)
+
+
+def analyze_trend(
+    frame: pd.DataFrame,
+    *,
+    metric: str,
+    time_column: str = "captured_at",
+    rolling_window: int = 10,
+    ewma_span: int | None = None,
+) -> TrendResult:
+    """Analyze center/variance movement over irregular observation time."""
+    if rolling_window < 3:
+        raise ValueError("rolling_window must be at least three")
+    missing = {metric, time_column} - set(frame.columns)
+    if missing:
+        raise ValueError(f"Trend columns not present: {sorted(missing)}")
+    clean = frame[[time_column, metric]].copy()
+    clean[time_column] = pd.to_datetime(clean[time_column], errors="coerce", utc=True)
+    clean[metric] = pd.to_numeric(clean[metric], errors="coerce")
+    clean = clean.dropna().sort_values(time_column).reset_index(drop=True)
+    if len(clean) < max(6, rolling_window):
+        raise ValueError("Insufficient complete observations for trend analysis")
+    values = clean[metric].to_numpy(float)
+    elapsed_days = (
+        clean[time_column] - clean[time_column].iloc[0]
+    ).dt.total_seconds().to_numpy() / 86400.0
+    regression = stats.linregress(elapsed_days, values)
+    robust = stats.theilslopes(values, elapsed_days)
+    span = ewma_span or rolling_window
+    rolling = pd.DataFrame(
+        {
+            time_column: clean[time_column],
+            "value": values,
+            "rolling_mean": clean[metric].rolling(rolling_window, min_periods=3).mean(),
+            "rolling_median": clean[metric]
+            .rolling(rolling_window, min_periods=3)
+            .median(),
+            "rolling_std": clean[metric].rolling(rolling_window, min_periods=3).std(),
+            "ewma": clean[metric].ewm(span=span, adjust=False).mean(),
+        }
+    )
+    segment = max(3, min(rolling_window, len(values) // 3))
+    return TrendResult(
+        metric,
+        len(clean),
+        float(regression.slope),
+        float(robust.slope),
+        float(regression.pvalue),
+        float(np.mean(values[:segment])),
+        float(np.mean(values[-segment:])),
+        rolling,
+        _change_candidates(clean[time_column], values, segment),
+    )

--- a/src/tools/launch_monitor_analytics/__init__.py
+++ b/src/tools/launch_monitor_analytics/__init__.py
@@ -1,0 +1,7 @@
+"""PyQt6 Launch Monitor Analytics workbench."""
+
+from __future__ import annotations
+
+__version__ = "1.0.0"
+
+__all__ = ["__version__"]

--- a/src/tools/launch_monitor_analytics/__main__.py
+++ b/src/tools/launch_monitor_analytics/__main__.py
@@ -1,0 +1,22 @@
+"""Run the standalone Launch Monitor Analytics workbench."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    try:
+        from src.tools.launch_monitor_analytics.gui import main as gui_main
+    except ImportError as exc:
+        sys.stderr.write(
+            "Launch Monitor Analytics requires GUI dependencies. Install with:\n"
+            "  pip install upstream-drift[gui-tools]\n"
+            f"Import error: {exc}\n"
+        )
+        return 1
+    return gui_main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/launch_monitor_analytics/_embed_adapter.py
+++ b/src/tools/launch_monitor_analytics/_embed_adapter.py
@@ -1,0 +1,43 @@
+"""PyQt6-free launcher embed adapter for Launch Monitor Analytics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.shared.python.launcher_embed import EmbedCapabilities, register_embeddable_tool
+
+
+class LaunchMonitorAnalyticsEmbedAdapter:
+    """Host the analytics workbench as a reusable launcher tab."""
+
+    tool_id = "launch_monitor_analytics"
+
+    def __init__(self) -> None:
+        self._widget: Any | None = None
+
+    def embed_capabilities(self) -> EmbedCapabilities:
+        return EmbedCapabilities(
+            supports_embedded=True,
+            prefers_dock=False,
+            min_size=(1100, 700),
+            requires_separate_qapplication=False,
+        )
+
+    def create_main_widget(self, parent: Any) -> Any:
+        if self._widget is None:
+            from src.tools.launch_monitor_analytics.gui import MainWidget
+
+            self._widget = MainWidget(parent=parent)
+        return self._widget
+
+    def cleanup(self) -> None:
+        widget = self._widget
+        self._widget = None
+        if widget is not None:
+            widget.deleteLater()
+
+    def is_dirty(self) -> bool:
+        return bool(self._widget is not None and self._widget.is_dirty())
+
+
+register_embeddable_tool(LaunchMonitorAnalyticsEmbedAdapter())

--- a/src/tools/launch_monitor_analytics/gui.py
+++ b/src/tools/launch_monitor_analytics/gui.py
@@ -1,0 +1,1051 @@
+"""PyQt6 Launch Monitor Analytics workbench."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.dates import date2num
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from src.shared.python.launch_monitor import (
+    CorrelationResult,
+    FilterRule,
+    ImportOptions,
+    LaunchMonitorProject,
+    TreatmentConfig,
+    analyze_dispersion,
+    analyze_trend,
+    apply_treatment,
+    compare_monitors,
+    compute_correlations,
+    compute_pca,
+    compute_vif,
+    fit_predictive_model,
+    import_session,
+    numeric_metric_columns,
+)
+from src.shared.python.logging_pkg.logging_config import get_logger
+from src.tools.launch_monitor_analytics.widgets import (
+    DataFrameTable,
+    ImportMappingDialog,
+)
+
+logger = get_logger(__name__)
+
+__all__ = ["LaunchMonitorAnalyticsWindow", "MainWidget", "main"]
+
+
+class PlotCanvas(FigureCanvasQTAgg):
+    """Small reusable matplotlib canvas."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        self.figure = Figure(figsize=(6.0, 4.0), tight_layout=True)
+        super().__init__(self.figure)
+        self.setParent(parent)
+        self.axes = self.figure.add_subplot(111)
+        self.empty("Import data to begin.")
+
+    def empty(self, message: str) -> None:
+        self.axes.clear()
+        self.axes.text(
+            0.5, 0.5, message, ha="center", va="center", transform=self.axes.transAxes
+        )
+        self.axes.set_axis_off()
+        self.draw_idle()
+
+    def reset_axes(self) -> Axes:
+        """Replace every axes, including colorbars from a prior analysis."""
+        self.figure.clear()
+        self.axes = self.figure.add_subplot(111)
+        return self.axes
+
+
+def _selected_text(list_widget: QtWidgets.QListWidget) -> tuple[str, ...]:
+    return tuple(item.text() for item in list_widget.selectedItems())
+
+
+def _populate_combo(combo: QtWidgets.QComboBox, values: list[str]) -> None:
+    previous = combo.currentText()
+    combo.blockSignals(True)
+    combo.clear()
+    combo.addItems(values)
+    previous_index = combo.findText(previous)
+    if previous_index >= 0:
+        combo.setCurrentIndex(previous_index)
+    combo.blockSignals(False)
+
+
+class MainWidget(QtWidgets.QWidget):
+    """Embeddable launch-monitor data-management and analysis workspace."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Launch Monitor Analytics")
+        self.project = LaunchMonitorProject("Untitled Launch Monitor Study")
+        self.analysis_frame = pd.DataFrame()
+        self._dirty = False
+        self._build_ui()
+        self._wire_actions()
+        self._apply_theme_best_effort()
+        self._refresh_all()
+
+    def _build_ui(self) -> None:
+        title = QtWidgets.QLabel("Launch Monitor Analytics")
+        title.setObjectName("WorkspaceTitle")
+        title_font = title.font()
+        title_font.setPointSize(max(14, title_font.pointSize() + 4))
+        title_font.setBold(True)
+        title.setFont(title_font)
+        subtitle = QtWidgets.QLabel(
+            "Harmonize multi-vendor sessions, map interdependencies, compare "
+            "measurement systems, and track dispersion and player change."
+        )
+        subtitle.setWordWrap(True)
+        self.scientific_boundary = QtWidgets.QLabel(
+            "Scientific Boundary: Correlation and predictive fit do not establish "
+            "causality. Derived metrics and unmatched monitor comparisons require "
+            "special care."
+        )
+        self.scientific_boundary.setObjectName("ScientificBoundary")
+        self.scientific_boundary.setWordWrap(True)
+
+        self.tabs = QtWidgets.QTabWidget()
+        self.tabs.addTab(self._build_sessions_tab(), "Sessions")
+        self.tabs.addTab(self._build_treatment_tab(), "Data Treatment")
+        self.tabs.addTab(self._build_relationships_tab(), "Relationships")
+        self.tabs.addTab(self._build_models_tab(), "Models")
+        self.tabs.addTab(self._build_comparison_tab(), "Monitor Comparison")
+        self.tabs.addTab(self._build_dispersion_tab(), "Dispersion")
+        self.tabs.addTab(self._build_trends_tab(), "Trends")
+        self.tabs.addTab(self._build_reports_tab(), "Reports")
+        self.status_label = QtWidgets.QLabel(
+            "Ready. Import one or more launch-monitor exports."
+        )
+        self.status_label.setWordWrap(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+        layout.addWidget(self.scientific_boundary)
+        layout.addWidget(self.tabs, 1)
+        layout.addWidget(self.status_label)
+
+    def _build_sessions_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.session_tree = QtWidgets.QTreeWidget()
+        self.session_tree.setHeaderLabels(["Session", "Monitor", "Shots", "Profile"])
+        self.session_tree.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.data_table = DataFrameTable()
+        self.import_button = QtWidgets.QPushButton("Import Files...")
+        self.open_project_button = QtWidgets.QPushButton("Open Project...")
+        self.save_project_button = QtWidgets.QPushButton("Save Project...")
+        self.remove_session_button = QtWidgets.QPushButton("Remove Selected Sessions")
+        self.clear_project_button = QtWidgets.QPushButton("New Project")
+        for button in (
+            self.import_button,
+            self.open_project_button,
+            self.save_project_button,
+            self.remove_session_button,
+            self.clear_project_button,
+        ):
+            button.setMinimumHeight(30)
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(self.import_button)
+        buttons.addWidget(self.open_project_button)
+        buttons.addWidget(self.save_project_button)
+        buttons.addWidget(self.remove_session_button)
+        buttons.addWidget(self.clear_project_button)
+        buttons.addStretch(1)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(self.session_tree)
+        splitter.addWidget(self.data_table)
+        splitter.setSizes([340, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addLayout(buttons)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_treatment_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.required_metrics_edit = QtWidgets.QLineEdit()
+        self.required_metrics_edit.setPlaceholderText("club_speed, ball_speed")
+        self.outlier_metrics_edit = QtWidgets.QLineEdit()
+        self.outlier_metrics_edit.setPlaceholderText("club_speed, ball_speed")
+        self.outlier_threshold_spin = QtWidgets.QDoubleSpinBox()
+        self.outlier_threshold_spin.setRange(1.0, 20.0)
+        self.outlier_threshold_spin.setValue(4.5)
+        self.outlier_threshold_spin.setSingleStep(0.25)
+        self.exclude_flagged_check = QtWidgets.QCheckBox(
+            "Exclude Flagged Rows from Analysis View"
+        )
+        self.exclude_flagged_check.setChecked(False)
+        self.run_treatment_button = QtWidgets.QPushButton(
+            "Apply Reproducible Treatment"
+        )
+        self.filter_table = QtWidgets.QTableWidget(0, 3)
+        self.filter_table.setHorizontalHeaderLabels(["Column", "Operator", "Value"])
+        filter_header = self.filter_table.horizontalHeader()
+        assert filter_header is not None
+        filter_header.setStretchLastSection(True)
+        self.add_filter_button = QtWidgets.QPushButton("Add Filter")
+        self.remove_filter_button = QtWidgets.QPushButton("Remove Selected Filters")
+        filter_buttons = QtWidgets.QHBoxLayout()
+        filter_buttons.addWidget(self.add_filter_button)
+        filter_buttons.addWidget(self.remove_filter_button)
+        filter_buttons.addStretch(1)
+        form = QtWidgets.QFormLayout()
+        form.addRow("Required Metrics:", self.required_metrics_edit)
+        form.addRow("Robust-Outlier Metrics:", self.outlier_metrics_edit)
+        form.addRow("Modified Z Threshold:", self.outlier_threshold_spin)
+        form.addRow("", self.exclude_flagged_check)
+        form.addRow("", self.run_treatment_button)
+        controls = QtWidgets.QGroupBox("Treatment Recipe")
+        controls.setLayout(form)
+        self.flags_table = DataFrameTable()
+        self.audit_text = QtWidgets.QPlainTextEdit()
+        self.audit_text.setReadOnly(True)
+        self.audit_text.setPlaceholderText("Every treatment action is recorded here.")
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.flags_table)
+        output.addWidget(self.audit_text)
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(controls)
+        filter_box = QtWidgets.QGroupBox("Structured Subset Filters")
+        filter_layout = QtWidgets.QVBoxLayout(filter_box)
+        filter_layout.addLayout(filter_buttons)
+        filter_layout.addWidget(self.filter_table)
+        layout.addWidget(filter_box)
+        layout.addWidget(output, 1)
+        return tab
+
+    def _build_relationships_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.relationship_method = QtWidgets.QComboBox()
+        self.relationship_method.addItems(["pearson", "spearman", "kendall"])
+        self.relationship_metrics = QtWidgets.QListWidget()
+        self.relationship_metrics.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.relationship_controls = QtWidgets.QListWidget()
+        self.relationship_controls.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.edge_threshold_spin = QtWidgets.QDoubleSpinBox()
+        self.edge_threshold_spin.setRange(0.0, 1.0)
+        self.edge_threshold_spin.setValue(0.3)
+        self.edge_threshold_spin.setSingleStep(0.05)
+        self.run_relationship_button = QtWidgets.QPushButton("Map Interdependencies")
+        self.run_multivariate_button = QtWidgets.QPushButton(
+            "Run PCA and VIF Diagnostics"
+        )
+        control_form = QtWidgets.QFormLayout()
+        control_form.addRow("Method:", self.relationship_method)
+        control_form.addRow("Metrics:", self.relationship_metrics)
+        control_form.addRow("Partial-Correlation Controls:", self.relationship_controls)
+        control_form.addRow("Network Edge Threshold:", self.edge_threshold_spin)
+        control_form.addRow("", self.run_relationship_button)
+        control_form.addRow("", self.run_multivariate_button)
+        control_box = QtWidgets.QGroupBox("Relationship Configuration")
+        control_box.setLayout(control_form)
+        self.relationship_table = DataFrameTable()
+        self.relationship_plot = PlotCanvas()
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.relationship_plot)
+        output.addWidget(self.relationship_table)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(control_box)
+        splitter.addWidget(output)
+        splitter.setSizes([330, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_models_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.model_target = QtWidgets.QComboBox()
+        self.model_features = QtWidgets.QListWidget()
+        self.model_features.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.model_type = QtWidgets.QComboBox()
+        self.model_type.addItems(["linear", "ridge", "lasso", "elastic_net", "mlp"])
+        self.model_group = QtWidgets.QComboBox()
+        self.model_group.addItems(
+            ["(random split)", "session_id", "monitor_vendor", "club"]
+        )
+        self.model_seed = QtWidgets.QSpinBox()
+        self.model_seed.setRange(0, 2_147_483_647)
+        self.model_seed.setValue(42)
+        self.run_model_button = QtWidgets.QPushButton("Fit and Validate Model")
+        form = QtWidgets.QFormLayout()
+        form.addRow("Target:", self.model_target)
+        form.addRow("Features:", self.model_features)
+        form.addRow("Model:", self.model_type)
+        form.addRow("Grouped Holdout:", self.model_group)
+        form.addRow("Random Seed:", self.model_seed)
+        form.addRow("", self.run_model_button)
+        controls = QtWidgets.QGroupBox("Predictive Recipe")
+        controls.setLayout(form)
+        self.model_report = QtWidgets.QPlainTextEdit()
+        self.model_report.setReadOnly(True)
+        self.model_plot = PlotCanvas()
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.model_plot)
+        output.addWidget(self.model_report)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(controls)
+        splitter.addWidget(output)
+        splitter.setSizes([330, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_comparison_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.comparison_metric = QtWidgets.QComboBox()
+        self.comparison_match = QtWidgets.QComboBox()
+        self.comparison_reference = QtWidgets.QComboBox()
+        self.run_comparison_button = QtWidgets.QPushButton("Compare Monitor Behavior")
+        self.comparison_warning = QtWidgets.QLabel(
+            "Use a match identifier for the same shots whenever possible. "
+            "Unmatched results are descriptive, not calibration evidence."
+        )
+        self.comparison_warning.setWordWrap(True)
+        form = QtWidgets.QFormLayout()
+        form.addRow("Metric:", self.comparison_metric)
+        form.addRow("Matched-Shot Column:", self.comparison_match)
+        form.addRow("Reference Monitor:", self.comparison_reference)
+        form.addRow("", self.run_comparison_button)
+        form.addRow("", self.comparison_warning)
+        controls = QtWidgets.QGroupBox("Comparison Design")
+        controls.setLayout(form)
+        self.comparison_table = DataFrameTable()
+        self.comparison_plot = PlotCanvas()
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(controls)
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.comparison_plot)
+        output.addWidget(self.comparison_table)
+        splitter.addWidget(output)
+        splitter.setSizes([330, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_dispersion_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.dispersion_forward = QtWidgets.QComboBox()
+        self.dispersion_lateral = QtWidgets.QComboBox()
+        self.dispersion_group = QtWidgets.QComboBox()
+        self.dispersion_group.addItems(
+            ["(all shots)", "monitor_vendor", "session_id", "club"]
+        )
+        self.run_dispersion_button = QtWidgets.QPushButton("Analyze Dispersion")
+        form = QtWidgets.QFormLayout()
+        form.addRow("Forward Coordinate:", self.dispersion_forward)
+        form.addRow("Lateral Coordinate:", self.dispersion_lateral)
+        form.addRow("Group By:", self.dispersion_group)
+        form.addRow("", self.run_dispersion_button)
+        controls = QtWidgets.QGroupBox("Dispersion Definition")
+        controls.setLayout(form)
+        self.dispersion_table = DataFrameTable()
+        self.dispersion_plot = PlotCanvas()
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(controls)
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.dispersion_plot)
+        output.addWidget(self.dispersion_table)
+        splitter.addWidget(output)
+        splitter.setSizes([330, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_trends_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.trend_metric = QtWidgets.QComboBox()
+        self.trend_time = QtWidgets.QComboBox()
+        self.trend_window = QtWidgets.QSpinBox()
+        self.trend_window.setRange(3, 500)
+        self.trend_window.setValue(10)
+        self.run_trend_button = QtWidgets.QPushButton("Analyze Longitudinal Change")
+        form = QtWidgets.QFormLayout()
+        form.addRow("Metric:", self.trend_metric)
+        form.addRow("Time Column:", self.trend_time)
+        form.addRow("Rolling Window:", self.trend_window)
+        form.addRow("", self.run_trend_button)
+        controls = QtWidgets.QGroupBox("Trend Configuration")
+        controls.setLayout(form)
+        self.trend_table = DataFrameTable()
+        self.trend_plot = PlotCanvas()
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        splitter.addWidget(controls)
+        output = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
+        output.addWidget(self.trend_plot)
+        output.addWidget(self.trend_table)
+        splitter.addWidget(output)
+        splitter.setSizes([330, 900])
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addWidget(splitter, 1)
+        return tab
+
+    def _build_reports_tab(self) -> QtWidgets.QWidget:
+        tab = QtWidgets.QWidget()
+        self.report_text = QtWidgets.QPlainTextEdit()
+        self.report_text.setReadOnly(True)
+        self.export_data_button = QtWidgets.QPushButton("Export Canonical Data...")
+        self.export_manifest_button = QtWidgets.QPushButton(
+            "Export Reproducibility Manifest..."
+        )
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(self.export_data_button)
+        buttons.addWidget(self.export_manifest_button)
+        buttons.addStretch(1)
+        layout = QtWidgets.QVBoxLayout(tab)
+        layout.addLayout(buttons)
+        layout.addWidget(self.report_text, 1)
+        return tab
+
+    def _wire_actions(self) -> None:
+        self.import_button.clicked.connect(self._on_import_files)
+        self.open_project_button.clicked.connect(self._on_open_project)
+        self.save_project_button.clicked.connect(self._on_save_project)
+        self.remove_session_button.clicked.connect(self._remove_selected_sessions)
+        self.clear_project_button.clicked.connect(self.clear_project)
+        self.run_treatment_button.clicked.connect(self._run_treatment_ui)
+        self.add_filter_button.clicked.connect(self._add_filter_row)
+        self.remove_filter_button.clicked.connect(self._remove_filter_rows)
+        self.run_relationship_button.clicked.connect(self._run_relationship_ui)
+        self.run_multivariate_button.clicked.connect(self._run_multivariate_ui)
+        self.run_model_button.clicked.connect(self._run_model_ui)
+        self.run_comparison_button.clicked.connect(self._run_comparison_ui)
+        self.run_dispersion_button.clicked.connect(self._run_dispersion_ui)
+        self.run_trend_button.clicked.connect(self._run_trend_ui)
+        self.export_data_button.clicked.connect(self._on_export_data)
+        self.export_manifest_button.clicked.connect(self._on_export_manifest)
+
+    def _apply_theme_best_effort(self) -> None:
+        try:
+            from src.shared.python.theme import apply_theme_to_window
+        except ImportError:
+            return
+        if apply_theme_to_window is None:
+            return
+        try:
+            cast(Any, apply_theme_to_window)(self)
+        except (RuntimeError, AttributeError, TypeError, ValueError) as exc:
+            logger.debug("Theme application skipped: %s", exc)
+
+    def is_dirty(self) -> bool:
+        return self._dirty
+
+    def import_file(self, path: str | Path, options: ImportOptions | None = None):  # noqa: ANN201
+        """Import and append a session, then refresh every workspace."""
+        session = import_session(path, options)
+        self.project.add_session(session)
+        self.analysis_frame = self.project.combined_shots()
+        self._dirty = True
+        self._refresh_all()
+        self.status_label.setText(
+            f"Imported {session.name}: {len(session.shots)} shots from "
+            f"{session.manifest.vendor}. Project now contains "
+            f"{len(self.analysis_frame)} shots."
+        )
+        return session
+
+    def save_project(self, path: str | Path) -> Path:
+        saved = self.project.save(path)
+        self._dirty = False
+        self.status_label.setText(f"Saved project to {saved}.")
+        return saved
+
+    def load_project(self, path: str | Path) -> None:
+        self.project = LaunchMonitorProject.load(path)
+        self.analysis_frame = self.project.combined_shots()
+        self._dirty = False
+        self._refresh_all()
+        self.status_label.setText(
+            f"Loaded {self.project.name}: {len(self.analysis_frame)} shots."
+        )
+
+    def clear_project(self) -> None:
+        self.project = LaunchMonitorProject("Untitled Launch Monitor Study")
+        self.analysis_frame = pd.DataFrame()
+        self._dirty = False
+        self._refresh_all()
+        self.status_label.setText("New empty project. Import launch-monitor exports.")
+
+    def _refresh_all(self) -> None:
+        self._refresh_session_tree()
+        self.data_table.set_frame(self.analysis_frame)
+        metrics = numeric_metric_columns(self.analysis_frame)
+        for widget in (
+            self.relationship_metrics,
+            self.relationship_controls,
+            self.model_features,
+        ):
+            widget.clear()
+            widget.addItems(metrics)
+        for combo in (
+            self.model_target,
+            self.comparison_metric,
+            self.dispersion_forward,
+            self.dispersion_lateral,
+            self.trend_metric,
+        ):
+            _populate_combo(combo, metrics)
+        columns = [str(column) for column in self.analysis_frame.columns]
+        _populate_combo(self.comparison_match, ["(unmatched)", *columns])
+        monitors = (
+            sorted(self.analysis_frame["monitor_vendor"].dropna().astype(str).unique())
+            if "monitor_vendor" in self.analysis_frame
+            else []
+        )
+        _populate_combo(self.comparison_reference, monitors)
+        time_columns = [
+            column
+            for column in columns
+            if "time" in column or "date" in column or column == "captured_at"
+        ]
+        _populate_combo(self.trend_time, time_columns)
+        self._set_preferred_combo(self.dispersion_forward, "carry_distance")
+        self._set_preferred_combo(self.dispersion_lateral, "lateral_carry")
+        self._refresh_report()
+
+    @staticmethod
+    def _set_preferred_combo(combo: QtWidgets.QComboBox, value: str) -> None:
+        index = combo.findText(value)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+
+    def _refresh_session_tree(self) -> None:
+        self.session_tree.clear()
+        for session in self.project.sessions:
+            item = QtWidgets.QTreeWidgetItem(
+                [
+                    session.name,
+                    session.manifest.vendor,
+                    str(len(session.shots)),
+                    session.manifest.profile_id,
+                ]
+            )
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, session.session_id)
+            item.setToolTip(0, session.manifest.source_path)
+            self.session_tree.addTopLevelItem(item)
+        self.session_tree.resizeColumnToContents(0)
+
+    def _refresh_report(self) -> None:
+        source_fields = len(
+            [
+                column
+                for column in self.analysis_frame
+                if str(column).startswith("source::")
+            ]
+        )
+        metrics = numeric_metric_columns(self.analysis_frame)
+        warnings = [
+            warning
+            for session in self.project.sessions
+            for warning in session.manifest.warnings
+        ]
+        self.report_text.setPlainText(
+            "Launch Monitor Analytics Project\n"
+            "================================\n"
+            f"Project: {self.project.name}\n"
+            f"Sessions: {len(self.project.sessions)}\n"
+            f"Shots: {len(self.analysis_frame)}\n"
+            f"Canonical Numeric Metrics: {len(metrics)}\n"
+            f"Retained Source Fields: {source_fields}\n"
+            f"Import Warnings: {len(warnings)}\n\n"
+            f"Recorded Treatment Actions: {len(self.project.audit_log)}\n\n"
+            "Scientific Interpretation\n"
+            "-------------------------\n"
+            "Relationships describe association, not causation. Identity-derived "
+            "metrics are marked by the metric registry. Matched shots are required "
+            "for monitor bias and agreement claims; unmatched comparisons remain "
+            "descriptive. Original source columns and per-file SHA-256 provenance "
+            "are retained in the project."
+        )
+
+    def run_relationship_analysis(self) -> CorrelationResult:
+        metrics = _selected_text(self.relationship_metrics)
+        if len(metrics) < 2:
+            raise ValueError("Select at least two relationship metrics")
+        controls = tuple(
+            item
+            for item in _selected_text(self.relationship_controls)
+            if item not in metrics
+        )
+        result = compute_correlations(
+            self.analysis_frame,
+            metrics=metrics,
+            method=self.relationship_method.currentText(),
+            controls=controls,
+            edge_threshold=float(self.edge_threshold_spin.value()),
+        )
+        self.relationship_table.set_frame(
+            result.coefficients.reset_index(names="metric")
+        )
+        axes = self.relationship_plot.reset_axes()
+        image = axes.imshow(
+            result.coefficients.to_numpy(float), vmin=-1, vmax=1, cmap="coolwarm"
+        )
+        axes.set_xticks(range(len(metrics)), metrics, rotation=45, ha="right")
+        axes.set_yticks(range(len(metrics)), metrics)
+        axes.set_title(f"{result.method.title()} Correlation")
+        self.relationship_plot.figure.colorbar(image, ax=axes, fraction=0.046)
+        self.relationship_plot.draw_idle()
+        self.status_label.setText(
+            f"Mapped {len(result.edges)} screened dependency edges across "
+            f"{len(metrics)} metrics. Interpret as association, not causation."
+        )
+        return result
+
+    def _run_treatment_ui(self) -> None:
+        try:
+            required = tuple(
+                item.strip()
+                for item in self.required_metrics_edit.text().split(",")
+                if item.strip()
+            )
+            outliers = tuple(
+                item.strip()
+                for item in self.outlier_metrics_edit.text().split(",")
+                if item.strip()
+            )
+            result = apply_treatment(
+                self.project.combined_shots(),
+                TreatmentConfig(
+                    required_metrics=required,
+                    outlier_metrics=outliers,
+                    robust_z_threshold=float(self.outlier_threshold_spin.value()),
+                    exclude_flagged=self.exclude_flagged_check.isChecked(),
+                    filters=self._filter_rules(),
+                ),
+            )
+        except ValueError as exc:
+            self._show_error("Data Treatment Failed", exc)
+            return
+        self.analysis_frame = result.data
+        self.project.record_actions(result.audit_log)
+        self.flags_table.set_frame(result.flags)
+        self.audit_text.setPlainText(
+            json.dumps(self.project.audit_log, indent=2, default=str)
+        )
+        self._dirty = True
+        self._refresh_all()
+        self.status_label.setText(
+            f"Treatment complete: {len(result.flags)} flags; "
+            f"{len(result.data)} shots in the analysis view. Raw sessions are unchanged."
+        )
+
+    def _run_relationship_ui(self) -> None:
+        try:
+            self.run_relationship_analysis()
+        except ValueError as exc:
+            self._show_error("Relationship Analysis Failed", exc)
+
+    def _run_multivariate_ui(self) -> None:
+        metrics = _selected_text(self.relationship_metrics)
+        try:
+            pca = compute_pca(self.analysis_frame, metrics=metrics)
+            vif = compute_vif(self.analysis_frame, metrics=metrics)
+        except ValueError as exc:
+            self._show_error("Multivariate Analysis Failed", exc)
+            return
+        table = pca.loadings.copy()
+        table.insert(0, "VIF", vif.values)
+        self.relationship_table.set_frame(table.reset_index(names="metric"))
+        axes = self.relationship_plot.reset_axes()
+        axes.bar(
+            pca.explained_variance_ratio.index,
+            pca.explained_variance_ratio.to_numpy(dtype=float),
+        )
+        axes.set_ylim(0, 1)
+        axes.set_ylabel("Explained Variance Ratio")
+        axes.set_title("Principal-Component Variance")
+        axes.grid(True, axis="y", alpha=0.25)
+        self.relationship_plot.draw_idle()
+        warning = ", ".join(vif.warning_metrics) or "none"
+        self.status_label.setText(
+            f"PCA/VIF complete for {pca.sample_count} complete shots. "
+            f"VIF >= 5: {warning}."
+        )
+
+    def _run_model_ui(self) -> None:
+        group = self.model_group.currentText()
+        try:
+            result = fit_predictive_model(
+                self.analysis_frame,
+                target=self.model_target.currentText(),
+                features=_selected_text(self.model_features),
+                model=self.model_type.currentText(),
+                random_seed=int(self.model_seed.value()),
+                group_column=None if group == "(random split)" else group,
+            )
+        except (ValueError, ImportError) as exc:
+            self._show_error("Predictive Model Failed", exc)
+            return
+        self.model_report.setPlainText(
+            json.dumps(
+                {
+                    "model": result.model,
+                    "target": result.target,
+                    "features": result.features,
+                    "metrics": result.metrics,
+                    "coefficients": result.coefficients,
+                    "random_seed": result.random_seed,
+                    "train_count": result.train_count,
+                    "test_count": result.test_count,
+                },
+                indent=2,
+            )
+        )
+        axes = self.model_plot.reset_axes()
+        axes.scatter(
+            result.predictions["actual"], result.predictions["predicted"], alpha=0.75
+        )
+        bounds = [
+            result.predictions[["actual", "predicted"]].min().min(),
+            result.predictions[["actual", "predicted"]].max().max(),
+        ]
+        axes.plot(bounds, bounds, linestyle="--", color="gray")
+        axes.set_xlabel("Actual")
+        axes.set_ylabel("Predicted")
+        axes.set_title(f"Held-Out {result.model.replace('_', ' ').title()} Predictions")
+        axes.grid(True, alpha=0.25)
+        self.model_plot.draw_idle()
+        self.status_label.setText(
+            f"Model complete: R2={result.metrics['r2']:.3f}, "
+            f"RMSE={result.metrics['rmse']:.3g}."
+        )
+
+    def _run_comparison_ui(self) -> None:
+        match = self.comparison_match.currentText()
+        try:
+            result = compare_monitors(
+                self.analysis_frame,
+                metric=self.comparison_metric.currentText(),
+                match_column=None if match == "(unmatched)" else match,
+                reference_monitor=self.comparison_reference.currentText() or None,
+            )
+        except ValueError as exc:
+            self._show_error("Monitor Comparison Failed", exc)
+            return
+        self.comparison_table.set_frame(
+            pd.DataFrame(asdict(item) for item in result.pairwise)
+        )
+        axes = self.comparison_plot.reset_axes()
+        labels = [item.monitor for item in result.summaries]
+        means = [item.mean for item in result.summaries]
+        errors = [item.standard_deviation for item in result.summaries]
+        axes.errorbar(labels, means, yerr=errors, fmt="o", capsize=5)
+        axes.set_title(f"{result.metric}: Mean and Standard Deviation")
+        axes.grid(True, axis="y", alpha=0.25)
+        self.comparison_plot.draw_idle()
+        warning = next((item.warning for item in result.pairwise if item.warning), None)
+        self.status_label.setText(
+            warning or "Matched monitor agreement analysis complete."
+        )
+
+    def _run_dispersion_ui(self) -> None:
+        forward = self.dispersion_forward.currentText()
+        lateral = self.dispersion_lateral.currentText()
+        group_column = self.dispersion_group.currentText()
+        groups: list[tuple[object, pd.DataFrame]] = [("All Shots", self.analysis_frame)]
+        if group_column != "(all shots)" and group_column in self.analysis_frame:
+            groups = [
+                (name, group)
+                for name, group in self.analysis_frame.groupby(
+                    group_column, dropna=False
+                )
+            ]
+        rows: list[dict[str, object]] = []
+        axes = self.dispersion_plot.reset_axes()
+        try:
+            for name, group in groups:
+                result = analyze_dispersion(group, forward=forward, lateral=lateral)
+                rows.append({"group": str(name), **asdict(result)})
+                axes.scatter(
+                    group[forward], group[lateral], alpha=0.55, label=str(name)
+                )
+                angle = np.linspace(0, 2 * np.pi, 200)
+                ellipse = np.column_stack(
+                    [
+                        result.ellipse_major / 2 * np.cos(angle),
+                        result.ellipse_minor / 2 * np.sin(angle),
+                    ]
+                )
+                rotation = np.array(
+                    [
+                        [
+                            np.cos(result.ellipse_angle_rad),
+                            -np.sin(result.ellipse_angle_rad),
+                        ],
+                        [
+                            np.sin(result.ellipse_angle_rad),
+                            np.cos(result.ellipse_angle_rad),
+                        ],
+                    ]
+                )
+                rotated = ellipse @ rotation.T
+                axes.plot(
+                    rotated[:, 0] + result.mean_forward,
+                    rotated[:, 1] + result.mean_lateral,
+                )
+        except ValueError as exc:
+            self._show_error("Dispersion Analysis Failed", exc)
+            return
+        self.dispersion_table.set_frame(pd.DataFrame(rows))
+        axes.set_xlabel(forward)
+        axes.set_ylabel(lateral)
+        axes.set_title("95% Dispersion Ellipses")
+        axes.grid(True, alpha=0.25)
+        if len(groups) > 1:
+            axes.legend(fontsize="small")
+        self.dispersion_plot.draw_idle()
+        self.status_label.setText(f"Dispersion complete for {len(groups)} group(s).")
+
+    def _run_trend_ui(self) -> None:
+        try:
+            result = analyze_trend(
+                self.analysis_frame,
+                metric=self.trend_metric.currentText(),
+                time_column=self.trend_time.currentText(),
+                rolling_window=int(self.trend_window.value()),
+            )
+        except ValueError as exc:
+            self._show_error("Trend Analysis Failed", exc)
+            return
+        candidates = pd.DataFrame(asdict(item) for item in result.change_candidates)
+        self.trend_table.set_frame(candidates)
+        axes = self.trend_plot.reset_axes()
+        time_column = self.trend_time.currentText()
+        axes.scatter(
+            result.rolling[time_column],
+            result.rolling["value"],
+            s=16,
+            alpha=0.4,
+            label="Shots",
+        )
+        axes.plot(
+            result.rolling[time_column],
+            result.rolling["rolling_mean"],
+            label="Rolling Mean",
+        )
+        axes.plot(result.rolling[time_column], result.rolling["ewma"], label="EWMA")
+        for candidate in result.change_candidates:
+            axes.axvline(
+                date2num(candidate.captured_at.to_pydatetime()),
+                linestyle="--",
+                alpha=0.35,
+            )
+        axes.set_title(f"{result.metric}: Longitudinal Change")
+        axes.legend(fontsize="small")
+        axes.grid(True, alpha=0.25)
+        self.trend_plot.draw_idle()
+        self.status_label.setText(
+            f"Trend slope={result.slope_per_day:.4g}/day; "
+            f"{len(result.change_candidates)} candidate change point(s)."
+        )
+
+    def _on_import_files(self) -> None:
+        paths, _ = QtWidgets.QFileDialog.getOpenFileNames(
+            self,
+            "Import Launch Monitor Exports",
+            "",
+            "Data Files (*.csv *.tsv *.txt *.xlsx *.xls *.json);;All Files (*)",
+        )
+        for raw_path in paths:
+            path = Path(raw_path)
+            try:
+                dialog = ImportMappingDialog(path, self)
+                if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+                    continue
+                self.import_file(path, dialog.import_options())
+            except (ValueError, OSError) as exc:
+                self._show_error(f"Could Not Import {path.name}", exc)
+
+    def _remove_selected_sessions(self) -> None:
+        selected = self.session_tree.selectedItems()
+        if not selected:
+            return
+        for item in selected:
+            session_id = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            self.project.remove_session(str(session_id))
+        self.analysis_frame = self.project.combined_shots()
+        self._dirty = True
+        self._refresh_all()
+
+    def _on_open_project(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Open Launch Monitor Project",
+            "",
+            "Launch Monitor Projects (*.lmproject);;All Files (*)",
+        )
+        if path:
+            try:
+                self.load_project(path)
+            except (ValueError, OSError, json.JSONDecodeError) as exc:
+                self._show_error("Could Not Open Project", exc)
+
+    def _on_save_project(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Save Launch Monitor Project",
+            "study.lmproject",
+            "Launch Monitor Projects (*.lmproject)",
+        )
+        if path:
+            try:
+                self.save_project(path)
+            except OSError as exc:
+                self._show_error("Could Not Save Project", exc)
+
+    def _on_export_data(self) -> None:
+        path, selected_filter = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export Canonical Analysis View",
+            "launch_monitor_data.csv",
+            "CSV (*.csv);;Parquet (*.parquet)",
+        )
+        if not path:
+            return
+        try:
+            if "Parquet" in selected_filter or Path(path).suffix.lower() == ".parquet":
+                self.analysis_frame.to_parquet(path, index=False)
+            else:
+                self.analysis_frame.to_csv(path, index=False)
+        except (OSError, ValueError, ImportError) as exc:
+            self._show_error("Could Not Export Data", exc)
+            return
+        self.status_label.setText(f"Exported canonical analysis view to {path}.")
+
+    def _on_export_manifest(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export Reproducibility Manifest",
+            "launch_monitor_manifest.json",
+            "JSON (*.json)",
+        )
+        if not path:
+            return
+        payload = {
+            "project": self.project.name,
+            "sessions": [asdict(session.manifest) for session in self.project.sessions],
+            "treatment_audit_log": self.project.audit_log,
+            "analysis_rows": len(self.analysis_frame),
+            "canonical_metrics": numeric_metric_columns(self.analysis_frame),
+            "scientific_boundary": self.scientific_boundary.text(),
+        }
+        try:
+            Path(path).write_text(
+                json.dumps(payload, indent=2, default=str), encoding="utf-8"
+            )
+        except OSError as exc:
+            self._show_error("Could Not Export Manifest", exc)
+
+    def _show_error(self, title: str, exc: Exception) -> None:
+        logger.warning("%s: %s", title, exc)
+        self.status_label.setText(f"{title}: {exc}")
+        QtWidgets.QMessageBox.warning(self, title, str(exc))
+
+    def _add_filter_row(self) -> None:
+        row = self.filter_table.rowCount()
+        self.filter_table.insertRow(row)
+        column_combo = QtWidgets.QComboBox()
+        column_combo.addItems([str(column) for column in self.analysis_frame.columns])
+        operator_combo = QtWidgets.QComboBox()
+        operator_combo.addItems(["eq", "ne", "lt", "le", "gt", "ge", "contains", "in"])
+        self.filter_table.setCellWidget(row, 0, column_combo)
+        self.filter_table.setCellWidget(row, 1, operator_combo)
+        self.filter_table.setItem(row, 2, QtWidgets.QTableWidgetItem(""))
+
+    def _remove_filter_rows(self) -> None:
+        rows = sorted(
+            {index.row() for index in self.filter_table.selectedIndexes()}, reverse=True
+        )
+        for row in rows:
+            self.filter_table.removeRow(row)
+
+    def _filter_rules(self) -> tuple[FilterRule, ...]:
+        rules: list[FilterRule] = []
+        for row in range(self.filter_table.rowCount()):
+            column_widget = self.filter_table.cellWidget(row, 0)
+            operator_widget = self.filter_table.cellWidget(row, 1)
+            value_item = self.filter_table.item(row, 2)
+            if not isinstance(column_widget, QtWidgets.QComboBox) or not isinstance(
+                operator_widget, QtWidgets.QComboBox
+            ):
+                continue
+            rules.append(
+                FilterRule(
+                    column_widget.currentText(),
+                    operator_widget.currentText(),
+                    value_item.text() if value_item is not None else "",
+                )
+            )
+        return tuple(rules)
+
+
+class LaunchMonitorAnalyticsWindow(QtWidgets.QMainWindow):
+    """Standalone window wrapper for :class:`MainWidget`."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Launch Monitor Analytics")
+        self.resize(1440, 900)
+        self.main_widget = MainWidget(self)
+        self.setCentralWidget(self.main_widget)
+        self._build_menu()
+
+    def _build_menu(self) -> None:
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        file_menu = menu_bar.addMenu("&File")
+        help_menu = menu_bar.addMenu("&Help")
+        assert file_menu is not None
+        assert help_menu is not None
+        quit_action = QtGui.QAction("&Quit", self)
+        quit_action.setShortcut(QtGui.QKeySequence.StandardKey.Quit)
+        quit_action.triggered.connect(self.close)
+        file_menu.addAction(quit_action)
+        about_action = QtGui.QAction("&About Launch Monitor Analytics", self)
+        about_action.triggered.connect(self._show_about)
+        help_menu.addAction(about_action)
+
+    def _show_about(self) -> None:
+        QtWidgets.QMessageBox.about(
+            self,
+            "About Launch Monitor Analytics",
+            "<b>Launch Monitor Analytics</b><br><br>"
+            "A vendor-neutral workbench for auditable session aggregation, "
+            "impact-parameter interdependency mapping, predictive modeling, "
+            "monitor agreement, dispersion, and longitudinal trend analysis.<br><br>"
+            "Association and predictive performance do not establish causality.",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the standalone workbench and return the Qt exit code."""
+    arguments = argv if argv is not None else sys.argv
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(arguments)
+    window = LaunchMonitorAnalyticsWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tools/launch_monitor_analytics/widgets.py
+++ b/src/tools/launch_monitor_analytics/widgets.py
@@ -1,0 +1,198 @@
+"""Reusable widgets for the Launch Monitor Analytics workbench."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from PyQt6 import QtCore, QtWidgets
+
+from src.shared.python.launch_monitor import (
+    IDENTITY_COLUMNS,
+    METRICS,
+    PROFILES,
+    ColumnMapping,
+    ImportOptions,
+    detect_profile,
+)
+
+
+class DataFrameTable(QtWidgets.QTableWidget):
+    """Read-only, copyable tabular preview for pandas frames."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.setAlternatingRowColors(True)
+        self.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.setSortingEnabled(False)
+        header = self.horizontalHeader()
+        assert header is not None  # noqa: S101 - Qt creates the header
+        header.setStretchLastSection(False)
+
+    def set_frame(self, frame: pd.DataFrame, *, max_rows: int = 500) -> None:
+        """Render at most ``max_rows`` while retaining all columns."""
+        preview = frame.head(max_rows)
+        self.clear()
+        self.setRowCount(len(preview))
+        self.setColumnCount(len(preview.columns))
+        self.setHorizontalHeaderLabels([str(column) for column in preview.columns])
+        for row_position, (_, row) in enumerate(preview.iterrows()):
+            for column_position, value in enumerate(row):
+                text = "" if pd.isna(value) else str(value)
+                self.setItem(
+                    row_position, column_position, QtWidgets.QTableWidgetItem(text)
+                )
+        self.resizeColumnsToContents()
+
+
+def _read_headers(path: Path) -> list[str]:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        frame = pd.read_csv(path, nrows=5, sep=None, engine="python")
+    elif suffix in {".tsv", ".txt"}:
+        frame = pd.read_csv(path, nrows=5, sep="\t")
+    elif suffix in {".xlsx", ".xls"}:
+        frame = pd.read_excel(path, nrows=5)
+    elif suffix == ".json":
+        frame = pd.read_json(path)
+    else:
+        raise ValueError(f"Unsupported file extension: {suffix}")
+    return [str(column) for column in frame.columns]
+
+
+class ImportMappingDialog(QtWidgets.QDialog):
+    """Preview profile detection and edit column/unit mappings before import."""
+
+    def __init__(self, source: Path, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.source = source
+        self.headers = _read_headers(source)
+        detection = detect_profile(self.headers)
+        self.setWindowTitle("Review Launch Monitor Import")
+        self.resize(1240, 600)
+
+        self.profile_combo = QtWidgets.QComboBox()
+        for profile_id, profile in PROFILES.items():
+            self.profile_combo.addItem(f"{profile.vendor} ({profile_id})", profile_id)
+        detected_index = self.profile_combo.findData(detection.profile_id)
+        self.profile_combo.setCurrentIndex(max(0, detected_index))
+
+        self.confidence_label = QtWidgets.QLabel(
+            f"Detected {detection.profile_id} with {detection.confidence:.0%} "
+            "header-fingerprint confidence. Review units before import."
+        )
+        self.confidence_label.setWordWrap(True)
+        self.mapping_table = QtWidgets.QTableWidget(len(self.headers), 5)
+        self.mapping_table.setHorizontalHeaderLabels(
+            [
+                "Source Column",
+                "Canonical Target",
+                "Source Unit",
+                "Direction",
+                "Measurement Status",
+            ]
+        )
+        mapping_header = self.mapping_table.horizontalHeader()
+        assert mapping_header is not None  # noqa: S101 - Qt creates the header
+        mapping_header.setStretchLastSection(True)
+        self.profile_combo.currentIndexChanged.connect(self._populate_mappings)
+        self._populate_mappings()
+
+        self.player_edit = QtWidgets.QLineEdit()
+        self.session_edit = QtWidgets.QLineEdit(source.stem)
+        self.model_edit = QtWidgets.QLineEdit()
+        self.version_edit = QtWidgets.QLineEdit()
+        metadata = QtWidgets.QFormLayout()
+        metadata.addRow("Session Name:", self.session_edit)
+        metadata.addRow("Player:", self.player_edit)
+        metadata.addRow("Monitor Model:", self.model_edit)
+        metadata.addRow("Software Version:", self.version_edit)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel(f"Source: {source}"))
+        layout.addWidget(self.confidence_label)
+        layout.addWidget(self.profile_combo)
+        layout.addWidget(self.mapping_table, 1)
+        layout.addLayout(metadata)
+        layout.addWidget(buttons)
+
+    def _populate_mappings(self) -> None:
+        profile_id = str(self.profile_combo.currentData())
+        auto = {
+            item.source_column: item.target_column
+            for item in PROFILES[profile_id].mappings_for(self.headers)
+        }
+        targets = ["(retain only)", *IDENTITY_COLUMNS, "date", "time", *METRICS]
+        for row, header in enumerate(self.headers):
+            source_item = QtWidgets.QTableWidgetItem(header)
+            source_item.setFlags(
+                source_item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable
+            )
+            self.mapping_table.setItem(row, 0, source_item)
+            target_combo = QtWidgets.QComboBox()
+            target_combo.addItems(targets)
+            target_combo.setCurrentText(auto.get(header, "(retain only)"))
+            self.mapping_table.setCellWidget(row, 1, target_combo)
+            unit_edit = QtWidgets.QLineEdit()
+            unit_edit.setPlaceholderText("Infer from header/profile")
+            self.mapping_table.setCellWidget(row, 2, unit_edit)
+            direction_combo = QtWidgets.QComboBox()
+            direction_combo.addItem("As Reported (+1)", 1.0)
+            direction_combo.addItem("Invert Sign (-1)", -1.0)
+            self.mapping_table.setCellWidget(row, 3, direction_combo)
+            status_combo = QtWidgets.QComboBox()
+            status_combo.addItems(
+                ["reported", "measured", "estimated", "derived", "unknown"]
+            )
+            self.mapping_table.setCellWidget(row, 4, status_combo)
+        self.mapping_table.resizeColumnsToContents()
+
+    def import_options(self) -> ImportOptions:
+        """Return the reviewed mapping configuration."""
+        mappings: list[ColumnMapping] = []
+        for row, header in enumerate(self.headers):
+            target_widget = self.mapping_table.cellWidget(row, 1)
+            unit_widget = self.mapping_table.cellWidget(row, 2)
+            direction_widget = self.mapping_table.cellWidget(row, 3)
+            status_widget = self.mapping_table.cellWidget(row, 4)
+            if not isinstance(target_widget, QtWidgets.QComboBox):
+                continue
+            target = target_widget.currentText()
+            if target == "(retain only)":
+                continue
+            unit = (
+                unit_widget.text().strip()
+                if isinstance(unit_widget, QtWidgets.QLineEdit)
+                else ""
+            )
+            multiplier = (
+                float(direction_widget.currentData())
+                if isinstance(direction_widget, QtWidgets.QComboBox)
+                else 1.0
+            )
+            status = (
+                status_widget.currentText()
+                if isinstance(status_widget, QtWidgets.QComboBox)
+                else "reported"
+            )
+            mappings.append(
+                ColumnMapping(header, target, unit or None, multiplier, status)
+            )
+        return ImportOptions(
+            profile_id=str(self.profile_combo.currentData()),
+            mappings=tuple(mappings),
+            session_name=self.session_edit.text().strip() or self.source.stem,
+            player=self.player_edit.text().strip() or None,
+            monitor_model=self.model_edit.text().strip() or None,
+            software_version=self.version_edit.text().strip() or None,
+        )

--- a/tests/fixtures/launch_monitor/flightscope.csv
+++ b/tests/fixtures/launch_monitor/flightscope.csv
@@ -1,0 +1,3 @@
+Shot,Club,Club Speed mph,Ball Speed mph,Vertical Launch deg,Horizontal Launch deg,Spin Rate rpm,Spin Axis deg,Carry Distance yd,Total Distance yd,Lateral Landing yd,Apex Height ft,Flight Time s
+1,6 Iron,92,127,15.0,1.0,5400,-1.5,181,188,4,95,5.8
+2,6 Iron,93,129,15.3,1.2,5300,-1.2,184,191,5,98,5.9

--- a/tests/fixtures/launch_monitor/foresight.csv
+++ b/tests/fixtures/launch_monitor/foresight.csv
@@ -1,0 +1,3 @@
+Shot Number,Club,Club Head Speed (mph),Ball Speed (mph),HLA (deg),VLA (deg),Total Spin (rpm),Carry (yd),Total Distance (yd),Offline (yd),Peak Height (ft)
+1,Driver,105,156,-1.0,13.5,2450,265,283,-8,97
+2,Driver,106,158,-0.5,14.0,2380,269,287,-5,101

--- a/tests/fixtures/launch_monitor/garmin.csv
+++ b/tests/fixtures/launch_monitor/garmin.csv
@@ -1,0 +1,3 @@
+Shot,Club,Club Speed (mph),Ball Speed (mph),Launch Angle (deg),Launch Direction (deg),Spin Rate (rpm),Spin Axis (deg),Carry Distance (yd),Total Distance (yd),Total Deviation Distance (yd),Apex Height (ft)
+1,8 Iron,82,111,18.0,-0.8,7200,2.0,148,154,-3,88
+2,8 Iron,83,112,18.3,-0.4,7100,1.8,150,156,-2,90

--- a/tests/fixtures/launch_monitor/skytrak.csv
+++ b/tests/fixtures/launch_monitor/skytrak.csv
@@ -1,0 +1,3 @@
+Shot,Club,Club Speed (mph),Ball Speed (mph),Launch Angle (deg),Side Angle (deg),Back Spin (rpm),Side Spin (rpm),Carry (yd),Total (yd),Offline (yd),Max Height (ft)
+1,Pitching Wedge,75,96,25.0,0.4,8900,-120,118,121,1,91
+2,Pitching Wedge,76,98,24.5,0.2,8750,-90,121,124,1,93

--- a/tests/fixtures/launch_monitor/trackman.csv
+++ b/tests/fixtures/launch_monitor/trackman.csv
@@ -1,0 +1,3 @@
+Shot,Date,Time,Club,Club Speed (mph),Ball Speed (mph),Attack Angle (deg),Club Path (deg),Face Angle (deg),Face to Path (deg),Dynamic Loft (deg),Launch Angle (deg),Launch Direction (deg),Spin Rate (rpm),Spin Axis (deg),Carry (yd),Total (yd),Carry Side (yd),Height (ft)
+1,2026-01-02,10:00:00,7 Iron,88,121,-3.5,2.0,1.0,-1.0,20.0,16.0,0.8,6100,-2.5,170,176,3,92
+2,2026-01-02,10:00:20,7 Iron,89,123,-3.2,2.4,1.2,-1.2,19.5,15.5,0.9,6000,-2.2,172,178,4,90

--- a/tests/fixtures/launch_monitor/uneekor.csv
+++ b/tests/fixtures/launch_monitor/uneekor.csv
@@ -1,0 +1,3 @@
+Shot,Club,Club Speed (mph),Ball Speed (mph),Side Angle (deg),Launch Angle (deg),Back Spin (rpm),Side Spin (rpm),Spin Axis (deg),Carry Distance (yd),Total Distance (yd),Side Distance (yd),Apex (ft)
+1,5 Iron,95,132,0.5,14.0,4800,-180,-2.1,193,201,2,86
+2,5 Iron,96,134,0.7,14.2,4700,-160,-1.9,196,204,3,89

--- a/tests/ui/tools/launch_monitor/conftest.py
+++ b/tests/ui/tools/launch_monitor/conftest.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")

--- a/tests/ui/tools/launch_monitor/test_embed_adapter.py
+++ b/tests/ui/tools/launch_monitor/test_embed_adapter.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from src.shared.python.launcher_embed import EmbeddableTool, get_embeddable_tool
+from src.tools.launch_monitor_analytics import _embed_adapter
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+def test_adapter_is_pyqt_free_and_satisfies_protocol() -> None:
+    adapter = _embed_adapter.LaunchMonitorAnalyticsEmbedAdapter()
+    assert isinstance(adapter, EmbeddableTool)
+    assert adapter.tool_id == "launch_monitor_analytics"
+    assert adapter.embed_capabilities().min_size == (1100, 700)
+
+
+def test_import_registers_adapter() -> None:
+    importlib.reload(_embed_adapter)
+    assert get_embeddable_tool("launch_monitor_analytics") is not None
+
+
+def test_create_and_cleanup_are_idempotent(qapp) -> None:  # noqa: ANN001
+    adapter = _embed_adapter.LaunchMonitorAnalyticsEmbedAdapter()
+    widget = adapter.create_main_widget(None)
+    assert adapter.create_main_widget(None) is widget
+    adapter.cleanup()
+    adapter.cleanup()

--- a/tests/ui/tools/launch_monitor/test_gui.py
+++ b/tests/ui/tools/launch_monitor/test_gui.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+FIXTURES = Path(__file__).parents[3] / "fixtures" / "launch_monitor"
+
+
+@pytest.fixture
+def widget(qapp):  # noqa: ANN001, ANN201
+    from src.tools.launch_monitor_analytics.gui import MainWidget
+
+    result = MainWidget()
+    yield result
+    result.deleteLater()
+
+
+def test_workbench_exposes_all_analysis_workspaces(widget) -> None:  # noqa: ANN001
+    labels = [widget.tabs.tabText(index) for index in range(widget.tabs.count())]
+    assert labels == [
+        "Sessions",
+        "Data Treatment",
+        "Relationships",
+        "Models",
+        "Monitor Comparison",
+        "Dispersion",
+        "Trends",
+        "Reports",
+    ]
+    assert widget.windowTitle() == "Launch Monitor Analytics"
+
+
+def test_import_refreshes_sessions_data_and_metric_controls(widget) -> None:  # noqa: ANN001
+    session = widget.import_file(FIXTURES / "trackman.csv")
+    assert session.manifest.profile_id == "trackman"
+    assert widget.session_tree.topLevelItemCount() == 1
+    assert widget.data_table.rowCount() == 2
+    assert widget.relationship_metrics.count() >= 8
+    assert "2 shots" in widget.status_label.text()
+
+
+def test_relationship_analysis_populates_matrix_and_scientific_warning(widget) -> None:  # noqa: ANN001
+    widget.import_file(FIXTURES / "trackman.csv")
+    widget.import_file(FIXTURES / "garmin.csv")
+    for index in range(widget.relationship_metrics.count()):
+        item = widget.relationship_metrics.item(index)
+        if item.text() in {"club_speed", "ball_speed", "carry_distance"}:
+            item.setSelected(True)
+    result = widget.run_relationship_analysis()
+    assert result.coefficients.shape == (3, 3)
+    assert widget.relationship_table.rowCount() == 3
+    assert "caus" in widget.scientific_boundary.text().lower()
+
+
+def test_project_save_and_load_round_trip(widget, tmp_path) -> None:  # noqa: ANN001
+    widget.import_file(FIXTURES / "uneekor.csv")
+    destination = tmp_path / "player.lmproject"
+    widget.save_project(destination)
+    widget.clear_project()
+    assert widget.data_table.rowCount() == 0
+    widget.load_project(destination)
+    assert widget.session_tree.topLevelItemCount() == 1
+    assert widget.data_table.rowCount() == 2
+
+
+def test_import_mapping_dialog_captures_direction_and_measurement_status(
+    qapp,
+) -> None:  # noqa: ANN001
+    from PyQt6 import QtWidgets
+
+    from src.tools.launch_monitor_analytics.widgets import ImportMappingDialog
+
+    dialog = ImportMappingDialog(FIXTURES / "trackman.csv")
+    try:
+        row = dialog.headers.index("Club Speed (mph)")
+        direction = dialog.mapping_table.cellWidget(row, 3)
+        status = dialog.mapping_table.cellWidget(row, 4)
+        assert isinstance(direction, QtWidgets.QComboBox)
+        assert isinstance(status, QtWidgets.QComboBox)
+        direction.setCurrentIndex(1)
+        status.setCurrentText("measured")
+        mapping = next(
+            item
+            for item in dialog.import_options().mappings
+            if item.source_column == "Club Speed (mph)"
+        )
+        assert mapping.multiplier == -1.0
+        assert mapping.measurement_status == "measured"
+    finally:
+        dialog.deleteLater()

--- a/tests/unit/launch_monitor/test_analysis.py
+++ b/tests/unit/launch_monitor/test_analysis.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.shared.python.launch_monitor import (
+    FilterRule,
+    TreatmentConfig,
+    analyze_dispersion,
+    analyze_trend,
+    apply_treatment,
+    compare_monitors,
+    compute_correlations,
+    compute_pca,
+    compute_vif,
+    fit_predictive_model,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+def _shots(n: int = 80) -> pd.DataFrame:
+    rng = np.random.default_rng(42)
+    club = np.linspace(35.0, 50.0, n)
+    attack = rng.normal(-0.04, 0.025, n)
+    ball = 1.47 * club + 3.0 * attack + rng.normal(0.0, 0.7, n)
+    return pd.DataFrame(
+        {
+            "shot_id": [f"s{i}" for i in range(n)],
+            "session_id": np.where(np.arange(n) < n / 2, "a", "b"),
+            "monitor_vendor": np.where(np.arange(n) % 2, "Garmin", "TrackMan"),
+            "captured_at": pd.date_range("2026-01-01", periods=n, freq="D"),
+            "club_speed": club,
+            "attack_angle": attack,
+            "ball_speed": ball,
+            "smash_factor": ball / club,
+            "carry_distance": 3.4 * ball + rng.normal(0.0, 2.0, n),
+            "lateral_carry": rng.normal(2.0, 8.0, n),
+        }
+    )
+
+
+def test_treatment_flags_duplicates_missing_and_robust_outliers() -> None:
+    frame = _shots(20)
+    frame.loc[2, "ball_speed"] = np.nan
+    frame.loc[3, "club_speed"] = 999.0
+    frame = pd.concat([frame, frame.iloc[[0]]], ignore_index=True)
+    result = apply_treatment(
+        frame,
+        TreatmentConfig(
+            required_metrics=("club_speed", "ball_speed"),
+            duplicate_columns=("shot_id",),
+            outlier_metrics=("club_speed",),
+            robust_z_threshold=3.5,
+            exclude_flagged=True,
+        ),
+    )
+    assert {"missing_required", "duplicate", "robust_outlier"} <= set(
+        result.flags["flag_type"]
+    )
+    assert len(result.data) == len(frame) - 3
+    assert len(result.audit_log) >= 3
+
+
+def test_treatment_filters_and_labels_derived_metrics() -> None:
+    frame = _shots(20).drop(columns=["smash_factor"])
+    result = apply_treatment(
+        frame,
+        TreatmentConfig(
+            filters=(FilterRule("monitor_vendor", "eq", "TrackMan"),),
+        ),
+    )
+    assert set(result.data["monitor_vendor"]) == {"TrackMan"}
+    assert result.data["smash_factor"].notna().all()
+    assert set(result.data["status::smash_factor"]) == {"derived"}
+    assert any(item["action"] == "filter" for item in result.audit_log)
+    assert any(item["action"] == "derive_metric" for item in result.audit_log)
+
+
+def test_correlations_include_counts_significance_and_derived_warning() -> None:
+    result = compute_correlations(
+        _shots(),
+        metrics=("club_speed", "ball_speed", "smash_factor", "attack_angle"),
+        method="spearman",
+        controls=("attack_angle",),
+    )
+    assert result.coefficients.loc["club_speed", "ball_speed"] > 0.95
+    assert result.p_values.loc["club_speed", "ball_speed"] < 0.001
+    assert result.pair_counts.loc["club_speed", "ball_speed"] == 80
+    assert result.adjusted_p_values is not None
+    assert result.partial_coefficients is not None
+    assert "smash_factor" in result.derived_metrics
+    assert result.edges
+
+
+def test_pca_and_vif_expose_multicollinearity() -> None:
+    frame = _shots(100)
+    metrics = ("club_speed", "ball_speed", "carry_distance", "attack_angle")
+    pca = compute_pca(frame, metrics=metrics)
+    vif = compute_vif(frame, metrics=metrics)
+    assert pca.sample_count == 100
+    assert pca.explained_variance_ratio.sum() == pytest.approx(1.0)
+    assert pca.loadings.shape == (4, 4)
+    assert vif.sample_count == 100
+    assert vif.values["ball_speed"] > 5
+    assert "ball_speed" in vif.warning_metrics
+
+
+@pytest.mark.parametrize("model", ["linear", "ridge", "lasso", "elastic_net"])
+def test_regression_models_are_reproducible(model: str) -> None:
+    frame = _shots(120)
+    first = fit_predictive_model(
+        frame,
+        target="ball_speed",
+        features=("club_speed", "attack_angle"),
+        model=model,
+        random_seed=7,
+        group_column="session_id",
+    )
+    second = fit_predictive_model(
+        frame,
+        target="ball_speed",
+        features=("club_speed", "attack_angle"),
+        model=model,
+        random_seed=7,
+        group_column="session_id",
+    )
+    assert first.metrics == second.metrics
+    assert first.metrics["r2"] > 0.9
+    assert first.predictions.equals(second.predictions)
+
+
+def test_shallow_mlp_is_reproducible_when_analysis_extra_is_installed() -> None:
+    pytest.importorskip("sklearn")
+    result = fit_predictive_model(
+        _shots(160),
+        target="ball_speed",
+        features=("club_speed", "attack_angle"),
+        model="mlp",
+        random_seed=11,
+    )
+    assert result.metrics["r2"] > 0.85
+    assert result.coefficients is None
+
+
+def test_model_rejects_identity_derived_leakage() -> None:
+    with pytest.raises(ValueError, match="leakage"):
+        fit_predictive_model(
+            _shots(),
+            target="ball_speed",
+            features=("club_speed", "smash_factor"),
+            model="ridge",
+        )
+
+
+def test_matched_monitor_comparison_recovers_bias_and_slope() -> None:
+    x = np.linspace(30.0, 50.0, 30)
+    frame = pd.DataFrame(
+        {
+            "match_id": np.repeat(np.arange(30), 2),
+            "monitor_vendor": np.tile(["A", "B"], 30),
+            "ball_speed": np.column_stack([x, 1.03 * x + 0.8]).ravel(),
+        }
+    )
+    result = compare_monitors(
+        frame,
+        metric="ball_speed",
+        monitor_column="monitor_vendor",
+        match_column="match_id",
+        reference_monitor="A",
+    )
+    comparison = result.pairwise[0]
+    assert comparison.matched is True
+    assert comparison.slope == pytest.approx(1.03, rel=0.01)
+    assert comparison.intercept == pytest.approx(0.8, rel=0.1)
+    assert comparison.mean_bias > 1.0
+
+
+def test_dispersion_and_longitudinal_trend_capture_change() -> None:
+    frame = _shots(80)
+    dispersion = analyze_dispersion(
+        frame, forward="carry_distance", lateral="lateral_carry"
+    )
+    assert dispersion.sample_count == 80
+    assert dispersion.ellipse_major >= dispersion.ellipse_minor > 0
+    assert dispersion.area_95 > 0
+
+    trend_frame = frame.copy()
+    trend_frame["club_speed"] += np.where(np.arange(80) >= 40, 4.0, 0.0)
+    trend = analyze_trend(
+        trend_frame,
+        metric="club_speed",
+        time_column="captured_at",
+        rolling_window=10,
+    )
+    assert trend.slope_per_day > 0
+    assert trend.change_candidates
+    assert trend.latest_mean > trend.earliest_mean

--- a/tests/unit/launch_monitor/test_importer.py
+++ b/tests/unit/launch_monitor/test_importer.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.shared.python.launch_monitor import (
+    ColumnMapping,
+    ImportOptions,
+    LaunchMonitorProject,
+    detect_profile,
+    import_session,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+FIXTURES = Path(__file__).parents[2] / "fixtures" / "launch_monitor"
+
+
+@pytest.mark.parametrize(
+    ("filename", "profile"),
+    [
+        ("trackman.csv", "trackman"),
+        ("foresight.csv", "foresight"),
+        ("flightscope.csv", "flightscope"),
+        ("garmin.csv", "garmin"),
+        ("skytrak.csv", "skytrak"),
+        ("uneekor.csv", "uneekor"),
+    ],
+)
+def test_detects_vendor_profiles(filename: str, profile: str) -> None:
+    headers = pd.read_csv(FIXTURES / filename, nrows=0).columns.tolist()
+    result = detect_profile(headers)
+    assert result.profile_id == profile
+    assert result.confidence >= 0.5
+
+
+def test_trackman_import_converts_units_and_preserves_provenance() -> None:
+    session = import_session(FIXTURES / "trackman.csv")
+    shots = session.shots
+    assert session.manifest.profile_id == "trackman"
+    assert session.manifest.file_sha256
+    assert session.manifest.row_count == 2
+    assert shots.loc[0, "club_speed"] == pytest.approx(88 * 0.44704)
+    assert shots.loc[0, "carry_distance"] == pytest.approx(170 * 0.9144)
+    assert shots.loc[0, "attack_angle"] == pytest.approx(np.deg2rad(-3.5))
+    assert shots.loc[0, "spin_rate"] == pytest.approx(6100 * 2 * np.pi / 60)
+    assert shots.loc[0, "source_row"] == 2
+    assert "source::Club Speed (mph)" in shots.columns
+    assert shots.loc[0, "source::Club Speed (mph)"] == 88
+    assert session.manifest.metric_sources["club_speed"] == "Club Speed (mph)"
+    assert set(shots["status::club_speed"]) == {"reported"}
+
+
+def test_generic_json_import_uses_explicit_mapping(tmp_path: Path) -> None:
+    source = tmp_path / "shots.json"
+    source.write_text(
+        json.dumps([{"speed": 100.0, "launch": 12.0, "note": "fit"}]),
+        encoding="utf-8",
+    )
+    options = ImportOptions(
+        profile_id="generic",
+        mappings=(
+            ColumnMapping("speed", "ball_speed", "mph"),
+            ColumnMapping("launch", "launch_angle", "deg"),
+        ),
+        session_name="Mapped JSON",
+    )
+    session = import_session(source, options)
+    assert session.shots.loc[0, "ball_speed"] == pytest.approx(44.704)
+    assert session.shots.loc[0, "launch_angle"] == pytest.approx(np.deg2rad(12))
+    assert session.shots.loc[0, "source::note"] == "fit"
+
+
+def test_gspro_open_connect_nested_json_is_flattened(tmp_path: Path) -> None:
+    source = tmp_path / "gspro.json"
+    source.write_text(
+        json.dumps(
+            {
+                "DeviceID": "Test Device",
+                "Units": "Yards",
+                "BallData": {
+                    "Speed": 150.0,
+                    "HLA": 1.0,
+                    "VLA": 12.0,
+                    "TotalSpin": 2500.0,
+                    "BackSpin": 2450.0,
+                },
+                "ClubData": {"Speed": 101.0, "AngleOfAttack": -1.5},
+            }
+        ),
+        encoding="utf-8",
+    )
+    session = import_session(source)
+    assert session.manifest.profile_id == "gspro"
+    assert session.shots.loc[0, "ball_speed"] == pytest.approx(150 * 0.44704)
+    assert session.shots.loc[0, "club_speed"] == pytest.approx(101 * 0.44704)
+    assert "source::BallData.Speed" in session.shots
+
+
+@pytest.mark.parametrize(
+    ("headers", "profile"),
+    [
+        (
+            [
+                "Club Speed (mph)",
+                "Ball Speed (mph)",
+                "Face to Path (deg)",
+                "Carry Distance (yd)",
+            ],
+            "full_swing",
+        ),
+        (
+            [
+                "Smash Factor",
+                "Launch Direction (deg)",
+                "Shot Type",
+                "Carry Distance (yd)",
+            ],
+            "rapsodo",
+        ),
+    ],
+)
+def test_detects_additional_common_profiles(headers: list[str], profile: str) -> None:
+    assert detect_profile(headers).profile_id == profile
+
+
+@pytest.mark.parametrize("suffix", [".csv", ".tsv", ".xlsx"])
+def test_generic_tabular_formats_use_same_mapping(tmp_path: Path, suffix: str) -> None:
+    pytest.importorskip("openpyxl")
+    source = tmp_path / f"shots{suffix}"
+    frame = pd.DataFrame({"speed": [90.0, 91.0], "distance": [150.0, 152.0]})
+    if suffix == ".xlsx":
+        frame.to_excel(source, index=False)
+    else:
+        frame.to_csv(source, index=False, sep="\t" if suffix == ".tsv" else ",")
+    session = import_session(
+        source,
+        ImportOptions(
+            profile_id="generic",
+            mappings=(
+                ColumnMapping("speed", "club_speed", "mph"),
+                ColumnMapping("distance", "carry_distance", "yd"),
+            ),
+        ),
+    )
+    assert len(session.shots) == 2
+    assert session.shots.loc[0, "club_speed"] == pytest.approx(90 * 0.44704)
+
+
+def test_project_aggregates_sessions_and_round_trips(tmp_path: Path) -> None:
+    project = LaunchMonitorProject("Player Study")
+    project.add_session(import_session(FIXTURES / "trackman.csv"))
+    project.add_session(import_session(FIXTURES / "garmin.csv"))
+    project.record_actions(({"action": "filter", "column": "club"},))
+    combined = project.combined_shots()
+    assert len(combined) == 4
+    assert set(combined["monitor_vendor"]) == {"TrackMan", "Garmin"}
+
+    destination = tmp_path / "study.lmproject"
+    project.save(destination)
+    restored = LaunchMonitorProject.load(destination)
+    assert restored.name == "Player Study"
+    assert len(restored.sessions) == 2
+    assert restored.audit_log == [{"action": "filter", "column": "club"}]
+    pd.testing.assert_frame_equal(
+        restored.combined_shots().reset_index(drop=True),
+        combined.reset_index(drop=True),
+        check_dtype=False,
+    )


### PR DESCRIPTION
## Summary

- add a vendor-neutral canonical launch-monitor shot schema with unit normalization, source-column retention, file hashes, mapping evidence, measurement status, and durable project audit logs
- import CSV, TSV, TXT, XLS, XLSX, and JSON exports using profiles for TrackMan, Foresight, FlightScope, Garmin, SkyTrak, Uneekor, Full Swing, Rapsodo, and GSPro/Open Connect, plus an explicit generic mapping path
- add reproducible data treatment, Pearson/Spearman/Kendall and partial correlations, FDR-screened dependency edges, PCA, VIF, regularized regression, and an optional shallow MLP
- add matched-monitor agreement and unmatched descriptive comparison, robust dispersion ellipses, actual-time OLS/Theil-Sen trends, rolling statistics, EWMA, and candidate step changes
- add an eight-workspace PyQt6 application, standalone/embedded launcher integration, project/data/manifest export, documentation, ADR, feature-parity registration, and representative vendor-shaped fixtures

## Why

Launch-monitor impact and flight parameters are often analyzed as if they were independent. This workbench makes their interdependency inspectable without erasing vendor provenance or conflating association, prediction, and causation. It also supports longitudinal assessment of dispersion and player-performance changes across sessions.

## Scientific Boundaries

- correlations and predictive performance do not establish causality
- algebraically derived metrics are marked and protected by leakage checks
- matched-shot monitor analysis reports bias, limits of agreement, and calibration trend; unmatched comparisons are explicitly labeled descriptive and potentially confounded
- the checked-in fixtures are synthetic, representative headers rather than vendor validation data; exact export variants must be reviewed in the mapping dialog

## Validation

- `pre-commit run --files <changed files>`
- pre-push suite: Ruff lint/format, wildcard/debug/print guards, Prettier, MyPy, Bandit, and unit tests all passed
- 35 launch-monitor unit/UI tests passed with 77.9% scoped line/branch coverage
- 197 focused launch-monitor, launcher-manifest, and feature-parity tests passed
- Python 3.12 MyPy passed for all 17 new source modules
- rendered offscreen QA covered the full workbench, relationship heatmap, and five-column import-mapping dialog at desktop dimensions

## Known Repository Baseline Findings

Broad repository-only checks still report inherited failures outside this diff: 84 Ruff findings, five pre-existing format diffs, an expired file-size exception for `src/shared/python/chat/_chat_dock_widget_qt.py`, and two stale paths already present in `SPEC.md`. Scoped and hook-enforced checks for this change pass.

Closes #8342
