### PR TITLE
feat(putting): add surface-aware collision dynamics

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -5,12 +5,15 @@ Update this file with every PR and every push to main.
 
 ## Where the repo is heading
 
-- **Repository_Management#1390** ("EPIC: Fleet-wide Agent Handoff & PR Policy") — this PR
-  adds this file plus the `AGENTS.md` policy section. Status: in progress (this PR).
-- **#8345** ("EPIC: 3-D Putt Simulation") — open, labeled `claim:claude`. Five phases (P1–P5):
-  R3F 3-D putt scene/collision viz, advanced surface+friction model
-  (`src/shared/python/putting_dynamics/`), two-body putter/ball collision model,
-  a public research-data review doc, and a public-sharing build. Not started yet.
+- **Repository_Management#1390** ("EPIC: Fleet-wide Agent Handoff & PR Policy") —
+  UpstreamDrift rollout merged as #8351; this file and the `AGENTS.md` policy section
+  are now binding on `main`.
+- **#8345** ("EPIC: 3-D Putt Simulation") — open. P2/P3/P4 are implemented on
+  `feat/putting-dynamics`: an advanced surface/friction/mode-machine package,
+  finite-mass collision with loft and adjustable-hosel wrench/twist outputs, and the
+  public-data review in `docs/physics/PUTTING_KINEMATICS_KINETICS_REVIEW.md`.
+  Local evidence: 70 focused pytest tests, Ruff clean, and Python 3.12 mypy clean.
+  P1 (R3F 3-D scene and controls) and P5 (public sharing/parity registration) remain.
 - **#8339** ("Rate of Closure Impact Explorer") — merged. `vendor/ud-tools` submodule
   pin was provisional pending Tools#4092; confirm the submodule now points at the
   squash-merge commit on Tools `main`, not the old branch-head SHA, before relying on it.
@@ -34,10 +37,10 @@ Update this file with every PR and every push to main.
 
 ## In-flight branches (what stacks on what)
 
-None of the currently open branches stack on each other — all are independent topic
-branches off `main`:
+The active branches are independent topic branches off `main` unless noted:
 
-- `docs/agent-handoff-1390` (this branch) — off `origin/main`.
+- `feat/putting-dynamics` — #8345 P2/P3/P4; two checkpoint commits, ready for a
+  full PR to `main`. P1 should branch from this interface until the PR merges.
 - `fix/impact-friction-spin-axis-and-gear-offset` (#8344) — off `main`.
 - `bolt-vdot-optimization-*`, `bolt/trendline-boolean-sum-optimization-*`,
   `bolt/ndarray-sum-optimization-*`, `bolt/optimize-rsquared-vdot-*` — each off `main`,
@@ -95,6 +98,9 @@ CI entry points: `.github/workflows/ci-standard.yml` (full matrix: `code-quality
    squash-merge commit (not the old branch-head SHA).
 3. Clear the small independent queue: `bolt-*` perf PRs, #8344 physics fix, dependabot
    bumps.
-4. Begin #8345 EPIC phase P1 (3-D putt scene & collision visualization) once claimed
-   work is scheduled — see the phase breakdown in the issue for P2–P5 ordering
-   (surface/friction model → collision model → data-review doc → public sharing).
+4. Review and merge `feat/putting-dynamics` for #8345 P2/P3/P4. Important audit
+   corrections include the 1.64 m/s full-chord capture bound, signed overspin settling,
+   down-grain friction semantics, immutable field ownership, and consistent tangential
+   impulse/backspin vector recomposition.
+5. Build #8345 P1 against the curated `putting_dynamics` façade, then complete P5
+   public sharing and parity registration. Do not duplicate the Python physics in React.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -8,8 +8,9 @@ Update this file with every PR and every push to main.
 - **Repository_Management#1390** ("EPIC: Fleet-wide Agent Handoff & PR Policy") —
   UpstreamDrift rollout merged as #8351; this file and the `AGENTS.md` policy section
   are now binding on `main`.
-- **#8345** ("EPIC: 3-D Putt Simulation") — open. P2/P3/P4 are implemented on
-  `feat/putting-dynamics`: an advanced surface/friction/mode-machine package,
+- **#8345** ("EPIC: 3-D Putt Simulation") — open. P2/P3/P4 are implemented in
+  full PR **#8352** (`feat/putting-dynamics`): an advanced
+  surface/friction/mode-machine package,
   finite-mass collision with loft and adjustable-hosel wrench/twist outputs, and the
   public-data review in `docs/physics/PUTTING_KINEMATICS_KINETICS_REVIEW.md`.
   Local evidence: 70 focused pytest tests, Ruff clean, and Python 3.12 mypy clean.
@@ -39,8 +40,8 @@ Update this file with every PR and every push to main.
 
 The active branches are independent topic branches off `main` unless noted:
 
-- `feat/putting-dynamics` — #8345 P2/P3/P4; two checkpoint commits, ready for a
-  full PR to `main`. P1 should branch from this interface until the PR merges.
+- `feat/putting-dynamics` — #8345 P2/P3/P4, full PR **#8352** to `main`.
+  P1 should branch from this interface until the PR merges.
 - `fix/impact-friction-spin-axis-and-gear-offset` (#8344) — off `main`.
 - `bolt-vdot-optimization-*`, `bolt/trendline-boolean-sum-optimization-*`,
   `bolt/ndarray-sum-optimization-*`, `bolt/optimize-rsquared-vdot-*` — each off `main`,
@@ -98,7 +99,8 @@ CI entry points: `.github/workflows/ci-standard.yml` (full matrix: `code-quality
    squash-merge commit (not the old branch-head SHA).
 3. Clear the small independent queue: `bolt-*` perf PRs, #8344 physics fix, dependabot
    bumps.
-4. Review and merge `feat/putting-dynamics` for #8345 P2/P3/P4. Important audit
+4. Review and merge PR **#8352** (`feat/putting-dynamics`) for #8345 P2/P3/P4.
+   Important audit
    corrections include the 1.64 m/s full-chord capture bound, signed overspin settling,
    down-grain friction semantics, immutable field ownership, and consistent tangential
    impulse/backspin vector recomposition.

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,7 +39,7 @@
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-| **Spec Version** | 1.0.480 |
+| **Spec Version** | 1.0.481 |
 | **Last Spec Update** | 2026-08-04 |
 
 ## 2. Purpose & Mission
@@ -71,6 +71,15 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-08-04** - Added the headless putting-dynamics foundation for #8345
+  P2/P3/P4. `src/shared/python/putting_dynamics/` provides DbC-validated
+  heterogeneous height/friction fields, seeded bumpiness, signed skid/overspin
+  transition, rolling/rest modes, full-chord hole capture, and finite-mass
+  putter-ball collision outputs including dynamic loft, slowdown, adjustable
+  hosel position, and an attachment-point impulse wrench. The public-data
+  review records verified sources, explicit assumptions, discrepancies, model
+  defaults, and validation bands. Seventy focused unit tests pin analytic
+  limits, determinism, symmetry, conservation, and the public façade.
 - **2026-08-04** - Added the vendor-neutral Launch Monitor Analytics workbench
   (#8342). A canonical, unit-normalized shot schema and provenance-preserving
   import pipeline aggregate common TrackMan, Foresight, FlightScope, Garmin,
@@ -1426,6 +1435,7 @@ UpstreamDrift/
 │       ├── engine_core/            # EngineManager/Registry/probes/capabilities
 │       ├── launcher_embed/         # EmbeddableTool contract + registry (ADR-0013)
 │       ├── physics/                # Ball flight models, impact, swing→flight pipeline
+│       ├── putting_dynamics/       # Surface-aware putt collision and roll physics
 │       ├── launch_monitor/         # Canonical shot import, treatment, and analytics
 │       ├── motion_pipeline/        # Mocap ingestion (C3D/TRC/BVH), IK backends
 │       ├── model_generation/       # URDF/MJCF parsing, Frankenstein editor (VENDORED)
@@ -1468,6 +1478,7 @@ UpstreamDrift/
 | Configuration Manager    | `src/config/`                            | Centralized configuration loading, validation, and environment management                   |
 | Analysis Tool CLIs       | `src/tools/drift_control/`, `src/tools/contraction/` | Headless AffineDrift-compatible drift/control, contraction, and Floquet analysis tools |
 | Launch Monitor Analytics | `src/tools/launch_monitor_analytics/`, `src/shared/python/launch_monitor/` | PyQt6 and headless vendor-neutral launch-monitor import, dependency, model, agreement, dispersion, and trend analysis |
+| Putting Dynamics         | `src/shared/python/putting_dynamics/`   | Headless heterogeneous-green, collision, loft, hosel-wrench, skid/roll/rest, and hole-capture physics for #8345 |
 | Shared Utilities         | `src/shared/`                            | Cross-engine validators, helpers, and exception definitions                                 |
 | Workspace Metadata       | `src/shared/python/workspace/`           | Project/session/dataset metadata store and CC-4 HDF5 result browser view models            |
 | URDF Models              | `shared/models/`                         | Canonical model definitions (URDF format) for golf swings, human body, pendulums            |
@@ -1934,6 +1945,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-04 | 1.0.481 | Added #8345 P2/P3/P4 putting dynamics and public-data review: heterogeneous and seeded green fields, advanced friction, signed skid/overspin settling, full-chord capture, finite-mass lofted collision, putter slowdown, adjustable-hosel impulse wrench and pinned-shaft twist proxy, 70 focused tests, and an explicit provenance/assumption ledger. |
 | 2026-08-01 | 1.1.0   | Bolt: Optimized `np.sum(arr * arr)` and `np.sum(arr ** 2)` to `np.vdot(arr, arr)` in drake compute cost and PARITY_SPEC to avoid intermediate array allocations and improve performance. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |
 | 2026-07-27 | 1.0.478 | Ensured the classic PyQt6 background API child inherits the sidebar's validated Tools authority and orders its package roots ahead of UpstreamDrift partial copies, preventing `chat.websocket_protocol` import failure (#8120). Recorded the Tools #3950 deprecations-as-errors Units repair and visible `100 °C` to `212 °F` retest, plus dynamic-port API-tree recovery and close cleanup that preserved the unrelated port-8000 blocker. |

--- a/docs/physics/PUTTING_KINEMATICS_KINETICS_REVIEW.md
+++ b/docs/physics/PUTTING_KINEMATICS_KINETICS_REVIEW.md
@@ -1,0 +1,446 @@
+# Putting Kinematics and Kinetics — Public-Data Review
+
+> Last reviewed: 2026-08-04
+> Epic: #8345 (P4, issue #8348). Seeds model defaults and test bands for
+> `src/shared/python/putting_dynamics/` (P2/P3) and the 3-D putt
+> visualization (P1).
+
+This review collects everything about putting stroke kinematics (how the
+putter moves) and kinetics (what the impact delivers) that can be stated
+from public, verifiable material, and derives the rest from first
+principles. It follows the sourcing discipline of the AffineDrift
+closure-rate literature dossier
+(`content-development/technology-research/closure-rate-literature-dossier.md`
+in D-sorganization/AffineDrift): every number carries a provenance class,
+nothing is cited that was not verified against a fetched source, and
+commonly repeated figures whose primary source could not be verified are
+flagged as pointers, not citations.
+
+## Provenance Classes
+
+| Class | Meaning                                                                                                                |
+| ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| SPEC  | Governing-body specification, verified against a fetched public document                                               |
+| DERIV | First-principles derivation from SPEC inputs; shown in full here or in a cross-linked verified derivation              |
+| DATA  | Openly published measurement data, verified against a fetched source (URL given; what it states quoted)                |
+| CONV  | Fleet modelling convention / assumption; no public primary source verified; the model must mark it as an assumption    |
+| PTR   | Unverified pointer: commonly referenced work whose numbers are NOT reproduced here because the source was not verified |
+
+## 1. Verified Public Specifications
+
+| Quantity                              | Value                                                                                                                                                                | Source (fetched and verified)                                                                                                                                                                                                                                                                                                             | Class |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| Ball mass (maximum)                   | 1.620 oz = 45.93 g                                                                                                                                                   | R&A Equipment Rules, Part 4: "The weight of the ball must not be greater than 1.620 ounces avoirdupois (45.93 g)" — <https://www.randa.org/en/roe/the-rules-of-equipment/part-4-conformance-of-balls>                                                                                                                                     | SPEC  |
+| Ball diameter (minimum)               | 1.680 in = 42.67 mm                                                                                                                                                  | Same source: "The diameter of the ball must not be less than 1.680 inches (42.67 mm)"                                                                                                                                                                                                                                                     | SPEC  |
+| Hole diameter                         | 4.25 in = 108 mm (lining outer diameter must not exceed the same)                                                                                                    | R&A _Rules of Golf_ (effective Jan 2023), Definitions, "Hole" (p. 222 of the official PDF): "The hole must be 4 1/4 inches (108 mm) in diameter and at least 4 inches (101.6 mm) deep" — <https://assets-us-01.kc-usercontent.com/c42c7bf4-dca7-00ea-4f2e-373223f80f76/48712d47-76dc-4fd3-add1-53972c021580/2023%20Rules%20of%20Golf.pdf> | SPEC  |
+| Hole depth (minimum)                  | 4 in = 101.6 mm; lining sunk >= 1 in (25.4 mm) below the surface                                                                                                     | Same source, same definition                                                                                                                                                                                                                                                                                                              | SPEC  |
+| Stimpmeter bar length                 | 36 in extruded aluminium bar with a V-shaped groove along its length                                                                                                 | USGA Stimpmeter Instructions (reprinted in _Hole Notes_, Aug 2000, pp. 24-35) — <https://archive.lib.msu.edu/tic/holen/article/2000aug24.pdf>                                                                                                                                                                                             | SPEC  |
+| Stimpmeter ball-release notch         | 30 in from the tapered (ground) end                                                                                                                                  | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| Stimpmeter release angle              | approximately 20 degrees ("a ball will always be released and start to roll when the Stimpmeter is raised to an angle of approximately 20 degrees")                  | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| Stimpmeter groove geometry            | V-groove included angle 145 degrees, "supporting a golf ball at two points 1/2 [in] apart"; the rolling ball has "a slight overspin, which is thoroughly consistent" | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| Stimp measurement protocol            | 3 balls each way along the same line, stop pattern <= 8 in, series averaged; up/back difference > 18 in questionable                                                 | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| USGA green-speed chart (regular play) | slow < 7'6", medium 7'6"-8'6", fast > 8'6"                                                                                                                           | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| USGA green-speed chart (tournament)   | slow < 8'6", medium 8'6"-9'6", fast > 9'6"                                                                                                                           | Same source                                                                                                                                                                                                                                                                                                                               | SPEC  |
+| Gravity g                             | 9.80665 m/s^2 (standard value used fleet-wide)                                                                                                                       | Defined constant                                                                                                                                                                                                                                                                                                                          | SPEC  |
+
+Model constants derived from the regulatory limits: nominal ball radius
+R = 21.335 mm (half the minimum conforming diameter) and nominal mass
+m = 45.93 g (the maximum conforming mass). These are reproducible fleet
+conventions, not measurements of every conforming ball: the rules specify
+no maximum diameter and no minimum mass. The uniform-sphere inertia
+I = (2/5) m R^2 is an additional idealisation, consistent with the
+measured inertia ratio ~0.40 recorded in the AffineDrift
+rotation-induced-spin supplement.
+
+## 2. Stroke Kinematics
+
+### 2.1 The Pendulum-Stroke Idealisation and What It Predicts
+
+Treat the arm-shoulder-putter system as a pendulum of effective length L
+(standard 35 in putter: L ~ 0.889 m) released from a backstroke arc
+amplitude A. Small-angle SHM gives the bottom-of-arc (impact) speed
+
+```
+v_head = A * omega,   omega_free = sqrt(g / L) = 3.32 rad/s  (L = 0.889 m)
+```
+
+so the free-pendulum stroke gain is `v_head / A = 3.32 s^-1`. [DERIV]
+
+This is the proxy currently implemented in Tools
+`swing_sim.putting.impact.clubhead_speed_from_backstroke`. The verified
+tour data below says the _real_ gain is about twice that — see §2.4.
+
+### 2.2 Tempo: The 2:1 Ratio Is Measured and Derivable
+
+Two independent verified sources:
+
+**Marquardt (2007), "The SAM PuttLab: Concept and PGA Tour Data",**
+_Annual Review of Golf Coaching_ — open PDF fetched and read:
+<https://sam-academy.com/wp-content/uploads/2020/04/ARGC07-SAM-PuttLab-Concept-and-Tour-Data.pdf>.
+99 male PGA Tour players, 9 tournaments 2003-2005, 7 recorded putts each on
+a nominally straight, level 4 m practice-green putt (slightly shortened on
+slower greens); ultrasound system, 210 Hz, resolution 0.1 mm / 0.1 degree.
+Its Table 2 (group average, group SD,
+intra-player consistency SD): [DATA]
+
+| Parameter                 | Group average | Group SD | Consistency |
+| ------------------------- | ------------- | -------- | ----------- |
+| Backswing time (BST)      | 670 ms        | 90 ms    | 30 ms       |
+| Time to impact (TI)       | 317 ms        | 35 ms    | 11 ms       |
+| Forward swing time (FST)  | 820 ms        | 100 ms   | 45 ms       |
+| Backswing rhythm (BST/TI) | 2.1           | 0.29     | 0.11        |
+| Impact timing (TI/FST)    | 0.39          | 0.04     | 0.02        |
+| Impact speed              | 1510 mm/s     | 119 mm/s | 45 mm/s     |
+| Backswing length (BSL)    | 241 mm        | 38 mm    | 10 mm       |
+| Path symmetry (BSL/FSL)   | 0.36          | 0.05     | 0.02        |
+
+So the folklore "2:1 putting tempo" is a measured tour average of 2.1
+(backswing time : time to impact), with tight intra-player consistency
+(0.11) against loose inter-player spread (0.29): individual tempo is a
+signature, while 2.1 is the mean for this tour sample. Impact occurs at 39% of
+the forward swing — before peak speed, i.e. the putter is still (gently)
+accelerating through the ball.
+
+**Grober, "Resonance in Putting" (arXiv:0903.1762)** — open PDF fetched
+and read: <https://arxiv.org/abs/0903.1762>. Models the stroke as a simple
+harmonic oscillator (mass = system inertia, spring = gravity +
+biomechanics) driven by an impulse at takeaway and an opposite impulse at
+transition. The derivation gives `omega_0 * tau_b = pi/2` for the
+backswing and `omega_0 * tau_d = pi/4` for the downswing **when the two
+impulses have equal magnitude**, hence
+
+```
+tau_b / tau_d = 2   exactly, for equal impulses
+```
+
+and the paper shows this equal-impulse stroke minimises the relative error
+of impact speed under uncorrelated random errors in the applied impulses.
+The total stroke duration is independent of putt length (only the impulse
+magnitudes scale), which matches the SAM observation that times are
+player-constant while backswing length varies with distance. [DATA/DERIV]
+
+Cross-check between the measured SAM intervals and Grober's model: from
+SAM's tour averages,
+`omega_0 = pi / (2 * 0.670 s) = 2.34 rad/s` (backswing condition) and
+`omega_0 = pi / (4 * 0.317 s) = 2.48 rad/s` (downswing condition) — the
+same oscillator frequency within 6% from two intervals in the same measured
+stroke dataset. This is a consistency check, not an independent validation
+dataset. [DERIV]
+
+**Internal source discrepancy:** SAM Table 2 reports average impact speed
+as 1510 mm/s, while the narrative on p. 111 reports 1570 mm/s. This review
+uses the tabulated 1510 mm/s value for reproducibility and carries 1570 mm/s
+as a same-source discrepancy; it does not average the two or silently choose
+one as ground truth.
+
+### 2.3 Face Rotation During the Putting Stroke
+
+From the same verified SAM tour dataset (Marquardt 2007): [DATA]
+
+| Parameter                                | Group average   | Group SD | Consistency |
+| ---------------------------------------- | --------------- | -------- | ----------- |
+| Face angle at address                    | 0.35 deg right  | 1.56 deg | 0.67 deg    |
+| Face angle at impact                     | 0.30 deg right  | 0.59 deg | 0.70 deg    |
+| Putter path direction at impact          | 0.80 deg left   | 2.24 deg | 0.83 deg    |
+| Face on path at impact                   | 1.10 deg open   | 2.76 deg | 0.70 deg    |
+| Face rotation in impact zone (+/- 10 cm) | 3.2 deg closing | 1.0 deg  | 0.34 deg    |
+| Total forward-swing rotation             | ~10 deg closing | —        | —           |
+| Dynamic shaft angle at impact            | 0.0 deg         | 1.2 deg  | 0.49 deg    |
+| Vertical angle of attack (rise)          | 2.8 deg up      | 1.8 deg  | 0.60 deg    |
+
+The paper's text adds: no tour player shows smooth zero rotation; the few
+low-rotation players achieve it by re-opening the face through impact, not
+by a more vertical swing plane; face rotation is the geometric consequence
+of swinging on a tilted plane (the face stays square to the _plane_), the
+same frame phenomenon as in the full swing.
+
+**Relation to the org's closure-rate work.** The closure-rate dossier's
+central finding — that "closure rate" numbers are meaningless without a
+stated reference frame — applies unchanged at putting scale, roughly two
+orders of magnitude down. A rough scale conversion from the verified SAM
+numbers: 3.2 deg of closing over +/- 10 cm of path at ~1.5 m/s impact
+speed is a face-to-target-line closing rate of order
+`3.2 deg / (0.2 m / 1.5 m/s) ~ 25 deg/s` near impact, versus the
+~1,800-3,600 deg/s global-frame closure rates of full driver swings
+recorded in the dossier. Any putting closure-rate display in the P1
+visualization must state its frame (face vs target line, as SAM measures)
+exactly as the dossier demands for the full swing. [DERIV from DATA]
+
+### 2.4 Stroke Length to Impact Speed: The Verified Gain
+
+The SAM tour averages give a directly measured stroke gain:
+
+```
+k = impact speed / backswing length = 1.510 / 0.241 = 6.27 s^-1   [DATA]
+```
+
+Compare the two idealisations: [DERIV]
+
+- free pendulum, `sqrt(g/L)` = 3.32 s^-1 — **under-predicts the tour gain
+  by a factor ~1.9**;
+- Grober's resonantly driven stroke is described in arXiv:1103.2827
+  (abstract verified) as "a pendulum driven at twice its natural resonance
+  frequency", i.e. gain `2 * sqrt(g/L)` = 6.64 s^-1 — within 6% of the
+  measured 6.27 s^-1.
+
+The tour stroke is a _driven_ pendulum, roughly twice as fast as free
+gravity swinging. Model default: `k = 6.3 s^-1`, test band [3.3, 6.6]
+(free-pendulum floor to exact-2x ceiling).
+
+> Reconciliation note (cross-repo): Tools
+> `swing_sim.putting.impact.clubhead_speed_from_backstroke` currently uses
+> the free-pendulum gain `sqrt(g/L)` and therefore under-predicts tour
+> head speed for a given backstroke by ~2x. Not wrong as a documented
+> proxy, but `putting_dynamics` should default to the measured gain.
+
+## 3. Impact Kinetics
+
+### 3.1 The Collision Model (Chain Used Throughout)
+
+Two-body impulse between a striking effective mass M_eff and the free ball
+(mass m), face presenting effective loft delta: [DERIV]
+
+```
+v_ball = v_head * (1 + e) / (1 + m / M_eff) * cos(delta)   (normal chain)
+```
+
+with the tangential 2/7 rolling-cap partition for the small loft component
+(the same sphere impulse partition as the full-swing impact model).
+Vector consistency matters: for positive loft the backspin-producing
+tangential impulse points down and forward along the face, so its vertical
+component subtracts from the normal component. The interrupted Tools H3
+implementation recomposes that impulse upward while assigning backspin;
+`putting_dynamics` corrects the direction and regression-tests linear and
+angular impulse consistency. At putter lofts (2-4 deg) the launch angle is a few
+degrees, launch spin is a small backspin, and the ground phase starts
+essentially sliding — the initial condition the roll model needs.
+
+Speed ratio (ball/head) for the defaults below: `q = (1 + e) \* M / (M + m)
+
+- cos^2(delta) = 1.57`with e = 0.78, M = 0.350 kg, m = 0.04593 kg,
+delta = 3 deg. If the hands couple extra mass through the grip
+(M_eff -> infinity) the ratio ceiling is`(1 + e) cos^2(delta) = 1.77`.
+
+Consistency check against verified tour data: SAM's 4 m putt at measured
+head speed 1.51 m/s implies ball speed 2.37 m/s (free head, q = 1.57) to
+2.67 m/s (rigid-coupling ceiling). The §3.3 table says a 4 m putt needs
+v0 = 2.54-2.76 m/s at stimp 12-10. The measured tour stroke sits inside
+the derived band only toward the high-q end. Within this simplified model
+that suggests grip/arm coupling raises effective striking mass above the
+bare head, but unmodeled launch, turf, and environmental differences are
+alternative explanations. Treat this as a model-calibration inference,
+not a direct mass measurement. `putting_dynamics` defaults to the bare head
+and exposes inertia and attachment quantities for sensitivity analysis.
+[INFERENCE from DERIV vs DATA]
+
+### 3.2 Putter Head Mass, COR, and Contact Time
+
+| Quantity                      | Value / band                                                                                            | Provenance                                                                                                                                                                                                            | Class                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Putter head mass              | modern blades ~340-350 g; historical norm ~300-310 g; e.g. Tiger Woods' Scotty Newport 2 GSS head 326 g | GOLF.com equipment column (J. Wall), fetched: <https://golf.com/gear/putters/blade-putters-weight-fully-equipped-mailbag/>                                                                                            | DATA (trade press; manufacturer-attributed) |
+| Putter head mass default      | 0.350 kg (blade), 0.360 kg (mallet)                                                                     | Fleet convention (Tools `MINIMAL_PUTTERS`), consistent with the DATA band above                                                                                                                                       | CONV                                        |
+| Putter static loft            | 3-4 deg ("most of the putters we measured showed a static loft between 3 and 4 degrees")                | Marquardt 2007, verified (see §2.2)                                                                                                                                                                                   | DATA                                        |
+| Putter face COR at putt speed | 0.78 default; 0.73-0.82 across milled/insert faces                                                      | Widely repeated value; used by Tools and this repo's `putter_stroke.py` / `contact.rs`; **no public primary measurement verified**                                                                                    | CONV                                        |
+| Contact time                  | ~0.5 ms order of magnitude                                                                              | Commonly quoted for golf impacts (e.g. R. Cross's impact publications, physics.usyd.edu.au — not verified at putting speeds specifically); used by Tools as a documented assumption to neglect gravity during contact | PTR/CONV                                    |
+| Putter head MOI               | no openly published per-model values verified                                                           | —                                                                                                                                                                                                                     | gap (§6)                                    |
+
+### 3.3 Putter Speed vs. Putt Distance (Derived Table)
+
+Chain: target distance D -> stimp deceleration a -> required launch speed
+v0 (skid + roll) -> head speed v0/q. Inputs: a = 5.49/S m/s^2 (§4),
+mu_k = 0.4 [CONV], q = 1.57 (free head, e = 0.78, M = 0.350 kg,
+3 deg loft). Level green, dying-at-the-hole pace. [DERIV]
+
+Required launch speed solves
+`D = (12/49) v0^2/(mu_k g) + (25/49) v0^2/(2a)`.
+
+| D (m) | Stimp 8: v0 -> v_head (m/s) | Stimp 10: v0 -> v_head | Stimp 12: v0 -> v_head |
+| ----- | --------------------------- | ---------------------- | ---------------------- |
+| 1     | 1.52 -> 0.97                | 1.38 -> 0.88           | 1.27 -> 0.81           |
+| 2     | 2.15 -> 1.37                | 1.95 -> 1.24           | 1.80 -> 1.14           |
+| 3     | 2.63 -> 1.68                | 2.39 -> 1.52           | 2.20 -> 1.40           |
+| 4     | 3.04 -> 1.93                | 2.76 -> 1.76           | 2.54 -> 1.62           |
+| 5     | 3.39 -> 2.16                | 3.08 -> 1.96           | 2.84 -> 1.81           |
+| 6     | 3.72 -> 2.37                | 3.37 -> 2.15           | 3.11 -> 1.98           |
+| 7     | 4.02 -> 2.56                | 3.65 -> 2.32           | 3.36 -> 2.14           |
+| 8     | 4.29 -> 2.74                | 3.90 -> 2.48           | 3.59 -> 2.29           |
+| 9     | 4.55 -> 2.90                | 4.13 -> 2.63           | 3.81 -> 2.43           |
+| 10    | 4.80 -> 3.06                | 4.36 -> 2.78           | 4.02 -> 2.56           |
+
+Reading: practical putts live in head speeds ~0.8-3 m/s; the SAM tour
+reference (1.51 m/s at 4 m) sits in-band; faster greens need slower
+strokes at every distance (the whole content of "pace adjustment").
+For hole-capture pace add the §5 arrival-speed margin to D.
+
+### 3.4 Grip Forces
+
+Nothing verifiable found. Putting grip-force studies exist (pressure-mat
+and instrumented-grip work is commonly referenced in coaching material),
+but no openly fetchable source with usable numbers was verified for this
+review. Grip force therefore has **no entry** in the defaults table and
+the model must not pretend to know it; the stroke model's honest inputs
+are the impulse pair (Grober) or the measured kinematics (SAM). [gap, §6]
+
+## 4. Roll Kinematics (Cross-Linked, Already Verified)
+
+The skid -> roll physics is derived in full in the org and is not
+re-derived here:
+
+- **AffineDrift PR #3778** (`articles/putting-roll-models.qmd`, merged):
+  impact -> skid -> 5/7 transition -> pure roll -> capture, with the
+  stimpmeter as deceleration instrument, slope/break as gravity
+  components, and an assumption ledger. Companion numerical survey in
+  `articles/green-simulation.qmd`.
+- **Tools `swing_sim.putting`** (`impact.py`, `roll.py`, `green.py`, epic
+  Tools#4125 H3): the same closed forms implemented with DbC contracts and
+  tests; UD's `putting_dynamics` must reproduce these closed forms in its
+  flat-uniform limit (epic #8345 acceptance).
+
+Headline closed forms (all DERIV from SPEC inputs; proofs in the article):
+
+| Result                        | Value                                            | Note                                                        |
+| ----------------------------- | ------------------------------------------------ | ----------------------------------------------------------- |
+| Slide-to-roll speed ratio     | v\* = (5/7)(v0 + (2/5) omega0 R)                 | = (5/7) v0 for spinless launch; property of I = (2/5) m R^2 |
+| Skid distance                 | (12/49) v0^2 / (mu_k g)                          | ends at t\* = 2 v0 / (7 mu_k g)                             |
+| Skid share of putt length     | (24/25) a / (mu_k g) -> 10-15%                   | launch-speed independent                                    |
+| Stimp -> deceleration         | `a = v_s^2 / (2 * 0.3048 * S)`                   | the stimp number is a deceleration in disguise              |
+| Runaway grade                 | a/g = mu_r (7.0% / 5.6% / 4.7% at stimp 8/10/12) | downhill putt cannot stop beyond it                         |
+| Dying-putt fractional break   | g sin(beta) / a                                  | launch-speed independent upper bound                        |
+| Capture ceiling (dead centre) | v_cap = D_h sqrt(g / 2R) = 1.64 m/s              | pure SPEC geometry                                          |
+| Effective hole half-width     | b_max(v) = sqrt(r_h^2 - v^2 R / 2g)              | 51/43/22 mm at 0.5/1.0/1.5 m/s                              |
+
+### 4.1 Stimpmeter Release Speed — Geometry Now Verified, One Correction
+
+The release-speed derivation (energy conservation down the groove,
+enlarged effective inertia from the two-line contact) is in the AffineDrift
+article. This review adds the **verified** groove geometry from the USGA
+instructions (§1): included angle 145 deg, contact points 1/2 in apart.
+That fixes the effective rolling radius with no free parameter:
+
+```
+contact half-separation = R sin(17.5 deg) = 6.4 mm  (2 x 6.4 = 12.8 mm ~ 1/2 in, consistent)
+r_c = R cos(17.5 deg) = 0.954 R
+v_release = sqrt(2 g L sin(20 deg) / (1 + (2/5)/(0.954)^2)) = 1.88 m/s
+a = v_s^2 / (2 * 0.3048 * S) = 5.82 / S  m/s^2
+```
+
+The AffineDrift article and Tools `roll.py` use r_c ~ 0.87 R, giving the
+conventional v_s = 1.83 m/s (6 ft/s) and a = 5.49/S. With the verified
+145-degree spec the geometric value is r_c = 0.954 R and v_s = 1.88 m/s
+(a = 5.82/S) — a 3% speed / 6% deceleration difference. Both lie inside
+the commonly quoted 1.8-1.9 m/s band; the flat-ramp limit is 1.91 m/s.
+[DERIV from SPEC]
+
+**Default decision:** keep `v_s = 1.83 m/s` and `a = 5.49/S` as the fleet
+default for cross-repo parity (AffineDrift article, Tools tests), and
+carry the verified-geometry value 1.88 m/s / 5.82/S as the documented
+upper edge of the test band. Reconciling Tools/AffineDrift to the
+145-degree geometry is flagged as follow-up; it shifts every stimp-derived
+number by ~6% in a known direction.
+
+## 5. Model Defaults and Test Bands for `putting_dynamics`
+
+| Parameter                                    | Default                                                                                                             | Test band                                                            | Class                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------ |
+| Ball mass m                                  | 0.04593 kg nominal                                                                                                  | maximum conforming mass; actual mass may be lower                    | SPEC/CONV                            |
+| Ball radius R                                | 0.021335 m nominal                                                                                                  | minimum conforming radius; actual radius may be larger               | SPEC/CONV                            |
+| Ball inertia                                 | (2/5) m R^2                                                                                                         | inertia ratio 0.40 +/- 0.02                                          | DERIV/CONV                           |
+| Hole diameter D_h                            | 0.10795 m                                                                                                           | exact                                                                | SPEC                                 |
+| Hole depth                                   | >= 0.1016 m                                                                                                         | exact (minimum)                                                      | SPEC                                 |
+| Gravity g                                    | 9.80665 m/s^2                                                                                                       | exact                                                                | SPEC                                 |
+| Stimpmeter release speed v_s                 | 1.83 m/s (fleet parity)                                                                                             | [1.83, 1.91]; verified-geometry point 1.88                           | DERIV                                |
+| Stimp -> rolling deceleration                | a = 5.49/S m/s^2                                                                                                    | [5.49/S, 5.82/S]; mu_r = a/g in 0.047-0.070 for stimp 8-12           | DERIV                                |
+| Stimp range to support                       | 8-12 (USGA chart: tournament fast > 9'6")                                                                           | 6-14 hard limits                                                     | SPEC/CONV                            |
+| Sliding friction mu_k (ball-turf)            | 0.40                                                                                                                | [0.3, 0.5] sensitivity band                                          | CONV (assumption — no public source) |
+| Slide-to-roll transition                     | v\* = (5/7)(v0 + (2/5) omega0 R)                                                                                    | exact closed form; parameter-free test pin                           | DERIV                                |
+| Skid share of putt                           | — (emergent)                                                                                                        | 10-15% at mu_k = 0.4, stimp 8-12                                     | DERIV                                |
+| Putter head mass                             | 0.350 kg blade / 0.360 kg mallet                                                                                    | [0.30, 0.37] published band                                          | DATA/CONV                            |
+| Putter effective striking mass M_eff         | head mass (free-head default)                                                                                       | [head mass, +inf); tour data favours the upper half (§3.1)           | CONV                                 |
+| Putter loft                                  | 3.0 deg                                                                                                             | 2-4 deg static (tour static lofts 3-4 deg)                           | DATA/CONV                            |
+| Putter face COR e                            | 0.78                                                                                                                | [0.73, 0.82]                                                         | CONV                                 |
+| Contact time scale                           | 0.5 ms (neglect gravity during contact)                                                                             | order of magnitude only                                              | PTR/CONV                             |
+| Ball/head speed ratio q                      | 1.57 (free head, 3 deg loft)                                                                                        | [1.4, 1.77] (COR band to rigid-coupling ceiling)                     | DERIV                                |
+| Stroke tempo BST/TI                          | 2.1                                                                                                                 | 2.1 +/- 0.29 (group); +/- 0.11 within-player                         | DATA                                 |
+| Backswing time                               | 670 ms                                                                                                              | +/- 90 ms                                                            | DATA                                 |
+| Time to impact                               | 317 ms                                                                                                              | +/- 35 ms                                                            | DATA                                 |
+| Impact timing TI/FST                         | 0.39                                                                                                                | +/- 0.04                                                             | DATA                                 |
+| Stroke gain k = v_head/BSL                   | 6.3 s^-1                                                                                                            | [3.3, 6.6] (free pendulum to 2x resonance)                           | DATA/DERIV                           |
+| Face rotation, impact zone (+/- 10 cm)       | 3.2 deg closing                                                                                                     | +/- 1.0 deg (group); 0.34 deg within-player                          | DATA                                 |
+| Face angle at impact                         | 0.3 deg (of target)                                                                                                 | SD 0.59 deg                                                          | DATA                                 |
+| Rise (attack) angle                          | 2.8 deg up                                                                                                          | +/- 1.8 deg                                                          | DATA                                 |
+| Capture ceiling                              | 1.64 m/s dead-centre                                                                                                | parameter-free test pin; b_max(v) curve per §4                       | DERIV                                |
+| Reference tour datum (validation comparison) | nominal 4 m level putt (shortened on slower greens): head 1.510 m/s from Table 2, BSL 241 mm, BST 670 ms, TI 317 ms | +/- 1 group SD each; same-source narrative impact speed is 1.570 m/s | DATA                                 |
+
+Suggested contract tests: (a) flat-uniform surface reproduces the shared
+closed forms (5/7 pin, skid share band, a = 5.49/S); (b) the SAM tour row
+is used as a validation comparison across the documented effective-mass
+range, not forced as an exact calibration target; (c) the full-chord
+capture ceiling is exact to the geometry; (d) a stimpmeter simulation
+launched _rolling at r_c contact_ (over-spinning by R/r_c) settles from
+above, not below (sign test).
+
+## 6. Gaps — No Public Verifiable Source
+
+The model must mark these as assumptions (CONV) or leave them
+unparameterised:
+
+1. **Ball-turf sliding friction mu_k.** No openly published measurement
+   verified. Default 0.40 is a fleet assumption; sensitivity 0.3-0.5
+   moves the stimp-10 skid share 9.7-15.2%.
+2. **Putter face COR primary data.** 0.78 is repeated across the fleet
+   and trade literature but no primary measurement source was verified.
+3. **Contact time at putting speeds.** Order 0.5 ms by analogy with
+   full-speed golf impacts (R. Cross's open publications are the natural
+   primary source — pointer, not verified for putts).
+4. **Grip forces during the stroke.** Nothing verifiable found (§3.4).
+5. **Putter head MOI values.** No openly published per-model numbers
+   verified; treat MOI as a free parameter in the P3 collision model.
+6. **Skid-phase field data** (high-speed footage statistics of skid
+   length/transition on real greens) — the 5/7 law is parameter-free
+   theory; no public measurement dataset verified to pin mu_k.
+7. **Green-condition statistics** (spatial variability of stimp/friction
+   on real greens) — the P2 stochastic fields have no public calibration
+   dataset; seeded perturbations are modelling choices.
+
+## 7. Unverified Pointers (Flagged; Numbers Not Used)
+
+- R. Cross, physics of ball-implement impacts (open PDFs at
+  physics.usyd.edu.au/~cross) — natural primary source for COR/contact
+  time; not verified against a fetched copy for putting-speed values.
+- D. Pelz, _Putt Like the Pros_ / putting research (cited by Marquardt as
+  [3] for the 82%/18% face/path direction weighting and the "Perfy"
+  robot) — the weighting is quoted here only as what Marquardt states.
+- Blast Motion / TrueRoll coaching statistics on tempo (repeat the 2:1
+  ratio; vendor blogs, no methodology published).
+- Grober, "Resonance as a Means of Distance Control in Putting"
+  (arXiv:1103.2827) — abstract verified ("driven at twice its natural
+  resonance frequency"); full-text numbers not extracted; the companion
+  paper arXiv:0903.1762 was fetched and used instead.
+- Academic putting-biomechanics literature (e.g. Delay et al., Karlsen's
+  green-reading work, Hurrion's putter-fitting studies) — commonly
+  referenced; none fetched; no numbers reproduced.
+
+## 8. Sources Actually Verified (Fetched During This Review)
+
+1. R&A Equipment Rules, Part 4 (the ball) —
+   <https://www.randa.org/en/roe/the-rules-of-equipment/part-4-conformance-of-balls>
+2. R&A _Rules of Golf_ effective Jan 2023, official PDF, Definitions:
+   "Hole" (p. 222) —
+   <https://assets-us-01.kc-usercontent.com/c42c7bf4-dca7-00ea-4f2e-373223f80f76/48712d47-76dc-4fd3-add1-53972c021580/2023%20Rules%20of%20Golf.pdf>
+3. USGA Stimpmeter Instructions (full reprint, _Hole Notes_ Aug 2000) —
+   <https://archive.lib.msu.edu/tic/holen/article/2000aug24.pdf>
+4. C. Marquardt, "The SAM PuttLab: Concept and PGA Tour Data", _Annual
+   Review of Golf Coaching_ 2007 —
+   <https://sam-academy.com/wp-content/uploads/2020/04/ARGC07-SAM-PuttLab-Concept-and-Tour-Data.pdf>
+5. R. D. Grober, "Resonance in Putting", arXiv:0903.1762 —
+   <https://arxiv.org/abs/0903.1762>
+6. R. D. Grober, "Resonance as a Means of Distance Control in Putting",
+   arXiv:1103.2827 (abstract only) — <https://arxiv.org/abs/1103.2827>
+7. J. Wall, "Why blade putters have increased in weight", GOLF.com —
+   <https://golf.com/gear/putters/blade-putters-weight-fully-equipped-mailbag/>
+
+In-org verified derivations cross-linked: AffineDrift PR #3778
+(`putting-roll-models.qmd`, `green-simulation.qmd`); Tools#4125 H3
+(`src/shared/python/swing_sim/putting/`); this repo's
+`docs/physics/GOLF_BALL_FLIGHT_IMPACT_SOURCE_MAP.md` (source-map pattern
+this document follows).

--- a/src/shared/python/putting_dynamics/__init__.py
+++ b/src/shared/python/putting_dynamics/__init__.py
@@ -1,0 +1,138 @@
+"""Surface-aware putting dynamics (epic #8345, phases P2 + P3).
+
+Advanced putt physics for the 3-D putt simulation: heterogeneous green
+surfaces (heightmap slope + spatial friction + seeded stochastic
+bumpiness), advanced friction laws (velocity-dependent rolling
+resistance, static rolling hold with steep-slope restart, optional
+grain anisotropy), a two-body putter-ball collision with finite putter
+effective mass, dynamic-loft sweeps, hosel-position face twist, and a
+mode-machine RK4 solver (airborne rise/settle -> slide -> roll ->
+rest) with hole capture.
+
+Package layout mirrors ``src.shared.python.physics.impact_model``
+(types / surfaces / friction / collision / solver / utils behind this
+façade); consume the package through this module — the submodule
+internals are not a public surface (Law of Demeter).
+
+Reused shared infrastructure (AGENTS.md section A; also credited in
+each submodule):
+
+* ``src.shared.python.contracts`` — DbC (require/ensure).
+* ``src.shared.python.core.physics_constants`` — USGA ball constants
+  and standard gravity (single source).
+* Tools ``swing_sim.putting`` (branch ``feat/putting-vertical``,
+  Tools#4125 H3) — skid/roll closed forms, stimp derivation, capture
+  bound, lofted-impact decomposition: restated with credit because the
+  vendored ``vendor/ud-tools`` snapshot predates that branch (UD
+  vendors Tools; never the reverse).
+* Tools ``swing_sim.variation.engine`` — keyed per-field RNG stream
+  discipline for the bumpy fields.
+* ``rust_core/upstream-physics/src/contact.rs`` — green restitution
+  (0.78) and sliding friction (0.4) defaults.
+
+Quick start::
+
+    from src.shared.python.putting_dynamics import (
+        PutterState, SurfaceSpec, simulate_strike,
+    )
+
+    surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+    putter = PutterState(
+        head_mass_kg=0.35, moi_kg_m2=4.5e-4, loft_deg=3.0, speed_mps=1.8
+    )
+    result = simulate_strike(putter, surface, hole_x_m=3.0, hole_y_m=0.0)
+
+All quantities are SI; convert for display via :mod:`.utils` only.
+"""
+
+from __future__ import annotations
+
+from .collision import (
+    GROUND_RESTITUTION,
+    LOFT_SWEEP_MAX_DEG,
+    LOFT_SWEEP_MIN_DEG,
+    effective_head_mass,
+    strike,
+    sweep_dynamic_loft,
+)
+from .friction import (
+    DEFAULT_SLIDING_MU,
+    DEFAULT_STATIC_MU,
+    STIMP_RELEASE_SPEED_MPS,
+    FrictionParams,
+    grain_factor,
+    is_static_hold,
+    rolling_mu,
+    rolling_mu_to_stimp,
+    sliding_mu,
+    stimp_to_rolling_mu,
+)
+from .solver import (
+    DT_S,
+    HOLE_RADIUS_M,
+    capture_speed_mps,
+    simulate_ball,
+    simulate_strike,
+)
+from .surfaces import (
+    FrictionField,
+    HeightField,
+    SurfaceSpec,
+    bumpy_friction_field,
+    bumpy_height_field,
+)
+from .types import (
+    BallState,
+    CollisionReport,
+    Mode,
+    PuttResult,
+    PutterState,
+    TrajectorySample,
+)
+from .utils import (
+    ball_kinetic_energy_j,
+    energy_balance_error_j,
+    m_to_feet,
+    m_to_yards,
+    mps_to_mph,
+)
+
+__all__ = [
+    "DEFAULT_SLIDING_MU",
+    "DEFAULT_STATIC_MU",
+    "DT_S",
+    "GROUND_RESTITUTION",
+    "HOLE_RADIUS_M",
+    "LOFT_SWEEP_MAX_DEG",
+    "LOFT_SWEEP_MIN_DEG",
+    "STIMP_RELEASE_SPEED_MPS",
+    "BallState",
+    "CollisionReport",
+    "FrictionField",
+    "FrictionParams",
+    "HeightField",
+    "Mode",
+    "PuttResult",
+    "PutterState",
+    "SurfaceSpec",
+    "TrajectorySample",
+    "ball_kinetic_energy_j",
+    "bumpy_friction_field",
+    "bumpy_height_field",
+    "capture_speed_mps",
+    "effective_head_mass",
+    "energy_balance_error_j",
+    "grain_factor",
+    "is_static_hold",
+    "m_to_feet",
+    "m_to_yards",
+    "mps_to_mph",
+    "rolling_mu",
+    "rolling_mu_to_stimp",
+    "simulate_ball",
+    "simulate_strike",
+    "sliding_mu",
+    "stimp_to_rolling_mu",
+    "strike",
+    "sweep_dynamic_loft",
+]

--- a/src/shared/python/putting_dynamics/collision.py
+++ b/src/shared/python/putting_dynamics/collision.py
@@ -1,0 +1,267 @@
+"""Two-body putter-ball collision with loft and hosel twist (#8345, P3).
+
+Reused shared infrastructure (AGENTS.md section A discovery):
+
+* Ball constants from ``src.shared.python.core.physics_constants``
+  (USGA Rule 5 mass/radius; single source).
+* DbC helpers from ``src.shared.python.contracts``.
+* The lofted-face decomposition and the 2/7 tangential rolling cap
+  restate the derivation in Tools ``swing_sim.putting.impact`` (branch
+  ``feat/putting-vertical``, epic Tools#4125 H3) — the vendored Tools
+  snapshot predates that branch, so the formulas are restated with
+  credit instead of imported (UD vendors Tools; no import cycle).
+* The ground restitution used by the post-impact hop settle is the
+  green-contact default in
+  ``rust_core/upstream-physics/src/contact.rs`` (``cor = 0.78``).
+
+Model
+-----
+The face is a plane tilted back by the dynamic loft ``delta``; the
+head travels horizontally at ``V``.  Contact is sub-millisecond, so
+gravity and turf reaction are ignored during the impulse (restated
+Tools assumption).
+
+**Normal direction** — two-body impulse with a *finite effective
+mass*.  For a strike offset ``d`` toe-ward of the head CG the head
+responds with::
+
+    1 / m_eff = 1 / M + d**2 / I
+
+(standard rigid-body effective mass at an offset contact; ``I`` is the
+head MOI about the vertical axis).  With reduced mass
+``m_red = m_eff m_b / (m_eff + m_b)`` the normal impulse is::
+
+    J_n = (1 + e) m_red V cos(delta)
+
+giving ball launch ``J_n / m_b`` along the normal and a putter CG
+slowdown ``J_x / M`` (momentum conservation is test-pinned).  The
+normal-direction energy loss is ``(1/2) m_red (V cos d)^2 (1 - e^2)``
+(test-pinned COR audit).
+
+**Tangential direction** — resolving the horizontal face velocity
+along the face tangent gives a down-and-forward contact velocity of
+magnitude ``u = V sin(delta)`` for positive loft.  Impulsive friction
+spins the ball to the no-slip cap, transferring ``v_t = (2/7) u``
+down the face and backspin ``omega r = (5/7) u``.  This uses the same
+2/7 sphere cap as Tools ``swing_sim.putting.impact`` but corrects that
+module's inconsistent vector recomposition: a backspin-producing
+tangential impulse must point down the face, not up it.  The tangential slip dissipates
+``m_b u^2 / 7`` (work ``(2/7) m u^2`` minus ball tangential KE gain
+``(1/7) m u^2``).
+
+**Hosel twist (face-balanced vs toe-hang spectrum)** — the shaft
+attaches at ``(hosel_forward_m, hosel_toe_m)`` relative to the head
+CG on the top surface.  The impact impulse acts at the strike point
+``(0, impact_toe_m)``; its moment about the vertical shaft axis is::
+
+    M_shaft = J_x * (impact_toe_m - hosel_toe_m)
+
+(the forward hosel offset drops out because the normal impulse has no
+lateral component — it still enters the full wrench below).  The
+face-twist impulse is ``M_shaft / I``; positive twist swings the toe
+backward (face opening toward the toe side).  A centered attachment
+with a centered strike therefore produces zero twist, and a heel-side
+(anser-style) attachment with a center strike produces positive twist
+(both test-pinned, with toe-mirror antisymmetry).
+
+This is a rigid-body *impulse* treatment.  The documented seam for the
+upcoming finite-interval twist-dynamics epic is the attachment-point
+impulse wrench reported on :class:`~.types.CollisionReport`
+(``attachment_impulse_n_s`` / ``attachment_moment_n_m_s``, head frame:
+x forward, y toe-ward, z up; the vertical lever from top surface to
+face center is omitted here and belongs to that epic).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+from src.shared.python.contracts import ensure, require, require_finite
+from src.shared.python.core.physics_constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+
+from .types import CollisionReport, PutterState
+
+__all__ = [
+    "GROUND_RESTITUTION",
+    "LOFT_SWEEP_MAX_DEG",
+    "LOFT_SWEEP_MIN_DEG",
+    "effective_head_mass",
+    "strike",
+    "sweep_dynamic_loft",
+]
+
+#: Green-contact restitution for the post-impact hop settle — the
+#: default in ``rust_core/upstream-physics/src/contact.rs``.
+GROUND_RESTITUTION = 0.78
+
+#: Dynamic-loft sweep bounds [deg] (epic #8345 P3).
+LOFT_SWEEP_MIN_DEG = -4.0
+LOFT_SWEEP_MAX_DEG = 8.0
+
+#: 2/7 tangential rolling cap for a struck sphere (restated from Tools
+#: ``swing_sim.putting.impact`` / ``swing_sim.impact``).
+_ROLLING_CAP = 2.0 / 7.0
+
+#: Contact-duration proxy [s] for visualization pacing (documented
+#: sub-millisecond scale; not a dynamics quantity).
+_CONTACT_TIME_PROXY_S = 0.0005
+
+
+def effective_head_mass(putter: PutterState, impact_toe_m: float) -> float:
+    """Head effective mass at an offset strike point.
+
+    ``1/m_eff = 1/M + d^2/I`` (module derivation); equals the head
+    mass for a centered strike.
+
+    Args:
+        putter: Putter head state.
+        impact_toe_m: Strike offset toe-ward of the head CG [m].
+
+    Returns:
+        Effective mass [kg], in ``(0, head_mass_kg]``.
+
+    Raises:
+        ValueError: If the offset is out of range.
+    """
+    require_finite(impact_toe_m, "impact_toe_m")
+    require(
+        abs(impact_toe_m) <= 0.08,
+        "impact offset within +/- 0.08 m",
+        impact_toe_m,
+    )
+    m_eff = 1.0 / (1.0 / putter.head_mass_kg + impact_toe_m**2 / putter.moi_kg_m2)
+    ensure(0.0 < m_eff <= putter.head_mass_kg, "m_eff in (0, M]", m_eff)
+    return m_eff
+
+
+def strike(putter: PutterState, impact_toe_m: float = 0.0) -> CollisionReport:
+    """Solve one putter-ball impact (module derivation).
+
+    Args:
+        putter: Putter head at impact (speed, loft, COR, hosel).
+        impact_toe_m: Strike offset toe-ward of the head CG [m];
+            0 is a centered strike.
+
+    Returns:
+        The full :class:`~.types.CollisionReport`.
+
+    Raises:
+        ValueError: If inputs are out of physical range.
+    """
+    delta = math.radians(putter.loft_deg)
+    m_ball = float(GOLF_BALL_MASS_KG)
+    m_eff = effective_head_mass(putter, impact_toe_m)
+    m_red = m_eff * m_ball / (m_eff + m_ball)
+
+    v_normal_rel = putter.speed_mps * math.cos(delta)
+    impulse_n = (1.0 + putter.cor) * m_red * v_normal_rel
+    ball_normal = impulse_n / m_ball
+
+    u_tangential = putter.speed_mps * math.sin(delta)
+    ball_tangential = _ROLLING_CAP * u_tangential
+    impulse_t = _ROLLING_CAP * m_ball * u_tangential
+    # Backspin: contact-surface speed (5/7) u, topspin-positive sign
+    # (restated Tools convention).
+    spin_rad_s = -(1.0 - _ROLLING_CAP) * u_tangential / GOLF_BALL_RADIUS_M
+
+    # World components (x forward, z up); n = (cos d, sin d), while
+    # the backspin-producing tangential impulse points down the face,
+    # -t = (sin d, -cos d).
+    horizontal = ball_normal * math.cos(delta) + ball_tangential * math.sin(delta)
+    vertical = ball_normal * math.sin(delta) - ball_tangential * math.cos(delta)
+    ball_speed = math.hypot(horizontal, vertical)
+
+    impulse_x = impulse_n * math.cos(delta) + impulse_t * math.sin(delta)
+    impulse_z = impulse_n * math.sin(delta) - impulse_t * math.cos(delta)
+    putter_dv = impulse_x / putter.head_mass_kg
+
+    energy_loss = (
+        0.5 * m_red * v_normal_rel**2 * (1.0 - putter.cor**2)
+        + m_ball * u_tangential**2 / 7.0
+    )
+
+    twist_moment = impulse_x * (impact_toe_m - putter.hosel_toe_m)
+    shaft_axis_moi = putter.moi_kg_m2 + putter.head_mass_kg * (
+        putter.hosel_toe_m**2 + putter.hosel_forward_m**2
+    )
+    face_twist = twist_moment / shaft_axis_moi
+
+    # Impulse wrench on the putter at the shaft attachment (head
+    # frame: x forward, y toe-ward, z up); vertical lever omitted —
+    # documented seam for the finite-interval twist epic.
+    lever_f = 0.0 - putter.hosel_forward_m
+    lever_t = impact_toe_m - putter.hosel_toe_m
+    force = (-impulse_x, 0.0, -impulse_z)
+    moment = (
+        lever_t * force[2],
+        -lever_f * force[2],
+        lever_f * 0.0 - lever_t * force[0],
+    )
+
+    ensure(ball_speed > 0.0, "ball must leave the face", ball_speed)
+    ensure(
+        ball_speed <= 2.0 * putter.speed_mps,
+        "smash factor bounded by 2 (equal-mass elastic limit)",
+        ball_speed / putter.speed_mps,
+    )
+    ensure(putter_dv >= 0.0, "the head cannot speed up", putter_dv)
+    ensure(energy_loss >= 0.0, "impact cannot create energy", energy_loss)
+    return CollisionReport(
+        ball_speed_mps=ball_speed,
+        launch_angle_deg=math.degrees(math.atan2(vertical, horizontal)),
+        horizontal_speed_mps=horizontal,
+        vertical_speed_mps=vertical,
+        spin_rad_s=spin_rad_s,
+        effective_loft_deg=putter.loft_deg,
+        putter_dv_mps=putter_dv,
+        impulse_n_s=impulse_n,
+        contact_time_proxy_s=_CONTACT_TIME_PROXY_S,
+        kinetic_energy_loss_j=energy_loss,
+        face_twist_rad_s=face_twist,
+        twist_moment_n_m_s=twist_moment,
+        attachment_impulse_n_s=force,
+        attachment_moment_n_m_s=moment,
+    )
+
+
+def sweep_dynamic_loft(
+    putter: PutterState,
+    loft_min_deg: float = LOFT_SWEEP_MIN_DEG,
+    loft_max_deg: float = LOFT_SWEEP_MAX_DEG,
+    step_deg: float = 1.0,
+    impact_toe_m: float = 0.0,
+) -> tuple[CollisionReport, ...]:
+    """Dynamic-loft sweep helper (P3 acceptance: -4 to +8 deg).
+
+    Args:
+        putter: Base putter state; its loft is replaced per sample.
+        loft_min_deg: Sweep start [deg].
+        loft_max_deg: Sweep end, inclusive [deg].
+        step_deg: Sweep step [deg], > 0.
+        impact_toe_m: Strike offset passed to every sample.
+
+    Returns:
+        Reports ordered by increasing loft.
+
+    Raises:
+        ValueError: If the sweep bounds are invalid.
+    """
+    require_finite(loft_min_deg, "loft_min_deg")
+    require_finite(loft_max_deg, "loft_max_deg")
+    require(loft_min_deg < loft_max_deg, "sweep must ascend", loft_min_deg)
+    require_finite(step_deg, "step_deg")
+    require(0.0 < step_deg <= 5.0, "step in (0, 5] deg", step_deg)
+    count = int(math.floor((loft_max_deg - loft_min_deg) / step_deg + 1e-9)) + 1
+    reports = tuple(
+        strike(
+            replace(putter, loft_deg=loft_min_deg + i * step_deg),
+            impact_toe_m=impact_toe_m,
+        )
+        for i in range(count)
+    )
+    ensure(len(reports) >= 2, "sweep must contain >= 2 samples", len(reports))
+    return reports

--- a/src/shared/python/putting_dynamics/friction.py
+++ b/src/shared/python/putting_dynamics/friction.py
@@ -1,0 +1,326 @@
+"""Advanced putting friction laws (epic #8345, P2).
+
+Reused shared infrastructure (AGENTS.md section A discovery):
+
+* DbC helpers from ``src.shared.python.contracts``.
+* Gravity from ``src.shared.python.core.physics_constants``.
+* The stimpmeter -> rolling-resistance conversion restates the
+  derivation from Tools ``swing_sim.putting.roll`` (Tools branch
+  ``feat/putting-vertical``, epic Tools#4125 H3).  The vendored Tools
+  snapshot in ``vendor/ud-tools`` predates that branch, so the closed
+  form is restated here with credit instead of imported; if the vendor
+  pin is bumped past Tools#4125 this module should re-export the Tools
+  functions instead (documented seam, no cycle: UD vendors Tools).
+
+Laws
+----
+**Stimp -> rolling resistance** (restated from Tools
+``swing_sim.putting.roll``): the USGA stimpmeter releases the ball at
+``v_release ~= 1.83 m/s`` (36 in ramp, 20 deg release, V-groove
+contact radius ~0.87 r).  A green that "stimps" ``S`` feet under a
+constant rolling deceleration ``mu_r g`` satisfies::
+
+    mu_r = v_release**2 / (2 g S)
+
+Sanity: stimp 10 -> ``mu_r ~= 0.056``, inside the published 0.05-0.07
+tournament band.
+
+**Velocity-dependent rolling resistance**::
+
+    mu_r(v) = mu_r0 * (1 + k_v * v)
+
+Rationale (engineering model, documented rather than cited): turf
+deformation depth and grass-blade drag both grow with ball speed, so
+the effective rolling deceleration is not constant; a term linear in
+``v`` is the smallest correction that (a) reduces exactly to the
+constant-deceleration stimp model at ``k_v = 0`` (preserving the Tools
+closed forms as an analytic limit, test-enforced) and (b) keeps the
+ODE smooth for RK4.  Default ``k_v = 0``; no published value is
+claimed for it.
+
+**Static/kinetic transition at rest**: the ball rests when its speed
+falls below ``v_stop`` *and* the in-plane gravity pull can be held by
+the static *rolling* hold.  A resting ball needs no sliding to move —
+it can re-start by rolling — so the relevant bound is the turf's
+static rolling resistance (indentation holding torque), slightly above
+the kinetic rolling band, not the sliding Coulomb coefficient.  On a
+small slope of magnitude ``s = |grad h|`` the driving acceleration is
+``g s`` and the maximum hold is ``mu_static g``, so the ball stays at
+rest iff ``s <= mu_static`` — otherwise it re-starts rolling downhill
+(both branches test-enforced).  This is also the self-consistency
+condition of the roll ODE: on slopes steeper than the rolling
+resistance a rolling ball cannot decelerate to rest at all.
+
+**Grain anisotropy** (optional): bermuda-style grain drags the ball
+less when rolling down-grain.  Modeled as a multiplicative factor::
+
+    mu * (1 - g_strength * cos(theta_v - theta_grain))
+
+with ``theta_grain`` the down-grain direction (the direction the laid
+grass points).  Down-grain travel therefore gives the minimum factor
+``1 - g_strength`` and directly opposing travel gives ``1 +
+g_strength``.  Purely phenomenological; ``g_strength``
+defaults to 0.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from src.shared.python.contracts import ensure, require, require_finite
+from src.shared.python.core.physics_constants import GRAVITY_M_S2
+
+__all__ = [
+    "DEFAULT_SLIDING_MU",
+    "DEFAULT_STATIC_MU",
+    "STIMP_RELEASE_SPEED_MPS",
+    "FrictionParams",
+    "grain_factor",
+    "is_static_hold",
+    "rolling_mu",
+    "rolling_mu_to_stimp",
+    "sliding_mu",
+    "stimp_to_rolling_mu",
+]
+
+#: Typical published grass sliding friction — the green-contact default
+#: in ``rust_core/upstream-physics/src/contact.rs`` (friction = 0.4) and
+#: the value used by Tools ``swing_sim.putting.roll``.
+DEFAULT_SLIDING_MU = 0.40
+
+#: Static rolling-hold default — slightly above the published 0.05-0.07
+#: kinetic rolling band (classic static > kinetic ordering), so greens
+#: hold putts on ordinary slopes but release them on steep ones.
+DEFAULT_STATIC_MU = 0.08
+
+#: Meters per foot (display conversions live in :mod:`.utils`; this is
+#: the stimp definition, which is inherently in feet).
+_FOOT_M = 0.3048
+
+#: USGA stimpmeter release speed [m/s] (~6.0 ft/s).  Restated from the
+#: Tools ``swing_sim.putting.roll`` derivation (see module docstring).
+STIMP_RELEASE_SPEED_MPS = 1.83
+
+
+@dataclass(frozen=True)
+class FrictionParams:
+    """Friction-law parameters for one green.
+
+    Attributes:
+        mu_roll0: Base rolling-resistance coefficient (stimp-derived
+            via :func:`stimp_to_rolling_mu`).
+        mu_slide: Kinetic sliding friction for the skid phase.
+        mu_static: Static rolling-hold bound for the rest/restart
+            check (module laws); must be at least the kinetic
+            ``mu_roll0``.
+        k_v_per_mps: Velocity coefficient of rolling resistance
+            [s/m]; 0 recovers the constant-deceleration model.
+        grain_strength: Grain anisotropy amplitude in [0, 0.9); 0
+            disables grain.
+        grain_direction_rad: Direction the grain points [rad], in the
+            surface x-y frame.
+        v_stop_mps: Speed below which the ball may come to rest.
+    """
+
+    mu_roll0: float
+    mu_slide: float = DEFAULT_SLIDING_MU
+    mu_static: float = DEFAULT_STATIC_MU
+    k_v_per_mps: float = 0.0
+    grain_strength: float = 0.0
+    grain_direction_rad: float = 0.0
+    v_stop_mps: float = 0.005
+
+    def __post_init__(self) -> None:
+        require_finite(self.mu_roll0, "mu_roll0")
+        require(0.0 < self.mu_roll0 < 0.2, "mu_roll0 in (0, 0.2)", self.mu_roll0)
+        require_finite(self.mu_slide, "mu_slide")
+        require(0.0 < self.mu_slide <= 1.5, "mu_slide in (0, 1.5]", self.mu_slide)
+        require_finite(self.mu_static, "mu_static")
+        require(
+            self.mu_roll0 <= self.mu_static <= 2.0,
+            "mu_static must be >= mu_roll0 and <= 2",
+            self.mu_static,
+        )
+        require_finite(self.k_v_per_mps, "k_v_per_mps")
+        require(
+            0.0 <= self.k_v_per_mps <= 2.0,
+            "k_v must be in [0, 2] s/m",
+            self.k_v_per_mps,
+        )
+        require_finite(self.grain_strength, "grain_strength")
+        require(
+            0.0 <= self.grain_strength < 0.9,
+            "grain_strength in [0, 0.9)",
+            self.grain_strength,
+        )
+        require_finite(self.grain_direction_rad, "grain_direction_rad")
+        require(
+            abs(self.grain_direction_rad) <= 2.0 * math.pi,
+            "grain direction within +/- 2 pi",
+            self.grain_direction_rad,
+        )
+        require_finite(self.v_stop_mps, "v_stop_mps")
+        require(
+            0.0 < self.v_stop_mps <= 0.1,
+            "v_stop in (0, 0.1] m/s",
+            self.v_stop_mps,
+        )
+
+
+def stimp_to_rolling_mu(stimp_ft: float) -> float:
+    """Rolling-resistance coefficient for a stimp reading.
+
+    ``mu_r = v_release**2 / (2 g S)`` — restated from Tools
+    ``swing_sim.putting.roll`` with credit (see module docstring).
+
+    Args:
+        stimp_ft: Stimpmeter reading [feet]; greens span ~4-16.
+
+    Returns:
+        Dimensionless rolling deceleration coefficient.
+
+    Raises:
+        ValueError: If the stimp reading is out of range.
+    """
+    require_finite(stimp_ft, "stimp_ft")
+    require(3.0 <= stimp_ft <= 16.0, "stimp must be in [3, 16] ft", stimp_ft)
+    mu = STIMP_RELEASE_SPEED_MPS**2 / (2.0 * GRAVITY_M_S2 * stimp_ft * _FOOT_M)
+    ensure(0.0 < mu < 0.2, "rolling mu must be physically small", mu)
+    return mu
+
+
+def rolling_mu_to_stimp(mu_r: float) -> float:
+    """Inverse of :func:`stimp_to_rolling_mu` (round-trip exact).
+
+    Args:
+        mu_r: Rolling-resistance coefficient in (0, 0.2).
+
+    Returns:
+        Stimpmeter reading [feet].
+
+    Raises:
+        ValueError: If the coefficient is out of range.
+    """
+    require_finite(mu_r, "mu_r")
+    require(0.0 < mu_r < 0.2, "mu_r must be in (0, 0.2)", mu_r)
+    return STIMP_RELEASE_SPEED_MPS**2 / (2.0 * GRAVITY_M_S2 * mu_r * _FOOT_M)
+
+
+def grain_factor(params: FrictionParams, travel_direction_rad: float) -> float:
+    """Anisotropic grain multiplier ``1 - g cos(theta_v - theta_g)``.
+
+    Args:
+        params: Friction parameters (grain strength/direction).
+        travel_direction_rad: Ball travel direction [rad].
+
+    Returns:
+        Multiplier in ``[1 - g, 1 + g]``; exactly 1 when grain is off.
+    """
+    if params.grain_strength == 0.0:
+        return 1.0
+    require_finite(travel_direction_rad, "travel_direction_rad")
+    factor = 1.0 - params.grain_strength * math.cos(
+        travel_direction_rad - params.grain_direction_rad
+    )
+    ensure(factor > 0.0, "grain factor must stay positive", factor)
+    return factor
+
+
+def rolling_mu(
+    params: FrictionParams,
+    speed_mps: float,
+    spatial_multiplier: float = 1.0,
+    travel_direction_rad: float = 0.0,
+) -> float:
+    """Effective rolling-resistance coefficient at a point.
+
+    ``mu_r0 * mult * (1 + k_v v) * grain`` — see the module laws.
+
+    Args:
+        params: Friction parameters.
+        speed_mps: Current ball speed [m/s], >= 0.
+        spatial_multiplier: Local :class:`~.surfaces.FrictionField`
+            rolling multiplier (> 0).
+        travel_direction_rad: Ball travel direction [rad] (grain).
+
+    Returns:
+        Effective coefficient, > 0.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(speed_mps, "speed_mps")
+    require(speed_mps >= 0.0, "speed must be non-negative", speed_mps)
+    require_finite(spatial_multiplier, "spatial_multiplier")
+    require(spatial_multiplier > 0.0, "multiplier must be > 0", spatial_multiplier)
+    mu = (
+        params.mu_roll0
+        * spatial_multiplier
+        * (1.0 + params.k_v_per_mps * speed_mps)
+        * grain_factor(params, travel_direction_rad)
+    )
+    ensure(mu > 0.0, "effective rolling mu must be positive", mu)
+    return mu
+
+
+def sliding_mu(
+    params: FrictionParams,
+    spatial_multiplier: float = 1.0,
+    travel_direction_rad: float = 0.0,
+) -> float:
+    """Effective kinetic sliding friction at a point.
+
+    Speed-independent (Coulomb); scaled by the local field multiplier
+    and the grain factor.
+
+    Args:
+        params: Friction parameters.
+        spatial_multiplier: Local sliding multiplier (> 0).
+        travel_direction_rad: Ball travel direction [rad] (grain).
+
+    Returns:
+        Effective coefficient, > 0.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(spatial_multiplier, "spatial_multiplier")
+    require(spatial_multiplier > 0.0, "multiplier must be > 0", spatial_multiplier)
+    mu = (
+        params.mu_slide
+        * spatial_multiplier
+        * grain_factor(params, travel_direction_rad)
+    )
+    ensure(mu > 0.0, "effective sliding mu must be positive", mu)
+    return mu
+
+
+def is_static_hold(
+    params: FrictionParams,
+    slope_magnitude: float,
+    spatial_multiplier: float = 1.0,
+) -> bool:
+    """Whether the static rolling hold keeps a resting ball in place.
+
+    Small-angle static balance (module laws): the ball stays at rest
+    iff ``|grad h| <= mu_static * mult``; on steeper slopes it
+    re-starts rolling.
+
+    Args:
+        params: Friction parameters.
+        slope_magnitude: ``|grad h|`` at the rest point (>= 0).
+        spatial_multiplier: Local *rolling* multiplier (> 0) — the
+            hold is a rolling-resistance bound, not a sliding one.
+
+    Returns:
+        True when the ball can remain at rest.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(slope_magnitude, "slope_magnitude")
+    require(slope_magnitude >= 0.0, "slope must be >= 0", slope_magnitude)
+    require_finite(spatial_multiplier, "spatial_multiplier")
+    require(spatial_multiplier > 0.0, "multiplier must be > 0", spatial_multiplier)
+    return slope_magnitude <= params.mu_static * spatial_multiplier

--- a/src/shared/python/putting_dynamics/solver.py
+++ b/src/shared/python/putting_dynamics/solver.py
@@ -1,0 +1,389 @@
+"""Mode-machine putt integration over heterogeneous greens (#8345).
+
+Reused shared infrastructure (AGENTS.md section A discovery):
+
+* Gravity and ball constants from
+  ``src.shared.python.core.physics_constants``.
+* DbC helpers from ``src.shared.python.contracts``.
+* The skid/roll ODE shape, the fixed 2 ms RK4 discipline (mode held
+  constant within a step, transitions applied between steps), and the
+  hole-capture bound restate the derivations in Tools
+  ``swing_sim.putting`` (``roll.py`` / ``green.py``, branch
+  ``feat/putting-vertical``, epic Tools#4125 H3).  The vendored Tools
+  snapshot in ``vendor/ud-tools`` predates that branch, so the
+  formulas are restated here with credit rather than imported (UD
+  vendors Tools; no cycle).  Capture bound (Tools derivation, after
+  Holmes, "Putting: How a golf ball and hole interact", Am. J. Phys.
+  59 (1991)): free fall must drop the ball half a diameter within a
+  travel budget of one full hole diameter::
+
+      v_capture = 2 R * sqrt(g / (2 r)) ~= 1.64 m/s
+
+Mode machine
+------------
+``AIRBORNE -> (bounce ...) -> SLIDE -> ROLL -> REST`` with two extra
+edges: SLIDE starts only while the contact point slips
+(``omega r < |v|``), and REST re-opens to ROLL when the local slope
+exceeds the static-friction bound (steep-slope restart, see
+:func:`~.friction.is_static_hold`).
+
+Ground modes integrate ``(x, y, vx, vy, s)`` — ``s = omega r`` is the
+contact-surface speed along travel (restated Tools simplification: the
+spin axis stays perpendicular to the velocity; exact for straight
+putts, first-order accurate for real break angles) — with classic RK4
+at a fixed ``dt = 2 ms`` (restated from Tools ``green.py``, where the
+same step pins a TS parity mirror; kept identical here so future
+parity is bit-comparable).  In-plane gravity is ``-g grad h`` from the
+height field each evaluation (small-slope), friction comes from the
+:mod:`.friction` laws with the local :class:`~.surfaces.FrictionField`
+multipliers.
+
+The airborne phase (post-impact rise) is ballistic (no drag at putt
+speeds, documented) with symplectic-Euler height updates; each ground
+contact reflects the vertical speed with the green restitution
+``e = 0.78`` (``rust_core/upstream-physics/src/contact.rs``) and hands
+off to the ground modes once the remaining hop apex is below a
+millimetre.  Spin is frozen during flight and bounce (documented
+simplification: no bounce friction impulse).
+"""
+
+from __future__ import annotations
+
+import math
+
+from src.shared.python.contracts import ensure, require, require_finite
+from src.shared.python.core.physics_constants import (
+    GOLF_BALL_RADIUS_M,
+    GRAVITY_M_S2,
+)
+
+from .collision import GROUND_RESTITUTION, strike
+from .friction import is_static_hold, rolling_mu, sliding_mu
+from .surfaces import SurfaceSpec
+from .types import (
+    BallState,
+    CollisionReport,
+    Mode,
+    PuttResult,
+    PutterState,
+    TrajectorySample,
+)
+
+__all__ = [
+    "DT_S",
+    "HOLE_RADIUS_M",
+    "capture_speed_mps",
+    "simulate_ball",
+    "simulate_strike",
+]
+
+#: USGA hole radius [m] (4.25 in diameter).
+HOLE_RADIUS_M = 0.054
+
+#: Fixed RK4 step [s] — restated from Tools ``green.py`` (parity-pinned
+#: there); kept identical for future cross-repo parity.
+DT_S = 0.002
+
+#: Integration time cap [s].
+_MAX_TIME_S = 60.0
+
+#: Hop apex below this height hands off to the ground modes [m].
+_SETTLE_APEX_M = 0.001
+
+#: Gravity as a plain float for the inner loop.
+_G = float(GRAVITY_M_S2)
+
+#: Ball radius as a plain float for the inner loop.
+_R_BALL = float(GOLF_BALL_RADIUS_M)
+
+_State = tuple[float, float, float, float, float]
+
+
+def capture_speed_mps() -> float:
+    """Full-chord capture bound ``2 R sqrt(g / (2 r))`` (module credit).
+
+    Returns:
+        The dead-centre capture bound [m/s], ~1.64.
+    """
+    return 2.0 * HOLE_RADIUS_M * math.sqrt(_G / (2.0 * _R_BALL))
+
+
+def _derivative(state: _State, sliding: bool, surface: SurfaceSpec) -> _State:
+    """Ground-mode ODE right-hand side (module docstring)."""
+    x, y, vx, vy, surface_speed = state
+    grad = surface.height.gradient(x, y)
+    gx, gy = -_G * grad[0], -_G * grad[1]
+    speed = math.hypot(vx, vy)
+    if speed <= 0.0:
+        return (0.0, 0.0, gx, gy, 0.0)
+    heading = math.atan2(vy, vx)
+    roll_mult, slide_mult = surface.friction_field.multipliers(x, y)
+    if sliding:
+        mu = sliding_mu(surface.friction, slide_mult, heading)
+        slip = speed - surface_speed
+        slip_sign = 1.0 if slip >= 0.0 else -1.0
+        ds = slip_sign * 2.5 * mu * _G
+    else:
+        mu = rolling_mu(surface.friction, speed, roll_mult, heading)
+        slip_sign = 1.0
+        ds = 0.0
+    ax = -slip_sign * mu * _G * vx / speed + gx
+    ay = -slip_sign * mu * _G * vy / speed + gy
+    return (vx, vy, ax, ay, ds)
+
+
+def _rk4_step(state: _State, sliding: bool, surface: SurfaceSpec) -> _State:
+    """One classic RK4 step with the mode held constant (Tools shape)."""
+    k1 = _derivative(state, sliding, surface)
+    mid1 = tuple(s + 0.5 * DT_S * k for s, k in zip(state, k1, strict=True))
+    k2 = _derivative(mid1, sliding, surface)  # type: ignore[arg-type]
+    mid2 = tuple(s + 0.5 * DT_S * k for s, k in zip(state, k2, strict=True))
+    k3 = _derivative(mid2, sliding, surface)  # type: ignore[arg-type]
+    end = tuple(s + DT_S * k for s, k in zip(state, k3, strict=True))
+    k4 = _derivative(end, sliding, surface)  # type: ignore[arg-type]
+    return tuple(  # type: ignore[return-value]
+        s + (DT_S / 6.0) * (a + 2.0 * b + 2.0 * c + d)
+        for s, a, b, c, d in zip(state, k1, k2, k3, k4, strict=True)
+    )
+
+
+class _Recorder:
+    """Sample/bookkeeping accumulator for one putt."""
+
+    def __init__(self, hole_x_m: float | None, hole_y_m: float | None) -> None:
+        self.samples: list[TrajectorySample] = []
+        self.distance = 0.0
+        self.skid_distance = 0.0
+        self.hole = (
+            (hole_x_m, hole_y_m)
+            if hole_x_m is not None and hole_y_m is not None
+            else None
+        )
+        self.speed_at_hole: float | None = None
+        self.holed = False
+
+    def record(
+        self,
+        t: float,
+        x: float,
+        y: float,
+        height: float,
+        speed: float,
+        spin: float,
+        mode: Mode,
+    ) -> None:
+        self.samples.append(
+            TrajectorySample(
+                t_s=t,
+                x_m=x,
+                y_m=y,
+                height_m=height,
+                speed_mps=speed,
+                spin_rad_s=spin,
+                mode=mode,
+            )
+        )
+
+    def check_hole(self, x: float, y: float, speed: float, on_ground: bool) -> bool:
+        """Track hole crossing; True when captured."""
+        if self.hole is None or not on_ground:
+            return False
+        if math.hypot(x - self.hole[0], y - self.hole[1]) > HOLE_RADIUS_M:
+            return False
+        if self.speed_at_hole is None:
+            self.speed_at_hole = speed
+        if speed <= capture_speed_mps():
+            self.holed = True
+            return True
+        return False
+
+
+def _fly(
+    ball: BallState, surface: SurfaceSpec, rec: _Recorder, t: float
+) -> tuple[_State, float, float]:
+    """Airborne rise/bounce phase; returns ground state, spin, time."""
+    x, y = ball.x_m, ball.y_m
+    vx, vy, vz = ball.vx_mps, ball.vy_mps, ball.vz_mps
+    z = surface.height.elevation(x, y) + ball.height_m
+    while t < _MAX_TIME_S:
+        vz -= _G * DT_S
+        x += vx * DT_S
+        y += vy * DT_S
+        z += vz * DT_S
+        t += DT_S
+        rec.distance += math.hypot(vx * DT_S, vy * DT_S)
+        floor = surface.height.elevation(x, y)
+        height = max(z - floor, 0.0)
+        rec.record(t, x, y, height, math.hypot(vx, vy), ball.spin_rad_s, Mode.AIRBORNE)
+        if z <= floor and vz < 0.0:
+            vz = -GROUND_RESTITUTION * vz
+            z = floor
+            if vz**2 / (2.0 * _G) < _SETTLE_APEX_M:
+                break
+    return (x, y, vx, vy, ball.spin_rad_s * _R_BALL), ball.spin_rad_s, t
+
+
+def _restart_state(x: float, y: float, surface: SurfaceSpec) -> _State | None:
+    """Steep-slope restart: tiny downhill velocity, or None to rest."""
+    grad = surface.height.gradient(x, y)
+    slope = math.hypot(grad[0], grad[1])
+    roll_mult, _slide_mult = surface.friction_field.multipliers(x, y)
+    if is_static_hold(surface.friction, slope, roll_mult):
+        return None
+    v0 = surface.friction.v_stop_mps
+    return (x, y, -v0 * grad[0] / slope, -v0 * grad[1] / slope, v0)
+
+
+def simulate_ball(
+    ball: BallState,
+    surface: SurfaceSpec,
+    hole_x_m: float | None = None,
+    hole_y_m: float | None = None,
+    collision: CollisionReport | None = None,
+) -> PuttResult:
+    """Integrate a ball state over a surface to rest or capture.
+
+    Args:
+        ball: Initial ball state (may be airborne or at rest).
+        surface: Green description.
+        hole_x_m: Hole center x [m]; hole disabled when None.
+        hole_y_m: Hole center y [m]; hole disabled when None.
+        collision: Optional impact report to attach to the result.
+
+    Returns:
+        The integrated :class:`~.types.PuttResult`.
+
+    Raises:
+        ValueError: If the hole position is half-specified.
+    """
+    require(
+        (hole_x_m is None) == (hole_y_m is None),
+        "hole position needs both coordinates",
+        (hole_x_m, hole_y_m),
+    )
+    if hole_x_m is not None:
+        require_finite(hole_x_m, "hole_x_m")
+        require_finite(hole_y_m, "hole_y_m")
+    rec = _Recorder(hole_x_m, hole_y_m)
+    t = 0.0
+    spin = ball.spin_rad_s
+    airborne = ball.height_m > 0.0 or ball.vz_mps > 0.0
+    initial_mode = (
+        Mode.AIRBORNE
+        if airborne
+        else (
+            Mode.SLIDE
+            if not math.isclose(
+                spin * _R_BALL, ball.speed_mps, rel_tol=0.0, abs_tol=1e-12
+            )
+            else Mode.ROLL
+        )
+    )
+    rec.record(
+        0.0, ball.x_m, ball.y_m, ball.height_m, ball.speed_mps, spin, initial_mode
+    )
+    if airborne:
+        state, spin, t = _fly(ball, surface, rec, t)
+    else:
+        state = (ball.x_m, ball.y_m, ball.vx_mps, ball.vy_mps, spin * _R_BALL)
+
+    sliding = not math.isclose(
+        state[4], math.hypot(state[2], state[3]), rel_tol=0.0, abs_tol=1e-12
+    )
+    while t < _MAX_TIME_S:
+        speed = math.hypot(state[2], state[3])
+        if (
+            speed <= surface.friction.v_stop_mps
+            and abs(state[4]) <= surface.friction.v_stop_mps
+        ):
+            restarted = _restart_state(state[0], state[1], surface)
+            if restarted is None:
+                break
+            state, sliding = restarted, False
+        prev = state
+        previous_slip = math.hypot(prev[2], prev[3]) - prev[4]
+        state = _rk4_step(state, sliding, surface)
+        t += DT_S
+        step = math.hypot(state[0] - prev[0], state[1] - prev[1])
+        rec.distance += step
+        speed = math.hypot(state[2], state[3])
+        if sliding:
+            rec.skid_distance += step
+            current_slip = speed - state[4]
+            crossed_zero = previous_slip * current_slip <= 0.0
+            within_one_step = (
+                abs(current_slip) <= abs(current_slip - previous_slip) + 1e-12
+            )
+            if crossed_zero or within_one_step:
+                sliding = False
+        if not sliding:
+            # Pin the contact-surface speed to pure roll.
+            state = (state[0], state[1], state[2], state[3], speed)
+        spin = state[4] / _R_BALL
+        mode = Mode.SLIDE if sliding else Mode.ROLL
+        rec.record(t, state[0], state[1], 0.0, speed, spin, mode)
+        if rec.check_hole(state[0], state[1], speed, on_ground=True):
+            break
+
+    last = rec.samples[-1]
+    if not rec.holed and last.speed_mps <= surface.friction.v_stop_mps:
+        rec.record(last.t_s, last.x_m, last.y_m, 0.0, 0.0, spin, Mode.REST)
+    ensure(rec.distance >= 0.0, "distance must be non-negative", rec.distance)
+    ensure(
+        rec.skid_distance <= rec.distance + 1e-9,
+        "skid cannot exceed the total path",
+        (rec.skid_distance, rec.distance),
+    )
+    return PuttResult(
+        samples=tuple(rec.samples),
+        collision=collision,
+        holed=rec.holed,
+        rest_x_m=rec.samples[-1].x_m,
+        rest_y_m=rec.samples[-1].y_m,
+        total_distance_m=rec.distance,
+        time_s=rec.samples[-1].t_s,
+        skid_distance_m=rec.skid_distance,
+        speed_at_hole_mps=rec.speed_at_hole,
+    )
+
+
+def simulate_strike(
+    putter: PutterState,
+    surface: SurfaceSpec,
+    impact_toe_m: float = 0.0,
+    hole_x_m: float | None = None,
+    hole_y_m: float | None = None,
+) -> PuttResult:
+    """Strike the ball with a putter and integrate the full putt.
+
+    Chains :func:`~.collision.strike` (impulse + hosel twist), the
+    airborne rise/settle phase, and the surface mode machine.
+
+    Args:
+        putter: Putter head at impact.
+        surface: Green description.
+        impact_toe_m: Strike offset toe-ward of the head CG [m].
+        hole_x_m: Hole center x [m]; hole disabled when None.
+        hole_y_m: Hole center y [m]; hole disabled when None.
+
+    Returns:
+        The integrated :class:`~.types.PuttResult` with its
+        :class:`~.types.CollisionReport` attached.
+    """
+    report = strike(putter, impact_toe_m=impact_toe_m)
+    ball = BallState(
+        x_m=0.0,
+        y_m=0.0,
+        height_m=0.0,
+        vx_mps=report.horizontal_speed_mps,
+        vy_mps=0.0,
+        vz_mps=max(report.vertical_speed_mps, 0.0),
+        spin_rad_s=report.spin_rad_s,
+    )
+    return simulate_ball(
+        ball,
+        surface,
+        hole_x_m=hole_x_m,
+        hole_y_m=hole_y_m,
+        collision=report,
+    )

--- a/src/shared/python/putting_dynamics/surfaces.py
+++ b/src/shared/python/putting_dynamics/surfaces.py
@@ -1,0 +1,478 @@
+"""Heterogeneous green surfaces: height, friction, bumpiness (#8345, P2).
+
+Reused shared infrastructure (AGENTS.md section A discovery):
+
+* DbC helpers from ``src.shared.python.contracts``.
+* Seeding discipline reused from the Tools variation engine
+  (``swing_sim.variation.engine._stream_for``, Tools branch
+  ``feat/putting-vertical``): every stochastic field draws from its own
+  ``numpy`` generator keyed by ``[seed, crc32(field_key)]`` so adding or
+  removing one field never perturbs another field's draws, and the same
+  seed always reproduces the identical field (test-pinned).
+
+Model
+-----
+A green is a rectangular grid.  :class:`HeightField` stores node
+elevations and answers ``elevation`` / ``gradient`` queries by bilinear
+interpolation (the gradient is the exact derivative of the bilinear
+patch, so the two are always consistent).  :class:`FrictionField`
+stores per-node multipliers applied on top of the base
+:class:`~.friction.FrictionParams` coefficients.  Bumpy variants add
+seeded, correlation-smoothed noise: white noise on the grid is smoothed
+with ``n`` box-blur passes whose footprint matches the requested
+correlation length (three passes approximate a Gaussian kernel by the
+central limit theorem), then rescaled to the requested amplitude
+(standard deviation for heights, fractional deviation for friction).
+
+Queries outside the grid clamp to the border cell (flat continuation),
+so the solver never extrapolates unboundedly.
+"""
+
+from __future__ import annotations
+
+import math
+import zlib
+from dataclasses import dataclass
+
+import numpy as np
+
+from src.shared.python.contracts import ensure, require, require_finite
+
+__all__ = [
+    "FrictionField",
+    "HeightField",
+    "SurfaceSpec",
+    "bumpy_friction_field",
+    "bumpy_height_field",
+]
+
+from .friction import FrictionParams
+
+#: Default grid extent [m] (40 m covers the Tools putting range).
+_DEFAULT_EXTENT_M = 40.0
+
+#: Default grid spacing [m].
+_DEFAULT_SPACING_M = 0.25
+
+#: Box-blur passes used to approximate Gaussian smoothing (CLT).
+_BLUR_PASSES = 3
+
+
+def _validate_grid(values: np.ndarray, spacing_m: float, name: str) -> None:
+    """Shared grid preconditions for the field dataclasses."""
+    require(isinstance(values, np.ndarray), f"{name} must be a numpy array")
+    require(values.ndim == 2, f"{name} must be a 2-D grid", values.shape)
+    require(
+        values.shape[0] >= 2 and values.shape[1] >= 2,
+        f"{name} needs at least a 2x2 grid",
+        values.shape,
+    )
+    require_finite(values, name)
+    require_finite(spacing_m, "spacing_m")
+    require(0.001 <= spacing_m <= 10.0, "spacing in [0.001, 10] m", spacing_m)
+
+
+def _validate_origin(origin_m: tuple[float, float]) -> None:
+    """Validate the shared two-dimensional field origin contract."""
+    require(len(origin_m) == 2, "origin_m must contain x and y", origin_m)
+    require_finite(origin_m[0], "origin_m[0]")
+    require_finite(origin_m[1], "origin_m[1]")
+
+
+def _validate_factory_grid(extent_m: float, spacing_m: float) -> int:
+    """Validate public factory dimensions and return the node count."""
+    require_finite(extent_m, "extent_m")
+    require(1.0 <= extent_m <= 200.0, "extent in [1, 200] m", extent_m)
+    require_finite(spacing_m, "spacing_m")
+    require(0.001 <= spacing_m <= 10.0, "spacing in [0.001, 10] m", spacing_m)
+    node_count = int(round(extent_m / spacing_m)) + 1
+    require(node_count >= 2, "grid must contain at least two nodes", node_count)
+    return node_count
+
+
+def _bilinear_setup(
+    x_m: float, y_m: float, origin: tuple[float, float], spacing: float, shape: tuple
+) -> tuple[int, int, float, float]:
+    """Clamped cell index and in-cell fractions for a query point."""
+    fx = (x_m - origin[0]) / spacing
+    fy = (y_m - origin[1]) / spacing
+    ix = int(min(max(math.floor(fx), 0), shape[1] - 2))
+    iy = int(min(max(math.floor(fy), 0), shape[0] - 2))
+    tx = min(max(fx - ix, 0.0), 1.0)
+    ty = min(max(fy - iy, 0.0), 1.0)
+    return ix, iy, tx, ty
+
+
+@dataclass(frozen=True)
+class HeightField:
+    """Bilinear-interpolated heightmap.
+
+    Attributes:
+        heights_m: Node elevations [m], indexed ``[iy, ix]``.
+        spacing_m: Grid spacing [m] (square cells).
+        origin_m: World coordinates of node ``[0, 0]`` (x, y) [m].
+    """
+
+    heights_m: np.ndarray
+    spacing_m: float = _DEFAULT_SPACING_M
+    origin_m: tuple[float, float] = (-_DEFAULT_EXTENT_M / 2.0, -_DEFAULT_EXTENT_M / 2.0)
+
+    def __post_init__(self) -> None:
+        _validate_grid(self.heights_m, self.spacing_m, "heights_m")
+        _validate_origin(self.origin_m)
+        owned = np.array(self.heights_m, dtype=float, copy=True)
+        owned.setflags(write=False)
+        object.__setattr__(self, "heights_m", owned)
+
+    @staticmethod
+    def flat(
+        extent_m: float = _DEFAULT_EXTENT_M,
+        spacing_m: float = _DEFAULT_SPACING_M,
+    ) -> HeightField:
+        """Perfectly flat green centered on the origin.
+
+        Args:
+            extent_m: Side length of the square grid [m].
+            spacing_m: Grid spacing [m].
+
+        Returns:
+            A zero-elevation :class:`HeightField`.
+        """
+        n = _validate_factory_grid(extent_m, spacing_m)
+        return HeightField(
+            heights_m=np.zeros((n, n)),
+            spacing_m=spacing_m,
+            origin_m=(-extent_m / 2.0, -extent_m / 2.0),
+        )
+
+    @staticmethod
+    def planar(
+        grade_percent: float,
+        aspect_deg: float,
+        extent_m: float = _DEFAULT_EXTENT_M,
+        spacing_m: float = _DEFAULT_SPACING_M,
+    ) -> HeightField:
+        """Uniformly sloped plane.
+
+        Convention matches Tools ``swing_sim.putting.green`` (restated
+        with credit): ``aspect_deg`` is the compass direction the green
+        falls *toward*, CCW from +x (0 = downhill along +x).
+
+        Args:
+            grade_percent: Slope grade [%] in [0, 10].
+            aspect_deg: Downhill direction, CCW from +x [deg].
+            extent_m: Side length of the square grid [m].
+            spacing_m: Grid spacing [m].
+
+        Returns:
+            A planar :class:`HeightField` whose gradient magnitude is
+            ``grade_percent / 100`` everywhere.
+        """
+        require_finite(grade_percent, "grade_percent")
+        require(0.0 <= grade_percent <= 10.0, "grade in [0, 10] %", grade_percent)
+        require_finite(aspect_deg, "aspect_deg")
+        require(-360.0 <= aspect_deg <= 360.0, "aspect in [-360, 360]", aspect_deg)
+        n = _validate_factory_grid(extent_m, spacing_m)
+        aspect = math.radians(aspect_deg)
+        grade = grade_percent / 100.0
+        # Downhill toward `aspect` means height decreases along it.
+        xs = np.arange(n) * spacing_m - extent_m / 2.0
+        gx, gy = -grade * math.cos(aspect), -grade * math.sin(aspect)
+        heights = gy * xs[:, None] + gx * xs[None, :]
+        return HeightField(
+            heights_m=heights,
+            spacing_m=spacing_m,
+            origin_m=(-extent_m / 2.0, -extent_m / 2.0),
+        )
+
+    def elevation(self, x_m: float, y_m: float) -> float:
+        """Bilinear surface elevation at a point [m]."""
+        require_finite(x_m, "x_m")
+        require_finite(y_m, "y_m")
+        ix, iy, tx, ty = _bilinear_setup(
+            x_m, y_m, self.origin_m, self.spacing_m, self.heights_m.shape
+        )
+        h = self.heights_m
+        return float(
+            h[iy, ix] * (1 - tx) * (1 - ty)
+            + h[iy, ix + 1] * tx * (1 - ty)
+            + h[iy + 1, ix] * (1 - tx) * ty
+            + h[iy + 1, ix + 1] * tx * ty
+        )
+
+    def gradient(self, x_m: float, y_m: float) -> tuple[float, float]:
+        """Exact gradient of the bilinear patch, ``(dh/dx, dh/dy)``."""
+        require_finite(x_m, "x_m")
+        require_finite(y_m, "y_m")
+        ix, iy, tx, ty = _bilinear_setup(
+            x_m, y_m, self.origin_m, self.spacing_m, self.heights_m.shape
+        )
+        h = self.heights_m
+        dhdx = (
+            (h[iy, ix + 1] - h[iy, ix]) * (1 - ty)
+            + (h[iy + 1, ix + 1] - h[iy + 1, ix]) * ty
+        ) / self.spacing_m
+        dhdy = (
+            (h[iy + 1, ix] - h[iy, ix]) * (1 - tx)
+            + (h[iy + 1, ix + 1] - h[iy, ix + 1]) * tx
+        ) / self.spacing_m
+        return float(dhdx), float(dhdy)
+
+
+@dataclass(frozen=True)
+class FrictionField:
+    """Spatial friction multipliers on the same grid convention.
+
+    Multipliers scale the base :class:`~.friction.FrictionParams`
+    coefficients locally; 1.0 everywhere reproduces a uniform green.
+
+    Attributes:
+        roll_multiplier: Rolling-resistance multipliers, ``[iy, ix]``.
+        slide_multiplier: Sliding/static-friction multipliers.
+        spacing_m: Grid spacing [m].
+        origin_m: World coordinates of node ``[0, 0]`` (x, y) [m].
+    """
+
+    roll_multiplier: np.ndarray
+    slide_multiplier: np.ndarray
+    spacing_m: float = _DEFAULT_SPACING_M
+    origin_m: tuple[float, float] = (-_DEFAULT_EXTENT_M / 2.0, -_DEFAULT_EXTENT_M / 2.0)
+
+    def __post_init__(self) -> None:
+        _validate_grid(self.roll_multiplier, self.spacing_m, "roll_multiplier")
+        _validate_grid(self.slide_multiplier, self.spacing_m, "slide_multiplier")
+        _validate_origin(self.origin_m)
+        require(
+            self.roll_multiplier.shape == self.slide_multiplier.shape,
+            "multiplier grids must share a shape",
+            (self.roll_multiplier.shape, self.slide_multiplier.shape),
+        )
+        require(
+            bool(np.all(self.roll_multiplier > 0.0)),
+            "roll multipliers must be positive",
+        )
+        require(
+            bool(np.all(self.slide_multiplier > 0.0)),
+            "slide multipliers must be positive",
+        )
+        roll = np.array(self.roll_multiplier, dtype=float, copy=True)
+        slide = np.array(self.slide_multiplier, dtype=float, copy=True)
+        roll.setflags(write=False)
+        slide.setflags(write=False)
+        object.__setattr__(self, "roll_multiplier", roll)
+        object.__setattr__(self, "slide_multiplier", slide)
+
+    @staticmethod
+    def uniform(
+        extent_m: float = _DEFAULT_EXTENT_M,
+        spacing_m: float = _DEFAULT_SPACING_M,
+    ) -> FrictionField:
+        """Unit multipliers everywhere (homogeneous green)."""
+        n = _validate_factory_grid(extent_m, spacing_m)
+        ones = np.ones((n, n))
+        return FrictionField(
+            roll_multiplier=ones,
+            slide_multiplier=ones.copy(),
+            spacing_m=spacing_m,
+            origin_m=(-extent_m / 2.0, -extent_m / 2.0),
+        )
+
+    def multipliers(self, x_m: float, y_m: float) -> tuple[float, float]:
+        """Bilinear ``(roll, slide)`` multipliers at a point."""
+        require_finite(x_m, "x_m")
+        require_finite(y_m, "y_m")
+        ix, iy, tx, ty = _bilinear_setup(
+            x_m, y_m, self.origin_m, self.spacing_m, self.roll_multiplier.shape
+        )
+        out = []
+        for grid in (self.roll_multiplier, self.slide_multiplier):
+            out.append(
+                float(
+                    grid[iy, ix] * (1 - tx) * (1 - ty)
+                    + grid[iy, ix + 1] * tx * (1 - ty)
+                    + grid[iy + 1, ix] * (1 - tx) * ty
+                    + grid[iy + 1, ix + 1] * tx * ty
+                )
+            )
+        ensure(out[0] > 0.0 and out[1] > 0.0, "multipliers stay positive", out)
+        return out[0], out[1]
+
+
+def _keyed_rng(seed: int, field_key: str) -> np.random.Generator:
+    """Per-field generator keyed by ``[seed, crc32(field_key)]``.
+
+    Reuses the Tools variation-engine seeding discipline
+    (``swing_sim.variation.engine._stream_for``): independent streams
+    per field so one field's draws never shift another's.
+    """
+    require(seed >= 0, "seed must be >= 0", seed)
+    return np.random.default_rng([seed, zlib.crc32(field_key.encode())])
+
+
+def _smoothed_noise(
+    rng: np.random.Generator,
+    shape: tuple[int, int],
+    correlation_cells: float,
+) -> np.ndarray:
+    """Unit-variance smoothed white noise (box-blur Gaussian approx)."""
+    noise = rng.standard_normal(shape)
+    radius = max(int(round(correlation_cells / 2.0)), 0)
+    if radius == 0:
+        return noise
+    kernel = np.ones(2 * radius + 1) / (2 * radius + 1)
+    for _ in range(_BLUR_PASSES):
+        padded = np.pad(noise, radius, mode="reflect")
+        noise = np.apply_along_axis(
+            lambda row: np.convolve(row, kernel, mode="valid"), 1, padded
+        )[radius:-radius, :]
+        padded = np.pad(noise, radius, mode="reflect")
+        noise = np.apply_along_axis(
+            lambda col: np.convolve(col, kernel, mode="valid"), 0, padded
+        )[:, radius:-radius]
+    std = float(noise.std())
+    ensure(std > 0.0, "smoothed noise must retain variance", std)
+    return noise / std
+
+
+def bumpy_height_field(
+    seed: int,
+    amplitude_m: float,
+    correlation_length_m: float,
+    base: HeightField | None = None,
+) -> HeightField:
+    """Seeded stochastic height perturbation of a base field.
+
+    Deterministic: the same ``(seed, amplitude, correlation, base)``
+    always produces the identical field (test-pinned), and zero
+    amplitude returns the base heights exactly.
+
+    Args:
+        seed: Master seed (>= 0); the height stream is keyed
+            independently of the friction stream.
+        amplitude_m: Standard deviation of the height bumps [m];
+            realistic greens sit well under 0.02.
+        correlation_length_m: Bump correlation length [m].
+        base: Field to perturb; a default flat field when omitted.
+
+    Returns:
+        A new :class:`HeightField` with bumps added.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require(isinstance(seed, int) and not isinstance(seed, bool), "seed must be an int")
+    require(seed >= 0, "seed must be >= 0", seed)
+    require_finite(amplitude_m, "amplitude_m")
+    require(0.0 <= amplitude_m <= 0.05, "amplitude in [0, 0.05] m", amplitude_m)
+    require_finite(correlation_length_m, "correlation_length_m")
+    require(
+        0.0 < correlation_length_m <= 20.0,
+        "correlation length in (0, 20] m",
+        correlation_length_m,
+    )
+    field = base if base is not None else HeightField.flat()
+    if amplitude_m == 0.0:
+        return field
+    rng = _keyed_rng(seed, "putting_dynamics.height")
+    bumps = amplitude_m * _smoothed_noise(
+        rng, field.heights_m.shape, correlation_length_m / field.spacing_m
+    )
+    return HeightField(
+        heights_m=field.heights_m + bumps,
+        spacing_m=field.spacing_m,
+        origin_m=field.origin_m,
+    )
+
+
+def bumpy_friction_field(
+    seed: int,
+    amplitude: float,
+    correlation_length_m: float,
+    base: FrictionField | None = None,
+) -> FrictionField:
+    """Seeded fractional friction-multiplier perturbation.
+
+    Both multiplier grids get independent keyed streams (roll vs
+    slide), each ``base * (1 + amplitude * smoothed_noise)`` clipped
+    to stay positive.  Zero amplitude returns the base field exactly.
+
+    Args:
+        seed: Master seed (>= 0).
+        amplitude: Fractional deviation (std) in [0, 0.5].
+        correlation_length_m: Patch correlation length [m].
+        base: Field to perturb; a default uniform field when omitted.
+
+    Returns:
+        A new :class:`FrictionField`.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require(isinstance(seed, int) and not isinstance(seed, bool), "seed must be an int")
+    require(seed >= 0, "seed must be >= 0", seed)
+    require_finite(amplitude, "amplitude")
+    require(0.0 <= amplitude <= 0.5, "amplitude in [0, 0.5]", amplitude)
+    require_finite(correlation_length_m, "correlation_length_m")
+    require(
+        0.0 < correlation_length_m <= 20.0,
+        "correlation length in (0, 20] m",
+        correlation_length_m,
+    )
+    field = base if base is not None else FrictionField.uniform()
+    if amplitude == 0.0:
+        return field
+    cells = correlation_length_m / field.spacing_m
+    grids = []
+    for key, grid in (
+        ("putting_dynamics.friction.roll", field.roll_multiplier),
+        ("putting_dynamics.friction.slide", field.slide_multiplier),
+    ):
+        noise = _smoothed_noise(_keyed_rng(seed, key), grid.shape, cells)
+        grids.append(np.clip(grid * (1.0 + amplitude * noise), 0.05, None))
+    return FrictionField(
+        roll_multiplier=grids[0],
+        slide_multiplier=grids[1],
+        spacing_m=field.spacing_m,
+        origin_m=field.origin_m,
+    )
+
+
+@dataclass(frozen=True)
+class SurfaceSpec:
+    """Complete green description consumed by the solver.
+
+    Attributes:
+        height: Elevation field.
+        friction_field: Spatial friction multipliers.
+        friction: Base friction-law parameters.
+    """
+
+    height: HeightField
+    friction_field: FrictionField
+    friction: FrictionParams
+
+    @staticmethod
+    def flat_uniform(
+        stimp_ft: float = 10.0,
+        friction: FrictionParams | None = None,
+        extent_m: float = _DEFAULT_EXTENT_M,
+    ) -> SurfaceSpec:
+        """Flat, homogeneous green — the analytic-limit surface.
+
+        Args:
+            stimp_ft: Green speed used when ``friction`` is omitted.
+            friction: Full parameter override.
+            extent_m: Side length of the square grid [m].
+
+        Returns:
+            A :class:`SurfaceSpec` on which the solver must reproduce
+            the Tools closed-form skid/roll results (test-enforced).
+        """
+        from .friction import stimp_to_rolling_mu
+
+        params = friction or FrictionParams(mu_roll0=stimp_to_rolling_mu(stimp_ft))
+        return SurfaceSpec(
+            height=HeightField.flat(extent_m=extent_m),
+            friction_field=FrictionField.uniform(extent_m=extent_m),
+            friction=params,
+        )

--- a/src/shared/python/putting_dynamics/types.py
+++ b/src/shared/python/putting_dynamics/types.py
@@ -1,0 +1,277 @@
+"""Core dataclasses for the putting-dynamics package (#8345, P2+P3).
+
+Reused shared infrastructure (AGENTS.md section A discovery):
+
+* DbC helpers from ``src.shared.python.contracts``.
+* Golf-ball constants from ``src.shared.python.core.physics_constants``
+  (USGA Rule 5 values; single source, not re-declared here).
+* Layout mirrors ``src.shared.python.physics.impact_model``
+  (types / solver / utils split with a curated façade).
+
+All quantities are SI internally; display conversions (yards default
+per fleet direction) live in :mod:`.utils` and are applied only at the
+edges.
+
+Frame convention: ``x`` along the initial putt line, ``y`` to the
+left, ``z`` up.  ``spin_rad_s`` is about the transverse (left) axis
+with topspin positive, matching Tools ``swing_sim.putting`` (restated
+convention; a freshly struck putt has backspin, negative).
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+from dataclasses import dataclass
+
+from src.shared.python.contracts import require, require_finite
+
+__all__ = [
+    "BallState",
+    "CollisionReport",
+    "Mode",
+    "PuttResult",
+    "PutterState",
+    "TrajectorySample",
+]
+
+
+class Mode(enum.Enum):
+    """Ball motion mode used by the solver's mode machine."""
+
+    AIRBORNE = "airborne"
+    SLIDE = "slide"
+    ROLL = "roll"
+    REST = "rest"
+
+
+@dataclass(frozen=True)
+class BallState:
+    """Instantaneous ball state.
+
+    Attributes:
+        x_m: Position along the putt line [m].
+        y_m: Lateral position, left positive [m].
+        height_m: Height above the local surface [m]; 0 on-surface.
+        vx_mps: Velocity along x [m/s].
+        vy_mps: Velocity along y [m/s].
+        vz_mps: Vertical velocity [m/s]; nonzero only while airborne.
+        spin_rad_s: Spin about the transverse axis [rad/s], topspin
+            positive.
+    """
+
+    x_m: float
+    y_m: float
+    height_m: float = 0.0
+    vx_mps: float = 0.0
+    vy_mps: float = 0.0
+    vz_mps: float = 0.0
+    spin_rad_s: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("x_m", "y_m", "height_m", "vx_mps", "vy_mps", "vz_mps"):
+            require_finite(getattr(self, name), name)
+        require_finite(self.spin_rad_s, "spin_rad_s")
+        require(self.height_m >= 0.0, "height must be >= 0", self.height_m)
+        require(
+            abs(self.x_m) <= 200.0 and abs(self.y_m) <= 200.0,
+            "position must be within +/- 200 m",
+            (self.x_m, self.y_m),
+        )
+        require(
+            math.hypot(self.vx_mps, self.vy_mps) <= 20.0,
+            "putt speeds must be <= 20 m/s",
+            (self.vx_mps, self.vy_mps),
+        )
+
+    @property
+    def speed_mps(self) -> float:
+        """Horizontal speed magnitude [m/s]."""
+        return math.hypot(self.vx_mps, self.vy_mps)
+
+
+@dataclass(frozen=True)
+class PutterState:
+    """Putter head at impact.
+
+    The shaft attachment (hosel) is freely positionable on the head's
+    top surface relative to the head CG: ``hosel_toe_m`` (heel
+    negative, toe positive) and ``hosel_forward_m`` (toward the target
+    positive).  An impact impulse that is not collinear with the
+    attachment/CG line produces a twisting moment about the shaft axis
+    — the face-balanced vs toe-hang spectrum; see
+    :func:`~.collision.strike`.
+
+    Attributes:
+        head_mass_kg: Head mass [kg]; putters span ~0.30-0.40.
+        moi_kg_m2: Scalar head moment of inertia about the vertical
+            (shaft-parallel) axis through the CG [kg m^2]; typical
+            putters are ~3e-4 to 6e-4 (0.3-0.6 g m^2 in catalogue
+            units). Used for the off-center effective mass; the
+            shaft-axis twist proxy applies the parallel-axis theorem
+            using the hosel offsets.
+        loft_deg: Dynamic loft presented at impact [deg]; the sweep
+            helper spans -4 to +8.
+        speed_mps: Head speed at impact along the putt line [m/s].
+        cor: Face coefficient of restitution at putt speeds.
+        hosel_toe_m: Shaft-attachment offset toward the toe [m]
+            (negative = heel-side, anser-style).
+        hosel_forward_m: Shaft-attachment offset toward the target [m]
+            (negative = behind the CG).
+    """
+
+    head_mass_kg: float
+    moi_kg_m2: float
+    loft_deg: float
+    speed_mps: float
+    cor: float = 0.78
+    hosel_toe_m: float = 0.0
+    hosel_forward_m: float = 0.0
+
+    def __post_init__(self) -> None:
+        require_finite(self.head_mass_kg, "head_mass_kg")
+        require(
+            0.1 <= self.head_mass_kg <= 1.0,
+            "head mass must be plausible [kg]",
+            self.head_mass_kg,
+        )
+        require_finite(self.moi_kg_m2, "moi_kg_m2")
+        require(
+            1e-5 <= self.moi_kg_m2 <= 1e-2,
+            "head MOI must be plausible [kg m^2]",
+            self.moi_kg_m2,
+        )
+        require_finite(self.loft_deg, "loft_deg")
+        require(
+            -6.0 <= self.loft_deg <= 10.0,
+            "dynamic loft must be in [-6, 10] deg",
+            self.loft_deg,
+        )
+        require_finite(self.speed_mps, "speed_mps")
+        require(
+            0.0 < self.speed_mps <= 10.0,
+            "head speed must be in (0, 10] m/s",
+            self.speed_mps,
+        )
+        require_finite(self.cor, "cor")
+        require(0.0 < self.cor < 1.0, "COR must be in (0, 1)", self.cor)
+        require_finite(self.hosel_toe_m, "hosel_toe_m")
+        require(
+            abs(self.hosel_toe_m) <= 0.08,
+            "hosel toe offset within +/- 0.08 m",
+            self.hosel_toe_m,
+        )
+        require_finite(self.hosel_forward_m, "hosel_forward_m")
+        require(
+            abs(self.hosel_forward_m) <= 0.05,
+            "hosel forward offset within +/- 0.05 m",
+            self.hosel_forward_m,
+        )
+
+
+@dataclass(frozen=True)
+class CollisionReport:
+    """Everything the P1 visualization needs from one impact.
+
+    The attachment-point *impulse wrench* (force impulse + moment
+    impulse, both at the shaft attachment) is the documented seam for
+    the upcoming finite-interval twist-dynamics epic: a richer model
+    can consume the same wrench without changing this report's shape.
+
+    Attributes:
+        ball_speed_mps: Ball launch speed magnitude [m/s].
+        launch_angle_deg: Launch angle above horizontal [deg].
+        horizontal_speed_mps: Ground-plane launch speed [m/s].
+        vertical_speed_mps: Upward launch speed [m/s].
+        spin_rad_s: Launch spin, topspin positive [rad/s].
+        effective_loft_deg: Dynamic loft presented at impact [deg].
+        putter_dv_mps: Putter-head slowdown along its travel [m/s].
+        impulse_n_s: Normal contact impulse magnitude [N s].
+        contact_time_proxy_s: Contact-duration proxy [s] (fixed
+            sub-millisecond scale for visualization pacing).
+        kinetic_energy_loss_j: Impact energy dissipated [J].
+        face_twist_rad_s: Pinned-shaft face-twist velocity proxy
+            [rad/s], computed from the moment impulse and the
+            parallel-axis MOI about the shaft; positive rotates the
+            toe backward (face opening for a strike toe-side of the
+            attachment). The finite-interval model will replace this
+            proxy with its boundary-condition-specific trajectory.
+        twist_moment_n_m_s: Moment impulse about the shaft axis
+            [N m s].
+        attachment_impulse_n_s: Impulse wrench force part at the
+            attachment, ``(x, y, z)`` [N s] (reaction on the putter).
+        attachment_moment_n_m_s: Impulse wrench moment part at the
+            attachment, ``(x, y, z)`` [N m s].
+    """
+
+    ball_speed_mps: float
+    launch_angle_deg: float
+    horizontal_speed_mps: float
+    vertical_speed_mps: float
+    spin_rad_s: float
+    effective_loft_deg: float
+    putter_dv_mps: float
+    impulse_n_s: float
+    contact_time_proxy_s: float
+    kinetic_energy_loss_j: float
+    face_twist_rad_s: float
+    twist_moment_n_m_s: float
+    attachment_impulse_n_s: tuple[float, float, float]
+    attachment_moment_n_m_s: tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class TrajectorySample:
+    """One solver output sample.
+
+    Attributes:
+        t_s: Sample time [s].
+        x_m: Position along the putt line [m].
+        y_m: Lateral position, left positive [m].
+        height_m: Height above the local surface [m].
+        speed_mps: Horizontal speed [m/s].
+        spin_rad_s: Spin, topspin positive [rad/s].
+        mode: Motion mode at the sample.
+    """
+
+    t_s: float
+    x_m: float
+    y_m: float
+    height_m: float
+    speed_mps: float
+    spin_rad_s: float
+    mode: Mode
+
+
+@dataclass(frozen=True)
+class PuttResult:
+    """One integrated putt.
+
+    Attributes:
+        samples: Time-ordered trajectory samples.
+        collision: Impact report when the putt started from a strike;
+            None when integrated from a given ball state.
+        holed: Whether the ball was captured.
+        rest_x_m: Final x position [m].
+        rest_y_m: Final y position [m].
+        total_distance_m: Ground-path length [m].
+        time_s: Time to rest or capture [s].
+        skid_distance_m: Ground covered before pure roll [m].
+        speed_at_hole_mps: Speed when first over the hole mouth [m/s];
+            None when the ball never crossed it.
+    """
+
+    samples: tuple[TrajectorySample, ...]
+    collision: CollisionReport | None
+    holed: bool
+    rest_x_m: float
+    rest_y_m: float
+    total_distance_m: float
+    time_s: float
+    skid_distance_m: float
+    speed_at_hole_mps: float | None
+
+    @property
+    def final_mode(self) -> Mode:
+        """Mode of the last sample (REST when the ball stopped)."""
+        return self.samples[-1].mode

--- a/src/shared/python/putting_dynamics/utils.py
+++ b/src/shared/python/putting_dynamics/utils.py
@@ -1,0 +1,102 @@
+"""Display-edge conversions and energy audit helpers (#8345).
+
+Reused shared infrastructure (AGENTS.md section A discovery): ball
+constants from ``src.shared.python.core.physics_constants``; DbC
+helpers from ``src.shared.python.contracts``.
+
+The package is SI-only internally; these converters exist so UI code
+converts *at the display edge* (yards default for distances per fleet
+direction), never inside the models.
+"""
+
+from __future__ import annotations
+
+import math
+
+from src.shared.python.contracts import ensure, require, require_finite
+from src.shared.python.core.physics_constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+
+from .types import CollisionReport, PutterState
+
+__all__ = [
+    "ball_kinetic_energy_j",
+    "energy_balance_error_j",
+    "m_to_feet",
+    "m_to_yards",
+    "mps_to_mph",
+]
+
+_FOOT_M = 0.3048
+_YARD_M = 0.9144
+_MPH_PER_MPS = 2.2369362920516
+
+
+def m_to_yards(distance_m: float) -> float:
+    """Meters to yards (fleet display default for distances)."""
+    require_finite(distance_m, "distance_m")
+    return distance_m / _YARD_M
+
+
+def m_to_feet(distance_m: float) -> float:
+    """Meters to feet (stimp/green-reading displays)."""
+    require_finite(distance_m, "distance_m")
+    return distance_m / _FOOT_M
+
+
+def mps_to_mph(speed_mps: float) -> float:
+    """Meters per second to miles per hour."""
+    require_finite(speed_mps, "speed_mps")
+    return speed_mps * _MPH_PER_MPS
+
+
+def ball_kinetic_energy_j(speed_mps: float, spin_rad_s: float = 0.0) -> float:
+    """Ball translational + rotational kinetic energy [J].
+
+    Uses the USGA ball mass and the solid-sphere inertia
+    ``(2/5) m r^2`` (matching
+    ``GOLF_BALL_MOMENT_OF_INERTIA_KG_M2``).
+
+    Args:
+        speed_mps: Ball speed magnitude [m/s], >= 0.
+        spin_rad_s: Spin magnitude [rad/s].
+
+    Returns:
+        Kinetic energy [J], >= 0.
+    """
+    require_finite(speed_mps, "speed_mps")
+    require(speed_mps >= 0.0, "speed must be >= 0", speed_mps)
+    require_finite(spin_rad_s, "spin_rad_s")
+    inertia = 0.4 * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M**2
+    energy = 0.5 * GOLF_BALL_MASS_KG * speed_mps**2 + 0.5 * inertia * spin_rad_s**2
+    ensure(energy >= 0.0, "energy must be >= 0", energy)
+    return energy
+
+
+def energy_balance_error_j(report: CollisionReport, putter: PutterState) -> float:
+    """Residual of the impact energy audit [J].
+
+    Books the head's translational KE change (CG slowdown), the ball's
+    launch KE (translation + spin), and the reported dissipation
+    against the pre-impact head KE.  The residual is the energy parked
+    in head rotation by off-center strikes plus the sub-percent
+    cross-coupling of the split normal/tangential treatment; the
+    contract test pins it to a small fraction of the incoming KE for
+    centered strikes.
+
+    Args:
+        report: Impact report from :func:`~.collision.strike`.
+        putter: The putter state that produced the report.
+
+    Returns:
+        Absolute energy residual [J].
+    """
+    ke_head_before = 0.5 * putter.head_mass_kg * putter.speed_mps**2
+    ke_head_after = (
+        0.5 * putter.head_mass_kg * ((putter.speed_mps - report.putter_dv_mps) ** 2)
+    )
+    ke_ball = ball_kinetic_energy_j(report.ball_speed_mps, report.spin_rad_s)
+    residual = ke_head_before - (ke_head_after + ke_ball + report.kinetic_energy_loss_j)
+    return math.fabs(residual)

--- a/tests/unit/putting_dynamics/test_collision.py
+++ b/tests/unit/putting_dynamics/test_collision.py
@@ -1,0 +1,182 @@
+"""Collision-model tests for putting_dynamics (#8345 P3).
+
+Momentum and COR energy pins, putter-slowdown band, dynamic-loft
+sweep monotonicity, and the hosel-position face-twist model.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import pytest
+
+from src.shared.python.core.physics_constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+from src.shared.python.putting_dynamics import (
+    PutterState,
+    effective_head_mass,
+    energy_balance_error_j,
+    strike,
+    sweep_dynamic_loft,
+)
+
+pytestmark = pytest.mark.unit
+
+_M_BALL = float(GOLF_BALL_MASS_KG)
+
+
+def _putter(**overrides: float) -> PutterState:
+    defaults: dict[str, float] = {
+        "head_mass_kg": 0.35,
+        "moi_kg_m2": 4.5e-4,
+        "loft_deg": 3.0,
+        "speed_mps": 2.0,
+    }
+    defaults.update(overrides)
+    return PutterState(**defaults)
+
+
+class TestTwoBodyImpulse:
+    def test_momentum_conservation_along_the_putt_line(self) -> None:
+        putter = _putter()
+        report = strike(putter)
+        delta = math.radians(putter.loft_deg)
+        ball_px = _M_BALL * report.horizontal_speed_mps
+        # Tangential impulse also carries x-momentum; reconstruct the
+        # full x impulse from the report and pin head slowdown to it.
+        impulse_t = (2.0 / 7.0) * _M_BALL * putter.speed_mps * math.sin(delta)
+        impulse_x = report.impulse_n_s * math.cos(delta) + impulse_t * math.sin(delta)
+        assert ball_px == pytest.approx(impulse_x, rel=1e-12)
+        assert putter.head_mass_kg * report.putter_dv_mps == pytest.approx(
+            impulse_x, rel=1e-12
+        )
+
+    def test_energy_loss_is_pinned_to_the_cor_formula(self) -> None:
+        putter = _putter()
+        report = strike(putter)
+        delta = math.radians(putter.loft_deg)
+        m_eff = effective_head_mass(putter, 0.0)
+        m_red = m_eff * _M_BALL / (m_eff + _M_BALL)
+        v_n = putter.speed_mps * math.cos(delta)
+        u = putter.speed_mps * math.sin(delta)
+        expected = 0.5 * m_red * v_n**2 * (1.0 - putter.cor**2) + _M_BALL * u**2 / 7.0
+        assert report.kinetic_energy_loss_j == pytest.approx(expected, rel=1e-12)
+
+    def test_energy_audit_closes_for_a_centered_strike(self) -> None:
+        putter = _putter()
+        report = strike(putter)
+        ke_in = 0.5 * putter.head_mass_kg * putter.speed_mps**2
+        assert energy_balance_error_j(report, putter) < 0.01 * ke_in
+
+    def test_putter_slowdown_band_for_light_effective_head(self) -> None:
+        # ~2 m/s putter, 0.15 kg effective mass vs the 45.93 g ball:
+        # dv = J/M with J = (1 + e) m_red v -> ~0.83 m/s.
+        report = strike(_putter(head_mass_kg=0.15))
+        assert 0.6 <= report.putter_dv_mps <= 1.0
+
+    def test_centered_effective_mass_equals_head_mass(self) -> None:
+        putter = _putter()
+        assert effective_head_mass(putter, 0.0) == pytest.approx(
+            putter.head_mass_kg, rel=1e-12
+        )
+
+    def test_offset_strike_softens_the_blow(self) -> None:
+        putter = _putter()
+        assert effective_head_mass(putter, 0.03) < putter.head_mass_kg
+        centered = strike(putter)
+        toe = strike(putter, impact_toe_m=0.03)
+        assert toe.ball_speed_mps < centered.ball_speed_mps
+
+    def test_backspin_at_positive_loft(self) -> None:
+        report = strike(_putter())
+        assert report.spin_rad_s < 0.0
+        u = 2.0 * math.sin(math.radians(3.0))
+        expected = -(5.0 / 7.0) * u / float(GOLF_BALL_RADIUS_M)
+        assert report.spin_rad_s == pytest.approx(expected, rel=1e-12)
+
+    def test_tangential_impulse_is_consistent_with_backspin(self) -> None:
+        """The face drags the rear contact point down and forward."""
+        putter = _putter()
+        report = strike(putter)
+        delta = math.radians(putter.loft_deg)
+        u = putter.speed_mps * math.sin(delta)
+        normal_speed = report.impulse_n_s / _M_BALL
+        tangential_speed = (2.0 / 7.0) * u
+        assert report.horizontal_speed_mps == pytest.approx(
+            normal_speed * math.cos(delta) + tangential_speed * math.sin(delta),
+            rel=1e-12,
+        )
+        assert report.vertical_speed_mps == pytest.approx(
+            normal_speed * math.sin(delta) - tangential_speed * math.cos(delta),
+            rel=1e-12,
+        )
+        assert report.launch_angle_deg < putter.loft_deg
+
+
+class TestLoftSweep:
+    def test_sweep_covers_minus4_to_plus8(self) -> None:
+        reports = sweep_dynamic_loft(_putter())
+        assert reports[0].effective_loft_deg == pytest.approx(-4.0)
+        assert reports[-1].effective_loft_deg == pytest.approx(8.0)
+
+    def test_more_loft_launches_higher(self) -> None:
+        reports = sweep_dynamic_loft(_putter())
+        angles = [r.launch_angle_deg for r in reports]
+        assert all(a < b for a, b in zip(angles, angles[1:], strict=False))
+
+    def test_more_loft_means_more_initial_slide(self) -> None:
+        reports = sweep_dynamic_loft(_putter())
+        r = float(GOLF_BALL_RADIUS_M)
+        slip = [x.horizontal_speed_mps - x.spin_rad_s * r for x in reports]
+        assert all(a < b for a, b in zip(slip, slip[1:], strict=False))
+
+    def test_negative_loft_drives_the_ball_downward(self) -> None:
+        report = strike(_putter(loft_deg=-4.0))
+        assert report.vertical_speed_mps < 0.0
+        assert report.spin_rad_s > 0.0  # topspin off a delofted face
+
+
+class TestHoselTwist:
+    def test_centered_attachment_centered_strike_no_twist(self) -> None:
+        report = strike(_putter())
+        assert report.face_twist_rad_s == 0.0
+        assert report.twist_moment_n_m_s == 0.0
+
+    def test_heel_attachment_center_strike_twists_positively(self) -> None:
+        # Anser-style heel hosel: a center strike lies toe-side of the
+        # shaft axis, so the toe swings backward (positive twist).
+        report = strike(_putter(hosel_toe_m=-0.05))
+        assert report.face_twist_rad_s > 0.0
+
+    def test_twist_is_antisymmetric_under_toe_mirror(self) -> None:
+        putter = _putter(hosel_toe_m=0.03)
+        mirrored = replace(putter, hosel_toe_m=-0.03)
+        plus = strike(putter, impact_toe_m=0.01)
+        minus = strike(mirrored, impact_toe_m=-0.01)
+        assert plus.face_twist_rad_s == pytest.approx(
+            -minus.face_twist_rad_s, rel=1e-12
+        )
+
+    def test_strike_through_the_shaft_axis_has_no_twist(self) -> None:
+        report = strike(_putter(hosel_toe_m=0.02), impact_toe_m=0.02)
+        assert report.face_twist_rad_s == pytest.approx(0.0, abs=1e-15)
+
+    def test_wrench_moment_z_matches_twist_moment(self) -> None:
+        report = strike(_putter(hosel_toe_m=-0.04), impact_toe_m=0.01)
+        assert report.attachment_moment_n_m_s[2] == pytest.approx(
+            report.twist_moment_n_m_s, rel=1e-12
+        )
+
+    def test_forward_hosel_offset_alone_adds_no_twist(self) -> None:
+        report = strike(_putter(hosel_forward_m=0.02))
+        assert report.face_twist_rad_s == 0.0
+        # ... but it does appear in the wrench moment (pitch axis).
+        assert report.attachment_moment_n_m_s[1] != 0.0
+
+    def test_forward_hosel_offset_increases_shaft_axis_inertia(self) -> None:
+        near = strike(_putter(hosel_toe_m=-0.04, hosel_forward_m=0.0))
+        far = strike(_putter(hosel_toe_m=-0.04, hosel_forward_m=0.04))
+        assert abs(far.face_twist_rad_s) < abs(near.face_twist_rad_s)

--- a/tests/unit/putting_dynamics/test_contract_api.py
+++ b/tests/unit/putting_dynamics/test_contract_api.py
@@ -1,0 +1,92 @@
+"""Public-facade contract test for putting_dynamics (#8345).
+
+Pins the package's importable surface: downstream consumers (the P1
+R3F visualization API and any future Tools promotion via the vendor
+pattern) rely on these names resolving from the package root.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import src.shared.python.putting_dynamics as pd
+
+pytestmark = pytest.mark.unit
+
+_EXPECTED_EXPORTS = {
+    # constants
+    "DEFAULT_SLIDING_MU",
+    "DEFAULT_STATIC_MU",
+    "DT_S",
+    "GROUND_RESTITUTION",
+    "HOLE_RADIUS_M",
+    "LOFT_SWEEP_MAX_DEG",
+    "LOFT_SWEEP_MIN_DEG",
+    "STIMP_RELEASE_SPEED_MPS",
+    # types
+    "BallState",
+    "CollisionReport",
+    "FrictionField",
+    "FrictionParams",
+    "HeightField",
+    "Mode",
+    "PuttResult",
+    "PutterState",
+    "SurfaceSpec",
+    "TrajectorySample",
+    # functions
+    "ball_kinetic_energy_j",
+    "bumpy_friction_field",
+    "bumpy_height_field",
+    "capture_speed_mps",
+    "effective_head_mass",
+    "energy_balance_error_j",
+    "grain_factor",
+    "is_static_hold",
+    "m_to_feet",
+    "m_to_yards",
+    "mps_to_mph",
+    "rolling_mu",
+    "rolling_mu_to_stimp",
+    "simulate_ball",
+    "simulate_strike",
+    "sliding_mu",
+    "stimp_to_rolling_mu",
+    "strike",
+    "sweep_dynamic_loft",
+}
+
+
+def test_facade_exports_are_pinned() -> None:
+    assert set(pd.__all__) == _EXPECTED_EXPORTS
+
+
+def test_every_export_resolves() -> None:
+    for name in pd.__all__:
+        assert getattr(pd, name) is not None
+
+
+def test_collision_report_fields_needed_by_p1_visualization() -> None:
+    # The P1 scene consumes these exact fields (epic #8345 P1/P3).
+    fields = {
+        "ball_speed_mps",
+        "launch_angle_deg",
+        "horizontal_speed_mps",
+        "vertical_speed_mps",
+        "spin_rad_s",
+        "effective_loft_deg",
+        "putter_dv_mps",
+        "impulse_n_s",
+        "contact_time_proxy_s",
+        "kinetic_energy_loss_j",
+        "face_twist_rad_s",
+        "twist_moment_n_m_s",
+        "attachment_impulse_n_s",
+        "attachment_moment_n_m_s",
+    }
+    assert fields <= set(pd.CollisionReport.__dataclass_fields__)
+
+
+def test_ground_restitution_matches_contact_rs_default() -> None:
+    # rust_core/upstream-physics/src/contact.rs: cor = 0.78.
+    assert pd.GROUND_RESTITUTION == 0.78

--- a/tests/unit/putting_dynamics/test_friction.py
+++ b/tests/unit/putting_dynamics/test_friction.py
@@ -1,0 +1,99 @@
+"""Friction-law tests for putting_dynamics (#8345 P2)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.shared.python.putting_dynamics import (
+    FrictionParams,
+    grain_factor,
+    is_static_hold,
+    rolling_mu,
+    rolling_mu_to_stimp,
+    sliding_mu,
+    stimp_to_rolling_mu,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _params(**overrides: float) -> FrictionParams:
+    defaults: dict[str, float] = {"mu_roll0": stimp_to_rolling_mu(10.0)}
+    defaults.update(overrides)
+    return FrictionParams(**defaults)
+
+
+class TestStimpConversion:
+    def test_stimp_10_is_in_published_band(self) -> None:
+        # 0.05-0.07 for tournament greens (Tools swing_sim.putting.roll
+        # derivation, restated).
+        assert 0.05 <= stimp_to_rolling_mu(10.0) <= 0.07
+
+    def test_round_trip_is_exact(self) -> None:
+        for stimp in (4.0, 8.0, 10.0, 13.0):
+            assert rolling_mu_to_stimp(stimp_to_rolling_mu(stimp)) == pytest.approx(
+                stimp, rel=1e-12
+            )
+
+    def test_faster_green_has_lower_mu(self) -> None:
+        assert stimp_to_rolling_mu(13.0) < stimp_to_rolling_mu(8.0)
+
+    def test_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="stimp"):
+            stimp_to_rolling_mu(2.0)
+
+
+class TestVelocityDependentRolling:
+    def test_k_v_zero_recovers_constant_law(self) -> None:
+        params = _params()
+        assert rolling_mu(params, 3.0) == pytest.approx(params.mu_roll0, rel=1e-12)
+
+    def test_linear_velocity_scaling(self) -> None:
+        params = _params(k_v_per_mps=0.1)
+        assert rolling_mu(params, 2.0) == pytest.approx(
+            params.mu_roll0 * 1.2, rel=1e-12
+        )
+
+    def test_spatial_multiplier_scales(self) -> None:
+        params = _params()
+        assert rolling_mu(params, 1.0, spatial_multiplier=1.5) == pytest.approx(
+            params.mu_roll0 * 1.5, rel=1e-12
+        )
+
+
+class TestGrainAnisotropy:
+    def test_disabled_grain_is_unity(self) -> None:
+        assert grain_factor(_params(), 1.234) == 1.0
+
+    def test_extremes_at_with_and_against_grain(self) -> None:
+        params = _params(grain_strength=0.2, grain_direction_rad=0.5)
+        assert grain_factor(params, 0.5) == pytest.approx(0.8, rel=1e-12)
+        assert grain_factor(params, 0.5 + math.pi) == pytest.approx(1.2, rel=1e-12)
+
+    def test_sliding_mu_sees_grain(self) -> None:
+        params = _params(grain_strength=0.2, grain_direction_rad=0.0)
+        assert sliding_mu(params, 1.0, 0.0) == pytest.approx(
+            params.mu_slide * 0.8, rel=1e-12
+        )
+
+
+class TestStaticHold:
+    def test_shallow_slope_holds(self) -> None:
+        params = _params()
+        assert is_static_hold(params, 0.02)
+
+    def test_steep_slope_releases(self) -> None:
+        params = _params()
+        assert not is_static_hold(params, params.mu_static + 0.01)
+
+    def test_multiplier_shifts_the_bound(self) -> None:
+        params = _params()
+        slope = params.mu_static * 1.1
+        assert not is_static_hold(params, slope)
+        assert is_static_hold(params, slope, spatial_multiplier=1.5)
+
+    def test_mu_static_must_cover_rolling(self) -> None:
+        with pytest.raises(ValueError, match="mu_static"):
+            FrictionParams(mu_roll0=0.06, mu_static=0.05)

--- a/tests/unit/putting_dynamics/test_solver.py
+++ b/tests/unit/putting_dynamics/test_solver.py
@@ -1,0 +1,245 @@
+"""Solver analytic-limit and mode-machine tests (#8345 P2+P3).
+
+The flat uniform surface with the basic laws must reproduce the
+closed-form skid/roll results restated from Tools
+``swing_sim.putting.roll`` (5/7 transition, stimp deceleration)
+within RK4 tolerance.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.shared.python.core.physics_constants import (
+    GOLF_BALL_RADIUS_M,
+    GRAVITY_M_S2,
+)
+from src.shared.python.putting_dynamics import (
+    BallState,
+    FrictionField,
+    FrictionParams,
+    HeightField,
+    Mode,
+    PutterState,
+    SurfaceSpec,
+    bumpy_friction_field,
+    bumpy_height_field,
+    capture_speed_mps,
+    simulate_ball,
+    simulate_strike,
+    stimp_to_rolling_mu,
+)
+
+pytestmark = pytest.mark.unit
+
+_G = float(GRAVITY_M_S2)
+_R = float(GOLF_BALL_RADIUS_M)
+
+
+def _sloped_surface(grade: float, aspect: float, stimp: float = 10.0) -> SurfaceSpec:
+    return SurfaceSpec(
+        height=HeightField.planar(grade, aspect, extent_m=30.0),
+        friction_field=FrictionField.uniform(extent_m=30.0),
+        friction=FrictionParams(mu_roll0=stimp_to_rolling_mu(stimp)),
+    )
+
+
+class TestFlatUniformAnalyticLimits:
+    def test_skid_roll_matches_closed_form(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        v0 = 2.0
+        result = simulate_ball(BallState(x_m=0.0, y_m=0.0, vx_mps=v0), surface)
+        mu_k = surface.friction.mu_slide
+        mu_r = surface.friction.mu_roll0
+        # Closed forms restated from Tools swing_sim.putting.roll.
+        t_skid = v0 / (3.5 * mu_k * _G)
+        skid_dist = v0 * t_skid - 0.5 * mu_k * _G * t_skid**2
+        v_roll = 5.0 * v0 / 7.0
+        roll_out = v_roll**2 / (2.0 * mu_r * _G)
+        assert result.skid_distance_m == pytest.approx(skid_dist, rel=0.02)
+        assert result.total_distance_m == pytest.approx(skid_dist + roll_out, rel=0.01)
+        assert not result.holed
+        assert result.final_mode is Mode.REST
+
+    def test_five_sevenths_transition_speed(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        v0 = 2.0
+        result = simulate_ball(BallState(x_m=0.0, y_m=0.0, vx_mps=v0), surface)
+        first_roll = next(s for s in result.samples if s.mode is Mode.ROLL)
+        assert first_roll.speed_mps == pytest.approx(5.0 * v0 / 7.0, rel=0.01)
+
+    def test_pure_roll_start_skips_the_skid_phase(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        v0 = 1.5
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        result = simulate_ball(ball, surface)
+        assert result.skid_distance_m == 0.0
+        mu_r = surface.friction.mu_roll0
+        assert result.total_distance_m == pytest.approx(
+            v0**2 / (2.0 * mu_r * _G), rel=0.01
+        )
+
+    def test_overspin_settles_to_the_general_rolling_limit(self) -> None:
+        """Stimpmeter-style overspin must not be clamped away at t=0."""
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        v0 = 1.5
+        surface_speed0 = 1.8
+        ball = BallState(
+            x_m=0.0,
+            y_m=0.0,
+            vx_mps=v0,
+            spin_rad_s=surface_speed0 / _R,
+        )
+        result = simulate_ball(ball, surface)
+        first_roll = next(s for s in result.samples[1:] if s.mode is Mode.ROLL)
+        expected = (5.0 * v0 + 2.0 * surface_speed0) / 7.0
+        assert result.samples[0].mode is Mode.SLIDE
+        assert first_roll.speed_mps == pytest.approx(expected, rel=0.01)
+
+    def test_velocity_dependent_rolling_shortens_the_putt(self) -> None:
+        base = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        fast_decel = SurfaceSpec.flat_uniform(
+            friction=FrictionParams(mu_roll0=base.friction.mu_roll0, k_v_per_mps=0.5)
+        )
+        v0 = 1.5
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        assert (
+            simulate_ball(ball, fast_decel).total_distance_m
+            < simulate_ball(ball, base).total_distance_m
+        )
+
+
+class TestSlopesAndSymmetry:
+    def test_cross_slope_break_is_mirror_symmetric(self) -> None:
+        v0 = 1.5
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        left = simulate_ball(ball, _sloped_surface(2.0, 90.0))
+        right = simulate_ball(ball, _sloped_surface(2.0, -90.0))
+        assert left.rest_y_m > 0.01  # breaks toward the downhill side
+        assert left.rest_y_m == pytest.approx(-right.rest_y_m, rel=1e-9)
+        assert left.rest_x_m == pytest.approx(right.rest_x_m, rel=1e-9)
+
+    def test_downhill_putts_run_farther_than_uphill(self) -> None:
+        v0 = 1.5
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        down = simulate_ball(ball, _sloped_surface(2.0, 0.0))
+        up = simulate_ball(ball, _sloped_surface(2.0, 180.0))
+        assert down.total_distance_m > up.total_distance_m
+
+    def test_static_hold_on_a_shallow_slope(self) -> None:
+        result = simulate_ball(BallState(x_m=0.0, y_m=0.0), _sloped_surface(2.0, 0.0))
+        assert result.final_mode is Mode.REST
+        assert math.hypot(result.rest_x_m, result.rest_y_m) < 1e-9
+
+    def test_static_restart_on_a_steep_slope(self) -> None:
+        # 10 % grade exceeds the 0.08 static rolling hold: the resting
+        # ball must re-start rolling downhill (+x is downhill here).
+        result = simulate_ball(BallState(x_m=0.0, y_m=0.0), _sloped_surface(10.0, 0.0))
+        assert result.rest_x_m > 0.5
+        assert any(s.mode is Mode.ROLL for s in result.samples)
+
+
+class TestBumpySurfaces:
+    def test_zero_amplitude_bumpy_equals_flat_trajectory(self) -> None:
+        flat = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        bumpy = SurfaceSpec(
+            height=bumpy_height_field(7, 0.0, 1.0, flat.height),
+            friction_field=bumpy_friction_field(7, 0.0, 1.0, flat.friction_field),
+            friction=flat.friction,
+        )
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=1.5)
+        a = simulate_ball(ball, flat)
+        b = simulate_ball(ball, bumpy)
+        assert a.rest_x_m == b.rest_x_m
+        assert a.rest_y_m == b.rest_y_m
+        assert a.time_s == b.time_s
+
+    def test_seeded_bumpy_trajectory_is_reproducible(self) -> None:
+        def build() -> SurfaceSpec:
+            flat = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+            return SurfaceSpec(
+                height=bumpy_height_field(21, 0.003, 0.8, flat.height),
+                friction_field=bumpy_friction_field(21, 0.2, 0.8, flat.friction_field),
+                friction=flat.friction,
+            )
+
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=1.5)
+        a = simulate_ball(ball, build())
+        b = simulate_ball(ball, build())
+        assert a.rest_x_m == b.rest_x_m
+        assert a.rest_y_m == b.rest_y_m
+        # Bumps must actually perturb the putt vs the flat green.
+        flat_result = simulate_ball(ball, SurfaceSpec.flat_uniform(stimp_ft=10.0))
+        assert a.rest_x_m != flat_result.rest_x_m
+
+
+class TestHoleCapture:
+    def test_dying_putt_is_captured(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        mu_r = surface.friction.mu_roll0
+        v0 = math.sqrt(2.0 * mu_r * _G * 2.1)  # rolls out ~2.1 m
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        result = simulate_ball(ball, surface, hole_x_m=2.0, hole_y_m=0.0)
+        assert result.holed
+        assert result.speed_at_hole_mps is not None
+        assert result.speed_at_hole_mps <= capture_speed_mps()
+
+    def test_charging_putt_lips_through(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        mu_r = surface.friction.mu_roll0
+        v0 = math.sqrt(2.0 * mu_r * _G * 8.0)  # would roll out ~8 m
+        ball = BallState(x_m=0.0, y_m=0.0, vx_mps=v0, spin_rad_s=v0 / _R)
+        result = simulate_ball(ball, surface, hole_x_m=2.0, hole_y_m=0.0)
+        assert not result.holed
+        assert result.speed_at_hole_mps is not None
+        assert result.speed_at_hole_mps > capture_speed_mps()
+        assert result.rest_x_m > 2.0 + 0.054
+
+    def test_capture_bound_value(self) -> None:
+        # A dead-centre path has a full-hole-diameter travel budget:
+        # 2 R_h sqrt(g / (2 r_ball)) ~= 1.64 m/s (Holmes full-chord
+        # geometry, matching the AffineDrift article and P4 review).
+        assert capture_speed_mps() == pytest.approx(
+            2.0 * 0.054 * math.sqrt(_G / (2.0 * _R)), rel=1e-12
+        )
+        assert 1.5 < capture_speed_mps() < 1.75
+
+
+class TestStrikeToRoll:
+    def test_lofted_strike_rises_then_rolls_out(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        putter = PutterState(
+            head_mass_kg=0.35, moi_kg_m2=4.5e-4, loft_deg=8.0, speed_mps=3.0
+        )
+        result = simulate_strike(putter, surface)
+        modes = [s.mode for s in result.samples]
+        assert Mode.AIRBORNE in modes
+        assert Mode.SLIDE in modes
+        assert Mode.ROLL in modes
+        assert result.final_mode is Mode.REST
+        assert max(s.height_m for s in result.samples) > 0.0
+        assert result.collision is not None
+        assert result.collision.putter_dv_mps > 0.0
+
+    def test_airborne_precedes_ground_modes(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        putter = PutterState(
+            head_mass_kg=0.35, moi_kg_m2=4.5e-4, loft_deg=8.0, speed_mps=3.0
+        )
+        result = simulate_strike(putter, surface)
+        modes = [s.mode for s in result.samples]
+        last_air = max(i for i, m in enumerate(modes) if m is Mode.AIRBORNE)
+        first_ground = min(
+            i for i, m in enumerate(modes) if m in (Mode.SLIDE, Mode.ROLL)
+        )
+        assert last_air < first_ground
+
+    def test_delofted_strike_stays_on_the_turf(self) -> None:
+        surface = SurfaceSpec.flat_uniform(stimp_ft=10.0)
+        putter = PutterState(
+            head_mass_kg=0.35, moi_kg_m2=4.5e-4, loft_deg=-2.0, speed_mps=2.0
+        )
+        result = simulate_strike(putter, surface)
+        assert all(s.height_m == 0.0 for s in result.samples)

--- a/tests/unit/putting_dynamics/test_surfaces.py
+++ b/tests/unit/putting_dynamics/test_surfaces.py
@@ -1,0 +1,130 @@
+"""Surface-field tests for putting_dynamics (#8345 P2).
+
+Analytic limits, seeded reproducibility, and the keyed-stream
+discipline reused from the Tools variation engine.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from src.shared.python.putting_dynamics import (
+    FrictionField,
+    HeightField,
+    bumpy_friction_field,
+    bumpy_height_field,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestHeightField:
+    def test_flat_elevation_and_gradient_are_zero(self) -> None:
+        field = HeightField.flat(extent_m=10.0, spacing_m=0.5)
+        assert field.elevation(1.234, -2.345) == 0.0
+        assert field.gradient(1.234, -2.345) == (0.0, 0.0)
+
+    def test_bilinear_is_exact_on_grid_nodes(self) -> None:
+        rng = np.random.default_rng(7)
+        heights = rng.normal(0.0, 0.01, size=(9, 9))
+        field = HeightField(heights_m=heights, spacing_m=1.0, origin_m=(-4.0, -4.0))
+        assert field.elevation(-4.0 + 3.0, -4.0 + 5.0) == pytest.approx(
+            heights[5, 3], abs=1e-15
+        )
+
+    def test_planar_gradient_matches_grade_and_aspect(self) -> None:
+        grade, aspect_deg = 2.0, 30.0
+        field = HeightField.planar(grade, aspect_deg, extent_m=20.0)
+        gx, gy = field.gradient(1.3, -2.7)
+        aspect = math.radians(aspect_deg)
+        assert gx == pytest.approx(-0.02 * math.cos(aspect), rel=1e-9)
+        assert gy == pytest.approx(-0.02 * math.sin(aspect), rel=1e-9)
+        # Downhill direction: elevation drops along the aspect.
+        step = 1.0
+        drop = field.elevation(
+            step * math.cos(aspect), step * math.sin(aspect)
+        ) - field.elevation(0.0, 0.0)
+        assert drop == pytest.approx(-0.02 * step, rel=1e-9)
+
+    def test_out_of_grid_queries_clamp(self) -> None:
+        field = HeightField.planar(2.0, 0.0, extent_m=10.0)
+        inside = field.elevation(-5.0, 0.0)
+        outside = field.elevation(-50.0, 0.0)
+        assert outside == pytest.approx(inside, abs=0.02 * 0.5)
+
+    def test_rejects_tiny_grids(self) -> None:
+        with pytest.raises(ValueError, match="2x2"):
+            HeightField(heights_m=np.zeros((1, 5)))
+
+    def test_factory_rejects_invalid_spacing_with_contract_error(self) -> None:
+        with pytest.raises(ValueError, match="spacing"):
+            HeightField.flat(spacing_m=0.0)
+
+    def test_field_owns_an_immutable_copy_of_input_data(self) -> None:
+        source = np.zeros((3, 3))
+        field = HeightField(source)
+        source[1, 1] = 1.0
+        assert field.heights_m[1, 1] == 0.0
+        assert not field.heights_m.flags.writeable
+
+
+class TestFrictionField:
+    def test_uniform_multipliers_are_one(self) -> None:
+        field = FrictionField.uniform(extent_m=10.0)
+        roll, slide = field.multipliers(0.7, -3.1)
+        assert roll == pytest.approx(1.0, rel=1e-12)
+        assert slide == pytest.approx(1.0, rel=1e-12)
+
+    def test_rejects_non_positive_multipliers(self) -> None:
+        bad = np.ones((4, 4))
+        bad[2, 2] = 0.0
+        with pytest.raises(ValueError, match="positive"):
+            FrictionField(roll_multiplier=bad, slide_multiplier=np.ones((4, 4)))
+
+
+class TestBumpyFields:
+    def test_zero_amplitude_is_identical_to_base(self) -> None:
+        base = HeightField.flat(extent_m=10.0)
+        assert bumpy_height_field(3, 0.0, 1.0, base) is base
+        fbase = FrictionField.uniform(extent_m=10.0)
+        assert bumpy_friction_field(3, 0.0, 1.0, fbase) is fbase
+
+    def test_same_seed_reproduces_identical_field(self) -> None:
+        a = bumpy_height_field(42, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        b = bumpy_height_field(42, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        assert np.array_equal(a.heights_m, b.heights_m)
+
+    def test_different_seeds_differ(self) -> None:
+        a = bumpy_height_field(1, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        b = bumpy_height_field(2, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        assert not np.array_equal(a.heights_m, b.heights_m)
+
+    def test_amplitude_sets_bump_scale(self) -> None:
+        field = bumpy_height_field(5, 0.01, 1.0, HeightField.flat(extent_m=20.0))
+        assert field.heights_m.std() == pytest.approx(0.01, rel=0.05)
+
+    def test_height_and_friction_streams_are_independent(self) -> None:
+        # Keyed per-field streams (Tools variation-engine discipline):
+        # the height draw is the same whether or not friction is drawn.
+        before = bumpy_height_field(9, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        bumpy_friction_field(9, 0.2, 1.0, FrictionField.uniform(extent_m=10.0))
+        after = bumpy_height_field(9, 0.005, 1.0, HeightField.flat(extent_m=10.0))
+        assert np.array_equal(before.heights_m, after.heights_m)
+
+    def test_negative_seed_is_rejected_even_when_amplitude_is_zero(self) -> None:
+        with pytest.raises(ValueError, match="seed"):
+            bumpy_height_field(-1, 0.0, 1.0, HeightField.flat(extent_m=10.0))
+        with pytest.raises(ValueError, match="seed"):
+            bumpy_friction_field(-1, 0.0, 1.0, FrictionField.uniform(extent_m=10.0))
+
+    def test_friction_field_reproducible_and_positive(self) -> None:
+        a = bumpy_friction_field(11, 0.3, 2.0, FrictionField.uniform(extent_m=10.0))
+        b = bumpy_friction_field(11, 0.3, 2.0, FrictionField.uniform(extent_m=10.0))
+        assert np.array_equal(a.roll_multiplier, b.roll_multiplier)
+        assert np.array_equal(a.slide_multiplier, b.slide_multiplier)
+        assert np.all(a.roll_multiplier > 0.0)
+        # Roll and slide use distinct keyed streams.
+        assert not np.array_equal(a.roll_multiplier, a.slide_multiplier)


### PR DESCRIPTION
## Summary

- add a contract-first putting-dynamics package with heterogeneous slope/friction fields, anisotropic grain, seeded bumpiness, and an airborne/slide/roll/rest solver
- add a finite-mass, loft-aware two-body collision model with putter slowdown, energy audit, hosel-relative twist proxy, and an impulse-wrench seam for interval dynamics
- add 70 focused tests plus a source-verified public putting kinematics/kinetics review; update SPEC and the agent handoff

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] CI/CD

## Test plan

- [x] Tests pass locally
- [x] New tests added

Validated on Python 3.12:

- changed-file Ruff lint and format: passed
- changed-source mypy: passed for all 7 package modules
- tests/unit/putting_dynamics: 70 passed
- docs governance: passed
- git pre-push suite: Ruff, formatting, wildcard/debug/print guards, Prettier, mypy, Bandit, and unit tests all passed
- git diff --check: passed

Known unrelated baseline findings:

- the broad dependency-light selection reports 116 failures and 5 errors in existing AI adapter, Sidekick, signal-toolkit, and budget tests; no failure is in putting_dynamics
- scripts/check_spec_paths.py already fails on main because SPEC references missing task_manager_durable.py files; this PR does not add or modify those references
- whole-repository Ruff and size-budget audits contain existing failures outside this diff; the changed-file CI lanes are green

## Breaking changes?

- [x] No
- [ ] Yes

## AI Changes

- [x] AI-assisted: the implementation was reviewed line-by-line after takeover from an interrupted Claude session. Corrections include the full-chord capture bound, overspin handling, grain-direction semantics, immutable field ownership, factory contract ordering, collision vector/spin consistency, and parallel-axis shaft MOI.

## Implementation completeness checklist

- [x] P3 and P4 acceptance criteria are implemented; the epic remains open for P1, P2 issue tracking, and P5
- [x] Tests cover the new behavior and were developed test-first during correction
- [x] No new NotImplementedError, untracked TODO/FIXME, or hardcoded mock values
- [x] Manual verification: public-source values and derivations were checked against the linked primary/open sources; this phase has no app UI
- [x] Closes #8348
- [x] Closes #8349

## Checklist

- [x] Reproducible Python pipeline completes for the scoped package
- [x] No large binaries added
- [x] No environment-file changes required
- [x] No secrets added

Related epic: #8345