### PR TITLE
⚡ Bolt: Replace np.linalg.norm with math.hypot for end-effector speed calculation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2423,6 +2423,7 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - **Performance:** Replaced `np.sum(forces, axis=0)` with `sum((s.force for s in self._sources.values()), np.zeros(3))` in `ForceAccumulator` methods (`get_total_force`, `get_total_torque`, and `get_total_generalized_force`) in `src/engines/common/state.py` to avoid intermediate list and array allocations, yielding ~30% faster execution time for accumulating forces and torques.
 
 ### Performance Improvements
+- Replaced `np.linalg.norm` with `math.hypot` for 1D trajectory end-effector speed calculation to reduce overhead (spec-exempt: micro-optimization)
 - Optimized array reduction by replacing `np.sum(np.abs(...))` with `np.abs(...).sum()` in `motion_optimization.py` to bypass overhead. (spec-exempt: micro-optimization)
 - Replace $O(n^2)$ loop sum calculation with an $O(n)$ vectorized `np.cumsum` approach for computing cumulative mass in `physics_base.py` (spec-exempt: micro-optimization)
 

--- a/src/engines/physics_engines/drake/python/perturbation/analyzer.py
+++ b/src/engines/physics_engines/drake/python/perturbation/analyzer.py
@@ -29,6 +29,7 @@ Delegates noise generation and coefficient perturbation to the shared
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -304,7 +305,8 @@ class DrakePerturbationAnalyzer(PerturbationAnalyzerBase):
         joint_velocities_final = r.v_traj[last].copy()
         ee_pos_final = r.ee_pos_traj[last].copy()
         ee_vel_final = r.ee_vel_traj[last].copy()
-        ee_speed_final = float(np.linalg.norm(ee_vel_final))
+        # ⚡ Bolt: math.hypot is ~2x faster than np.linalg.norm for small arrays
+        ee_speed_final = float(math.hypot(*ee_vel_final))
 
         # ⚡ Bolt: Explicit element-wise sum of squares is faster than
         # np.linalg.norm(..., axis=1) when finding max.


### PR DESCRIPTION
⚡ Bolt: Replace np.linalg.norm with math.hypot for end-effector speed calculation\n\n💡 What: Replaced `np.linalg.norm` with `math.hypot` for small 1D arrays.\n🎯 Why: Using `np.linalg.norm` on small vectors incurs significant NumPy overhead compared to the C-optimized `math.hypot`.\n📊 Impact: ~2x speedup for calculating the end-effector speed final values.\n🔬 Measurement: Verified with `timeit` and ran relevant Drake engine tests.

---
*PR created automatically by Jules for task [7676937901285371924](https://jules.google.com/task/7676937901285371924) started by @dieterolson*