### PR TITLE
fix(launcher): recover classic startup in nested worktrees

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -18,6 +18,11 @@ Update this file with every PR and every push to main.
 - **#8339** ("Rate of Closure Impact Explorer") — merged. `vendor/ud-tools` submodule
   pin was provisional pending Tools#4092; confirm the submodule now points at the
   squash-merge commit on Tools `main`, not the old branch-head SHA, before relying on it.
+- `fix/classic-launcher-missing-tools` — PR pending. Fixes classic-launcher startup
+  from nested worktrees by locating the workspace-level Tools checkout. If no valid
+  implicit Tools runtime exists, only the optional Sidekick sidebar is disabled;
+  explicit `TOOLS_REPO_PATH` selections remain fail-closed. Commit `6699380d9` has
+  28 focused launcher/overlay tests plus clean Ruff checks.
 - Several open `bolt-*` PRs (#8334, #8335, #8336, #8341) — small automated numpy
   micro-optimizations (vdot/ndarray.sum/boolean reduction) in trendline/curve-fit code.
   Independent, not stacked.
@@ -42,6 +47,8 @@ The active branches are independent topic branches off `main` unless noted:
 
 - `feat/putting-dynamics` — #8345 P2/P3/P4, full PR **#8352** to `main`.
   P1 should branch from this interface until the PR merges.
+- `fix/classic-launcher-missing-tools` — classic PyQt6 nested-worktree discovery and
+  optional Sidekick fallback; independent of the putting stack.
 - `fix/impact-friction-spin-axis-and-gear-offset` (#8344) — off `main`.
 - `bolt-vdot-optimization-*`, `bolt/trendline-boolean-sum-optimization-*`,
   `bolt/ndarray-sum-optimization-*`, `bolt/optimize-rsquared-vdot-*` — each off `main`,

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -18,7 +18,7 @@ Update this file with every PR and every push to main.
 - **#8339** ("Rate of Closure Impact Explorer") — merged. `vendor/ud-tools` submodule
   pin was provisional pending Tools#4092; confirm the submodule now points at the
   squash-merge commit on Tools `main`, not the old branch-head SHA, before relying on it.
-- `fix/classic-launcher-missing-tools` — PR pending. Fixes classic-launcher startup
+- **#8353** (`fix/classic-launcher-missing-tools`) — full PR. Fixes classic-launcher startup
   from nested worktrees by locating the workspace-level Tools checkout. If no valid
   implicit Tools runtime exists, only the optional Sidekick sidebar is disabled;
   explicit `TOOLS_REPO_PATH` selections remain fail-closed. Commit `6699380d9` has
@@ -47,8 +47,9 @@ The active branches are independent topic branches off `main` unless noted:
 
 - `feat/putting-dynamics` — #8345 P2/P3/P4, full PR **#8352** to `main`.
   P1 should branch from this interface until the PR merges.
-- `fix/classic-launcher-missing-tools` — classic PyQt6 nested-worktree discovery and
-  optional Sidekick fallback; independent of the putting stack.
+- `fix/classic-launcher-missing-tools` — full PR **#8353**; classic PyQt6
+  nested-worktree discovery and optional Sidekick fallback, independent of the
+  putting stack.
 - `fix/impact-friction-spin-axis-and-gear-offset` (#8344) — off `main`.
 - `bolt-vdot-optimization-*`, `bolt/trendline-boolean-sum-optimization-*`,
   `bolt/ndarray-sum-optimization-*`, `bolt/optimize-rsquared-vdot-*` — each off `main`,

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,8 +39,8 @@
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-| **Spec Version** | 1.0.481 |
-| **Last Spec Update** | 2026-08-04 |
+| **Spec Version** | 1.0.482 |
+| **Last Spec Update** | 2026-08-05 |
 
 ## 2. Purpose & Mission
 
@@ -71,6 +71,13 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-08-05** - Hardened classic PyQt6 startup from nested worktrees.
+  Tools-source discovery now walks workspace ancestors after honoring explicit
+  and initialized vendored sources, so a worktree can locate the canonical
+  sibling `Tools/src` checkout. An unavailable implicit Sidekick runtime
+  disables only the optional sidebar; an explicitly configured incomplete
+  `TOOLS_REPO_PATH` remains fail-closed. Focused regressions pin nested
+  discovery and both fallback contracts.
 - **2026-08-04** - Added the headless putting-dynamics foundation for #8345
   P2/P3/P4. `src/shared/python/putting_dynamics/` provides DbC-validated
   heterogeneous height/friction fields, seeded bumpiness, signed skid/overspin
@@ -1945,6 +1952,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-05 | 1.0.482 | Fixed classic PyQt6 startup from nested worktrees by discovering the workspace-level Tools checkout, degrading only the optional Sidekick sidebar for an unavailable implicit runtime, and preserving fail-closed behavior for explicit `TOOLS_REPO_PATH`; 28 focused launcher/overlay tests pass. |
 | 2026-08-04 | 1.0.481 | Added #8345 P2/P3/P4 putting dynamics and public-data review: heterogeneous and seeded green fields, advanced friction, signed skid/overspin settling, full-chord capture, finite-mass lofted collision, putter slowdown, adjustable-hosel impulse wrench and pinned-shaft twist proxy, 70 focused tests, and an explicit provenance/assumption ledger. |
 | 2026-08-01 | 1.1.0   | Bolt: Optimized `np.sum(arr * arr)` and `np.sum(arr ** 2)` to `np.vdot(arr, arr)` in drake compute cost and PARITY_SPEC to avoid intermediate array allocations and improve performance. |
 | 2026-07-27 | 1.0.479 | Separated classic PyQt6 Diagnostics validation of the 46 directly declared parent `models.yaml` tiles from validation of the 75-entry provider-expanded runtime registry (#8121). Added hermetic provider regressions and recorded the computer-controlled transition from a false 29-model `DEGRADED` result to `Status: HEALTHY` with zero failed checks. |

--- a/src/launchers/launcher_sidekick_sidebar.py
+++ b/src/launchers/launcher_sidekick_sidebar.py
@@ -14,6 +14,7 @@ from typing import Any
 from src.launchers.launcher_constants import REPOS_ROOT, logger
 from src.launchers.launcher_manager_attrs import forward_manager_attribute
 from src.launchers.sidekick_extension_overlay import (
+    IncompleteParentSidekickRuntimeError,
     ManifestGatedSidekickFinder,
     install_manifest_gated_sidekick_extensions,
     validate_parent_sidekick_runtime,
@@ -105,7 +106,17 @@ class SidekickSidebarManager:
 
     def _get_sidekick_module(self) -> Any | None:
         """Import the Sidekick sidebar module, trying multiple fallback paths."""
-        SidekickSidebarManager._install_sidekick_import_paths(self)
+        try:
+            SidekickSidebarManager._install_sidekick_import_paths(self)
+        except IncompleteParentSidekickRuntimeError as exc:
+            if os.environ.get("TOOLS_REPO_PATH"):
+                raise
+            logger.warning(
+                "Sidekick sidebar disabled because the implicit Tools runtime "
+                "is unavailable: %s",
+                exc,
+            )
+            return None
         try:
             return importlib.import_module("sidekick.ui.tools_sidebar.api")
         except ImportError:

--- a/src/launchers/sidekick_extension_overlay.py
+++ b/src/launchers/sidekick_extension_overlay.py
@@ -30,6 +30,10 @@ _REQUIRED_PARENT_RUNTIME = (
 )
 
 
+class IncompleteParentSidekickRuntimeError(RuntimeError):
+    """The selected Tools source does not provide the required runtime."""
+
+
 @dataclass(frozen=True)
 class _ExtensionSource:
     """An exact local module approved by the ownership manifest."""
@@ -283,13 +287,14 @@ def validate_parent_sidekick_runtime(parent_python_root: Path) -> None:
         if not (parent_root / relative).is_file()
     ]
     if missing:
-        raise RuntimeError(
+        raise IncompleteParentSidekickRuntimeError(
             "The canonical Sidekick runtime is incomplete in the selected "
             f"Tools source: {', '.join(missing)}"
         )
 
 
 __all__ = [
+    "IncompleteParentSidekickRuntimeError",
     "ManifestGatedSidekickFinder",
     "install_manifest_gated_sidekick_extensions",
     "validate_parent_sidekick_runtime",

--- a/src/launchers/tools_repo_path.py
+++ b/src/launchers/tools_repo_path.py
@@ -49,9 +49,13 @@ def resolve_tools_source_root(repo_root: Path, env_value: str | None) -> Path:
     if vendor_source.is_dir():
         return vendor_source
 
-    sibling_root = repo_root.parent / "Tools"
-    if sibling_root.is_dir():
-        return sibling_root / "src"
+    # Normal clones sit directly beside Tools. Agent worktrees commonly sit
+    # below ``UpstreamDrift/.codex-worktrees/<branch>``; walk upward so those
+    # source checkouts still find the same workspace-level sibling.
+    for workspace_root in repo_root.parents:
+        sibling_source = workspace_root / "Tools" / "src"
+        if sibling_source.is_dir():
+            return sibling_source
 
     # Match the existing last-resort import contract. The missing path is
     # harmless in PYTHONPATH and produces the normal import error downstream.

--- a/tests/unit/launcher/test_sidekick_startup_coordination.py
+++ b/tests/unit/launcher/test_sidekick_startup_coordination.py
@@ -19,6 +19,9 @@ import pytest
 
 from src.launchers import launcher_sidekick_sidebar as sidebar_module
 from src.launchers.launcher_sidekick_sidebar import SidekickSidebarManager
+from src.launchers.sidekick_extension_overlay import (
+    IncompleteParentSidekickRuntimeError,
+)
 from src.launchers.upstream_drift_launcher import (
     SIDEKICK_API_HEALTHCHECK_MS,
     SIDEKICK_API_MAX_RESTARTS,
@@ -258,6 +261,73 @@ def test_vendored_tools_precedes_mutable_sibling_checkout(
         str(vendor_src),
         str(vendor_src / "shared" / "python"),
     ]
+
+
+def test_nested_worktree_finds_workspace_sibling_tools_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An uninitialized worktree vendor falls back to workspace Tools."""
+    monkeypatch.delenv("TOOLS_REPO_PATH", raising=False)
+    workspace = tmp_path / "Repositories"
+    repo_root = workspace / "UpstreamDrift" / ".codex-worktrees" / "feature"
+    sibling_src = workspace / "Tools" / "src"
+    (repo_root / "vendor" / "ud-tools").mkdir(parents=True)
+    (sibling_src / "shared" / "python").mkdir(parents=True)
+    manager = SidekickSidebarManager(SimpleNamespace())
+    installed: list[str] = []
+
+    with (
+        patch.object(sidebar_module, "REPOS_ROOT", repo_root),
+        patch.object(
+            SidekickSidebarManager,
+            "_prepend_sys_path",
+            side_effect=lambda path: installed.append(str(path)),
+        ),
+        patch.object(sidebar_module, "_activate_source_extensions"),
+    ):
+        manager._install_sidekick_import_paths()
+
+    assert installed == [
+        str(sibling_src),
+        str(sibling_src / "shared" / "python"),
+    ]
+
+
+def test_implicit_incomplete_tools_runtime_disables_optional_sidebar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing implicit Tools checkout must not abort the main launcher."""
+    monkeypatch.delenv("TOOLS_REPO_PATH", raising=False)
+    manager = SidekickSidebarManager(SimpleNamespace())
+
+    with patch.object(
+        SidekickSidebarManager,
+        "_install_sidekick_import_paths",
+        side_effect=IncompleteParentSidekickRuntimeError("missing runtime"),
+    ):
+        assert manager._get_sidekick_module() is None
+
+
+def test_explicit_incomplete_tools_runtime_remains_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicitly selected but incomplete Tools checkout is an error."""
+    tools_root = tmp_path / "Tools"
+    (tools_root / "src").mkdir(parents=True)
+    monkeypatch.setenv("TOOLS_REPO_PATH", str(tools_root))
+    manager = SidekickSidebarManager(SimpleNamespace())
+
+    with (
+        patch.object(
+            SidekickSidebarManager,
+            "_install_sidekick_import_paths",
+            side_effect=IncompleteParentSidekickRuntimeError("missing runtime"),
+        ),
+        pytest.raises(IncompleteParentSidekickRuntimeError, match="missing runtime"),
+    ):
+        manager._get_sidekick_module()
 
 
 def test_explicit_tools_checkout_precedes_initialized_fallbacks(


### PR DESCRIPTION
## Summary

- discover a workspace-level `Tools/src` checkout from nested UpstreamDrift worktrees after preserving explicit and initialized-vendor precedence
- disable only the optional Sidekick sidebar when an implicitly selected runtime is incomplete
- preserve fail-closed behavior for an explicit, incomplete `TOOLS_REPO_PATH`
- record the startup contract in `SPEC.md` and `AGENT_HANDOFF.md`

## Root Cause

Nested worktrees sit below `UpstreamDrift/.codex-worktrees/<branch>`, but source discovery checked only `repo_root.parent/Tools`. With an uninitialized vendored checkout, the launcher selected an incomplete runtime and raised during deferred Sidekick setup, leaving the splash screen visible while startup aborted.

## Validation

- 28 focused launcher and Sidekick overlay tests passed
- Ruff check and format check passed for all changed Python files
- docs governance passed
- real nested-worktree resolution returns `C:\Users\diete\Repositories\Tools\src` and validates its required Sidekick runtime

Two vendor-authority integration tests require an initialized `vendor/ud-tools` submodule and cannot run in this isolated worktree; CI's recursive checkout supplies that fixture.