### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in pandas query()

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -70,6 +70,8 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 ## 4. Architecture Overview
 
 ### Recent Spec Updates
+- (spec-exempt: security fix) Fixed Command Injection in `pandas.DataFrame.query()` inside `rust_engine.py` (both `data_processor` and `data_processor_io`) by explicitly validating user expressions using an AST-based validator (`validate_pandas_formula`). This eliminates an arbitrary code execution vulnerability.
+
 
 - **2026-08-05** - Retargeted #8345 P1's 3D putting workflow to `main`
   after the headless dynamics foundation merged. The FastAPI route executes the

--- a/src/shared/python/data_processor/rust_engine.py
+++ b/src/shared/python/data_processor/rust_engine.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pandas as pd
+from src.shared.python.safe_pandas_eval import validate_pandas_formula
+
 
 logger = logging.getLogger(__name__)
 
@@ -403,6 +405,10 @@ def filter_export(
     df = pd.read_csv(p) if fmt == "csv" else pd.read_parquet(p)
 
     df = _select_columns(df, columns)
+    try:
+        validate_pandas_formula(predicate, allowed_columns=df.columns)
+    except ValueError as e:
+        raise ValueError(f"Invalid predicate: {e}") from e
     filtered = df.query(predicate)
 
     Path(p_dst).parent.mkdir(parents=True, exist_ok=True)

--- a/src/shared/python/data_processor_io/rust_engine.py
+++ b/src/shared/python/data_processor_io/rust_engine.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
+from src.shared.python.safe_pandas_eval import validate_pandas_formula
+
 
 logger = logging.getLogger(__name__)
 
@@ -473,6 +475,10 @@ def filter_export(
     df = pd.read_csv(p) if fmt == "csv" else pd.read_parquet(p)
 
     df = _select_columns(df, columns)
+    try:
+        validate_pandas_formula(predicate, allowed_columns=df.columns)
+    except ValueError as e:
+        raise ValueError(f"Invalid predicate: {e}") from e
     filtered = df.query(predicate)
 
     if active_token.is_cancelled():


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: `DataFrame.query()` evaluates string expressions and is vulnerable to injection if the concatenated string isn't validated, effectively using `pd.eval()` under the hood. 
🎯 **Impact**: This could lead to arbitrary code execution attacks if a malicious predicate string is passed.
🔧 **Fix**: Added validation using `validate_pandas_formula()` to `src/shared/python/data_processor/rust_engine.py` and `src/shared/python/data_processor_io/rust_engine.py`.
✅ **Verification**: Ran unit tests.

---
*PR created automatically by Jules for task [1453767863690020830](https://jules.google.com/task/1453767863690020830) started by @dieterolson*