### PR TITLE
🛡️ Sentinel: [HIGH] Fix user enumeration via timing attack in login endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -137,3 +137,8 @@
 **Vulnerability:** Found arbitrary code execution vulnerability in `DataProcessorEngine.filter_data()` and `DataProcessorEngine.query()` where user-provided column and operator strings were concatenated and passed directly to `pandas.DataFrame.query()` without validation.
 **Learning:** `DataFrame.query()` evaluates string expressions and is vulnerable to injection if the concatenated string isn't validated, even if parts of it are formatted dynamically.
 **Prevention:** Always validate constructed query expressions passed to `pd.DataFrame.query()` using an AST-based validator to ensure they only contain safe operations.
+
+## 2024-05-18 - [Fix user enumeration via timing attack in login endpoint]
+**Vulnerability:** The `/login` endpoint returned 401 immediately if the user email was not found, but took hundreds of milliseconds to compute bcrypt hashes if the user was found (even if the password was wrong). This allowed an attacker to enumerate registered emails via timing analysis.
+**Learning:** Bcrypt's intentional slowness is a security feature to slow down brute force attacks, but it introduces a side-channel timing leak if it's only executed for valid users. This is a common pattern in authentication endpoints.
+**Prevention:** Always perform a dummy password verification using a valid bcrypt hash with the same work factor (e.g. 12) if the user is not found, to ensure the authentication endpoint takes roughly the same time regardless of whether the user exists.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2539,3 +2539,4 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 ## Refactoring & Optimization Notes
 
 - `spec-exempt`: Replaced `np.linalg.norm` with `math.sqrt(np.vdot(..., ...))` in `src/shared/python/spatial_algebra/indexed_acceleration.py` to optimize 1D array norm calculation without changing logic.
+- (spec-exempt: security fix) Fixed user enumeration via timing attack in `/login` endpoint by ensuring a dummy password verification is performed even if the user is not found, to normalize response time.

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -86,16 +86,21 @@ async def login(
 
     # Find user
     user = db.query(User).filter(User.email == login_data.email).first()
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect email or password",
-        )
 
-    # Verify password
-    if not security_manager.verify_password(
-        login_data.password, str(user.hashed_password)
-    ):
+    # SECURITY: Prevent user enumeration via timing attacks by always
+    # performing a password verification even if the user is not found.
+    if user:
+        password_valid = security_manager.verify_password(
+            login_data.password, str(user.hashed_password)
+        )
+    else:
+        # Perform dummy verification using a valid bcrypt hash with the same
+        # work factor (12) used in the system, to take roughly the same time.
+        dummy_hash = "$2b$12$L7M5I.3Tf30z0q2o0rD1n.yT2kG1a5c6m2a5m8m5j2v5l2r7z4a9G"
+        security_manager.verify_password(login_data.password, dummy_hash)
+        password_valid = False
+
+    if not password_valid:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect email or password",

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -96,7 +96,8 @@ async def login(
     else:
         # Perform dummy verification using a valid bcrypt hash with the same
         # work factor (12) used in the system, to take roughly the same time.
-        dummy_hash = "$2b$12$L7M5I.3Tf30z0q2o0rD1n.yT2kG1a5c6m2a5m8m5j2v5l2r7z4a9G"
+        # This hash was generated with bcrypt for the password 'dummy_password'
+        dummy_hash = "$2b$12$9KWF9XkUM7.biKJYGY1oCeql3F9vNsKwhxDusKhRk8iCg5gUdT7G."
         security_manager.verify_password(login_data.password, dummy_hash)
         password_valid = False
 

--- a/ui/src/api/generated/types.ts
+++ b/ui/src/api/generated/types.ts
@@ -255,6 +255,14 @@ export interface AnalysisStatisticsResponse {
 }
 
 /**
+ * Bounded inline data and an analysis request; paths are never accepted.
+ */
+export interface AnalyzePayload {
+  records: Record<string, unknown>[];
+  analysis: FlexibleAnalysisPayload;
+}
+
+/**
  * Appearance preferences for the web shell.
  */
 export interface AppearanceSettings {
@@ -955,6 +963,21 @@ export interface FeatureReportModel {
   message: string;
   missing?: string[];
   depends_on?: string[];
+}
+
+/**
+ * Serialized form of :class:`FlexibleAnalysisRequest`.
+ */
+export interface FlexibleAnalysisPayload {
+  outcome: string;
+  predictors: string[];
+  analysis_mode: "correlation" | "regression" | "comprehensive";
+  correlation_method: "pearson" | "spearman" | "kendall";
+  missing_policy: "pairwise" | "listwise" | "fail";
+  group_by?: string | null;
+  confidence_level: number;
+  min_samples: number;
+  allow_aggregate: boolean;
 }
 
 /**


### PR DESCRIPTION
The `/login` endpoint returned 401 immediately if the user email was not found, but took hundreds of milliseconds to compute bcrypt hashes if the user was found (even if the password was wrong). This allowed an attacker to enumerate registered emails via timing analysis.

Bcrypt's intentional slowness is a security feature to slow down brute force attacks, but it introduces a side-channel timing leak if it's only executed for valid users. This is a common pattern in authentication endpoints.

This PR fixes the issue by always performing a dummy password verification using a valid bcrypt hash with the same work factor (e.g. 12) if the user is not found, to ensure the authentication endpoint takes roughly the same time regardless of whether the user exists.

---
*PR created automatically by Jules for task [16287999036686770098](https://jules.google.com/task/16287999036686770098) started by @dieterolson*