### PR TITLE
Classify 1017 unmarked tests so the suite-marker ratchet passes without --update-baseline

### DIFF
--- a/tests/acceptance/test_counterfactual_experiments.py
+++ b/tests/acceptance/test_counterfactual_experiments.py
@@ -19,6 +19,8 @@ import numpy as np
 import pytest
 from src.shared.python.logging_pkg.logging_config import get_logger
 
+pytestmark = pytest.mark.scientific
+
 # Check if pendulum engine dependencies are available
 try:
     from src.engines.physics_engines.pendulum.python.pendulum_physics_engine import (

--- a/tests/architecture/test_dependency_direction.py
+++ b/tests/architecture/test_dependency_direction.py
@@ -20,6 +20,10 @@ import ast
 import logging
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.integration
+
 logger = logging.getLogger(__name__)
 
 # Repository root

--- a/tests/config/launcher_manifest/test_tile_properties.py
+++ b/tests/config/launcher_manifest/test_tile_properties.py
@@ -24,6 +24,8 @@ from src.config.launcher_manifest_loader import (
     LauncherTile,
 )
 
+pytestmark = pytest.mark.unit
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MATLAB_SUITE_DIALOG = _REPO_ROOT / "src" / "launchers" / "matlab_suite_dialog.py"
 

--- a/tests/config/wave5_config/test_provider_adapter.py
+++ b/tests/config/wave5_config/test_provider_adapter.py
@@ -14,6 +14,8 @@ from src.config.launcher_manifest_loader import (
 from src.shared.python.config.model_pack_manifest import LauncherPresentationMetadata
 from src.shared.python.config.model_registry import ModelConfig
 
+pytestmark = pytest.mark.unit
+
 
 def _make_model(**overrides) -> ModelConfig:
     base = {

--- a/tests/deployment/wave5_deployment/test_teleoperation.py
+++ b/tests/deployment/wave5_deployment/test_teleoperation.py
@@ -21,6 +21,8 @@ from src.deployment.teleoperation.interface import (
     WorkspaceMapping,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class FakeDevice:
     def __init__(self):

--- a/tests/engines/test_pinocchio_ecosystem.py
+++ b/tests/engines/test_pinocchio_ecosystem.py
@@ -13,6 +13,8 @@ import importlib.util
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 
 def _module_available(name: str) -> bool:
     """find_spec that tolerates mock modules other suites place in

--- a/tests/integration/test_physics_engines_strict.py
+++ b/tests/integration/test_physics_engines_strict.py
@@ -95,6 +95,8 @@ with patch.dict("sys.modules", module_patches):
 import src.engines.physics_engines.myosuite.python.myosuite_physics_engine as _myosuite_mod  # noqa: E402
 import src.engines.physics_engines.opensim.python.opensim_physics_engine as _opensim_mod  # noqa: E402
 
+pytestmark = pytest.mark.integration
+
 _opensim_mod.opensim = mock_opensim  # type: ignore[attr-defined]
 _opensim_mod.OPENSIM_AVAILABLE = True  # type: ignore[attr-defined]
 _myosuite_mod.gym = mock_gym  # type: ignore[attr-defined]

--- a/tests/launchers/test_golf_launcher.py
+++ b/tests/launchers/test_golf_launcher.py
@@ -14,6 +14,8 @@ from src.launchers.upstream_drift_launcher import (  # noqa: E402
 )
 from src.launchers.ui_components import StartupResults  # noqa: E402
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def startup_results() -> StartupResults:

--- a/tests/launchers/test_launcher_layout_manager.py
+++ b/tests/launchers/test_launcher_layout_manager.py
@@ -15,6 +15,8 @@ from src.launchers.launcher_layout_manager import (  # noqa: E402
 from src.launchers.model_registry import ModelSpec  # noqa: E402
 from src.shared.python.config.model_registry import ModelRegistry  # noqa: E402
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def available_models() -> dict[str, ModelSpec]:

--- a/tests/launchers/test_launcher_model_handlers.py
+++ b/tests/launchers/test_launcher_model_handlers.py
@@ -27,6 +27,8 @@ from src.launchers.launcher_model_handlers import (  # noqa: E402
 from src.config.launcher_manifest_loader import LauncherManifest
 from src.launchers.model_card import MODEL_IMAGES
 
+pytestmark = pytest.mark.unit
+
 
 def test_module_handler() -> None:
     handler = ModuleHandler({"type1", "type2"}, "my_module", "My Module")

--- a/tests/launchers/test_launcher_model_sources.py
+++ b/tests/launchers/test_launcher_model_sources.py
@@ -17,6 +17,8 @@ from src.shared.python.config.tools_vendor_authority import (
     ToolsVendorAuthority,
 )
 
+pytestmark = pytest.mark.unit
+
 
 TOOLS_MODEL_IDS = (
     "video_analyzer",

--- a/tests/launchers/test_launcher_process_manager.py
+++ b/tests/launchers/test_launcher_process_manager.py
@@ -19,6 +19,8 @@ from src.launchers.launcher_process_manager import (  # noqa: E402
     start_vcxsrv,
 )
 
+pytestmark = pytest.mark.unit
+
 # Convenience patch targets used by launch_script / launch_module tests
 _SECURE_POPEN = "src.launchers.launcher_process_manager.secure_popen"
 _VALIDATE_SCRIPT = "src.launchers.launcher_process_manager.validate_script_path"

--- a/tests/launchers/test_launcher_shared_tools_diagnostics.py
+++ b/tests/launchers/test_launcher_shared_tools_diagnostics.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from src.launchers.launcher_shared_tools_diagnostics import (
     inspect_shared_tools_freshness,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_probe_reports_missing_submodule_without_mutating_inputs(

--- a/tests/launchers/test_launcher_simulation.py
+++ b/tests/launchers/test_launcher_simulation.py
@@ -12,6 +12,8 @@ import pytest  # noqa: E402
 from PyQt6.QtWidgets import QMainWindow, QMessageBox  # noqa: E402
 from src.launchers.launcher_simulation import SimulationManager  # noqa: E402
 
+pytestmark = pytest.mark.unit
+
 
 class DummyModel:
     def __init__(self, id, name, type, path=None):

--- a/tests/launchers/test_launcher_ui_setup.py
+++ b/tests/launchers/test_launcher_ui_setup.py
@@ -14,6 +14,8 @@ from PyQt6.QtWidgets import (
 )  # noqa: E402
 from src.launchers.launcher_ui_setup import UISetupManager  # noqa: E402
 
+pytestmark = pytest.mark.unit
+
 
 class DummyLauncher(QMainWindow):
     def __getattr__(self, name: str) -> Any:

--- a/tests/launchers/test_matlab_suite_dialog.py
+++ b/tests/launchers/test_matlab_suite_dialog.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from PyQt6.QtWidgets import QDialog, QPushButton, QWidget
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 class _StubParent(QWidget):

--- a/tests/launchers/test_model_handlers.py
+++ b/tests/launchers/test_model_handlers.py
@@ -21,6 +21,8 @@ from src.launchers.launcher_model_handlers import (  # noqa: E402
 )
 from src.launchers.launcher_process_manager import ProcessManager  # noqa: E402
 
+pytestmark = pytest.mark.unit
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # =============================================================================

--- a/tests/launchers/test_settings_dialog_decomposition.py
+++ b/tests/launchers/test_settings_dialog_decomposition.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from src.launchers import settings_dialog
 from src.launchers._settings_auxiliary_tabs import SettingsAuxiliaryTabsMixin
 from src.launchers.settings_runtime import (
@@ -14,6 +16,8 @@ from src.launchers.settings_runtime import (
     WslScriptDialog,
     compare_version_strings,
 )
+
+pytestmark = pytest.mark.unit
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/launchers/test_shot_tracer.py
+++ b/tests/launchers/test_shot_tracer.py
@@ -11,6 +11,8 @@ from src.launchers.shot_tracer import (  # noqa: E402
     MultiModelShotTracerWindow,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_flight_models() -> Generator[tuple[MagicMock, MagicMock], None, None]:

--- a/tests/launchers/test_tools_vendor_authority.py
+++ b/tests/launchers/test_tools_vendor_authority.py
@@ -9,6 +9,8 @@ import pytest
 
 from src.shared.python.config import tools_vendor_authority as authority
 
+pytestmark = pytest.mark.unit
+
 GitResponseKey = tuple[Path, tuple[str, ...]]
 
 

--- a/tests/launchers/wave8_dashboards/test_exercise_dashboard.py
+++ b/tests/launchers/wave8_dashboards/test_exercise_dashboard.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 

--- a/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
+++ b/tests/launchers/wave8_misc/test_embedded_tool_bootstrap.py
@@ -20,6 +20,8 @@ import pytest
 
 from src.launchers import embedded_tool_bootstrap as bootstrap
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _reset_bootstrap_state():

--- a/tests/reinforcement_learning/test_trajectory_funnel_benchmark.py
+++ b/tests/reinforcement_learning/test_trajectory_funnel_benchmark.py
@@ -8,6 +8,8 @@ from src.reinforcement_learning.trajectory_funnel_benchmark import (
     TrajectoryFunnelBenchmark,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestTrajectoryFunnelBenchmark:
     """Basic tests for the TrajectoryFunnelBenchmark class."""

--- a/tests/research/test_advanced_biological_bridge_evidence.py
+++ b/tests/research/test_advanced_biological_bridge_evidence.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.scientific
+
 
 ROOT = Path(__file__).resolve().parents[2]
 ARTICLE = ROOT / "docs/research/proximal_distal_energy_transfer"

--- a/tests/research/test_bilateral_wrench_identifiability.py
+++ b/tests/research/test_bilateral_wrench_identifiability.py
@@ -10,6 +10,8 @@ from scripts.research.proximal_distal_energy.bilateral_wrench_identifiability im
     point_force_wrench_map,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 def _contacts(span_m: float = 0.20) -> np.ndarray:
     return np.array(((-0.5 * span_m, 0.0, 0.0), (0.5 * span_m, 0.0, 0.0)))

--- a/tests/research/test_bilateral_wrench_identifiability_evidence.py
+++ b/tests/research/test_bilateral_wrench_identifiability_evidence.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.scientific
+
 ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE = (
     ROOT

--- a/tests/research/test_experimental_falsification_protocol.py
+++ b/tests/research/test_experimental_falsification_protocol.py
@@ -13,6 +13,8 @@ from scripts.research.proximal_distal_energy.run_experimental_protocol_dry_run i
     build_readiness_record,
 )
 
+pytestmark = pytest.mark.unit
+
 
 ROOT = Path(__file__).resolve().parents[2]
 DATA = ROOT / "docs/research/proximal_distal_energy_transfer/data"

--- a/tests/research/test_flexible_shaft_study.py
+++ b/tests/research/test_flexible_shaft_study.py
@@ -16,6 +16,8 @@ from scripts.research.proximal_distal_energy.flexible_shaft_study import (
     velocity_bias_power_identity_residual,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 def test_acceleration_contributions_reconstruct_total() -> None:
     params = FlexibleShaftParams.reference()

--- a/tests/research/test_momentum_transfer_experiment_registry.py
+++ b/tests/research/test_momentum_transfer_experiment_registry.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRY = (
     ROOT

--- a/tests/research/test_momentum_transfer_human_registration.py
+++ b/tests/research/test_momentum_transfer_human_registration.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRATION = (
     ROOT

--- a/tests/research/test_moving_base_flexible_club.py
+++ b/tests/research/test_moving_base_flexible_club.py
@@ -20,6 +20,8 @@ from scripts.research.proximal_distal_energy.moving_base_flexible_club import (
 )
 from scripts.research.proximal_distal_energy.two_arm_closed_loop import TwoArmControl
 
+pytestmark = pytest.mark.scientific
+
 
 def test_parameter_contract_fails_closed() -> None:
     params = MovingBaseFlexibleParams.publication_default()

--- a/tests/research/test_moving_base_modal_shaft.py
+++ b/tests/research/test_moving_base_modal_shaft.py
@@ -18,6 +18,8 @@ from scripts.research.proximal_distal_energy.moving_base_modal_shaft import (
 )
 from scripts.research.proximal_distal_energy.two_arm_closed_loop import TwoArmControl
 
+pytestmark = pytest.mark.scientific
+
 
 def test_modal_contract_fails_closed() -> None:
     params = ModalShaftCouplingParams.publication_default(mode_count=3)

--- a/tests/research/test_moving_base_modal_shaft_evidence.py
+++ b/tests/research/test_moving_base_modal_shaft_evidence.py
@@ -7,6 +7,9 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
+
+pytestmark = pytest.mark.scientific
 
 ROOT = Path(__file__).resolve().parents[2]
 DATA = ROOT / "docs" / "research" / "proximal_distal_energy_transfer" / "data"

--- a/tests/research/test_shaft_contribution_evidence.py
+++ b/tests/research/test_shaft_contribution_evidence.py
@@ -13,6 +13,8 @@ from scripts.research.proximal_distal_energy.run_shaft_contribution_study import
     write_outputs,
 )
 
+pytestmark = pytest.mark.scientific
+
 RECORD = (
     Path(__file__).resolve().parents[2]
     / "docs"

--- a/tests/research/test_timing_failure_mode_study.py
+++ b/tests/research/test_timing_failure_mode_study.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.scientific
+
 ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE = (
     ROOT

--- a/tests/research/test_timing_viability.py
+++ b/tests/research/test_timing_viability.py
@@ -10,6 +10,8 @@ from scripts.research.proximal_distal_energy.timing_viability import (
     viability_mask,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 METRIC_NAMES = (
     "delivery_speed_m_s",

--- a/tests/research/test_timing_viability_study.py
+++ b/tests/research/test_timing_viability_study.py
@@ -4,6 +4,9 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
+
+pytestmark = pytest.mark.scientific
 
 ROOT = Path(__file__).resolve().parents[2]
 DATA = ROOT / "docs/research/proximal_distal_energy_transfer/data"

--- a/tests/research/test_torso_velocity_human_validation_registration.py
+++ b/tests/research/test_torso_velocity_human_validation_registration.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRATION = (
     ROOT

--- a/tests/research/test_transmission_stability_audit.py
+++ b/tests/research/test_transmission_stability_audit.py
@@ -3,9 +3,13 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.research.proximal_distal_energy.audit_transmission_stability import (
     build_audit,
 )
+
+pytestmark = pytest.mark.scientific
 
 ROOT = Path(__file__).resolve().parents[2]
 PATH = (

--- a/tests/research/test_two_hand_wrench.py
+++ b/tests/research/test_two_hand_wrench.py
@@ -13,6 +13,8 @@ from scripts.research.proximal_distal_energy.two_hand_wrench import (
     two_contact_wrench,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 def test_opposed_normal_forces_form_a_pure_couple() -> None:
     positions = np.array([[-0.1, 0.0], [0.1, 0.0]])

--- a/tests/research/test_two_hand_wscg_analysis.py
+++ b/tests/research/test_two_hand_wscg_analysis.py
@@ -12,6 +12,8 @@ from scripts.research.proximal_distal_energy.run_two_hand_wscg_analysis import (
     write_outputs,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 def test_publication_style_uses_portable_minus_glyph() -> None:
     """Core PDF fonts must not render negative ticks as missing-glyph question marks."""

--- a/tests/research/test_typed_slack.py
+++ b/tests/research/test_typed_slack.py
@@ -9,6 +9,8 @@ from scripts.research.proximal_distal_energy.typed_slack import (
     evaluate_slack,
 )
 
+pytestmark = pytest.mark.scientific
+
 
 def test_each_slack_class_has_distinct_engagement_and_energy_state() -> None:
     x = np.array([-0.02, 0.0, 0.02, 0.04])

--- a/tests/research/test_typed_slack_dynamic.py
+++ b/tests/research/test_typed_slack_dynamic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from scripts.research.proximal_distal_energy.typed_slack import SlackParameters
 from scripts.research.proximal_distal_energy.typed_slack_dynamic import (
@@ -9,6 +10,8 @@ from scripts.research.proximal_distal_energy.typed_slack_dynamic import (
     scaled_sensitivity_audit,
     simulate_dynamic_slack,
 )
+
+pytestmark = pytest.mark.scientific
 
 
 def _parameters(kind: str) -> DynamicSlackParameters:

--- a/tests/research/test_typed_slack_dynamic_evidence.py
+++ b/tests/research/test_typed_slack_dynamic_evidence.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.scientific
+
 ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE = (
     ROOT

--- a/tests/research/test_typed_slack_evidence.py
+++ b/tests/research/test_typed_slack_evidence.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.scientific
+
 ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE = (
     ROOT / "docs/research/proximal_distal_energy_transfer/data/typed_slack_study.json"

--- a/tests/research/wave6_research/test_mpc.py
+++ b/tests/research/wave6_research/test_mpc.py
@@ -19,6 +19,8 @@ from src.research.mpc.specialized import (
     WholeBodyMPC,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestCostFunction:
     def test_running_cost_no_ref(self) -> None:

--- a/tests/rust_bindings/test_rust_kernel_adapter.py
+++ b/tests/rust_bindings/test_rust_kernel_adapter.py
@@ -23,6 +23,8 @@ from src.shared.python.physics.rust_kernel import (
     is_rust_available,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def force_fallback(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/shared/test_pose_estimation_gui.py
+++ b/tests/shared/test_pose_estimation_gui.py
@@ -15,6 +15,8 @@ import pytest
 
 from unittest.mock import patch
 
+pytestmark = pytest.mark.unit
+
 # =============================================================================
 # Config Parser Tests
 # =============================================================================

--- a/tests/tools/hmr2_sidecar/test_betas_bridge.py
+++ b/tests/tools/hmr2_sidecar/test_betas_bridge.py
@@ -18,6 +18,8 @@ from src.tools.hmr2_sidecar.betas_bridge import (
 )
 from src.tools.hmr2_sidecar.run_hmr2 import NUM_BETAS, _write_stub_artifacts
 
+pytestmark = pytest.mark.unit
+
 _BETAS = [0.5, -1.2, 0.0, 0.3, -0.7, 1.1, 0.05, -0.4, 0.9, 0.2]
 
 

--- a/tests/tools/hmr2_sidecar/test_run_hmr2.py
+++ b/tests/tools/hmr2_sidecar/test_run_hmr2.py
@@ -31,6 +31,8 @@ from src.tools.hmr2_sidecar.run_hmr2 import (
     run_hmr2_sidecar,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture(autouse=True)
 def _no_ambient_hmr2_command(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/api/test_local_server_route_parity.py
+++ b/tests/unit/api/test_local_server_route_parity.py
@@ -21,6 +21,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
+pytestmark = pytest.mark.unit
+
 _SKIP_METHODS = frozenset({"HEAD", "OPTIONS"})
 
 

--- a/tests/unit/api/test_middleware.py
+++ b/tests/unit/api/test_middleware.py
@@ -10,7 +10,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse, Response
 
 # Configure async tests
-pytestmark = pytest.mark.anyio
+pytestmark = [pytest.mark.anyio, pytest.mark.unit]
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/api/test_route_uniqueness.py
+++ b/tests/unit/api/test_route_uniqueness.py
@@ -29,6 +29,8 @@ from fastapi.routing import APIRoute
 
 from src.api.route_registry import discover_routes, register_routes
 
+pytestmark = pytest.mark.unit
+
 _ROUTE_PARAMETER_RE = re.compile(r"\{[^}/]+\}")
 
 

--- a/tests/unit/api/test_routes_aip.py
+++ b/tests/unit/api/test_routes_aip.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 from src.api.routes.aip import router
 from src.api.dependencies import get_engine_manager
 
+pytestmark = pytest.mark.unit
+
 
 class MockEngineManager:
     def get_available_engines(self):

--- a/tests/unit/api/test_routes_dataset.py
+++ b/tests/unit/api/test_routes_dataset.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 from src.api.routes.dataset import router
 from src.api.dependencies import get_engine_manager
 
+pytestmark = pytest.mark.unit
+
 
 class MockEngine:
     def __init__(self):

--- a/tests/unit/api/test_routes_engines.py
+++ b/tests/unit/api/test_routes_engines.py
@@ -10,6 +10,8 @@ from src.api.routes.engines import router
 from src.api.dependencies import get_engine_manager
 from src.shared.python.engine_core.engine_registry import EngineType
 
+pytestmark = pytest.mark.unit
+
 
 class MockEngineCapabilities:
     def to_dict(self):

--- a/tests/unit/api/test_routes_observability.py
+++ b/tests/unit/api/test_routes_observability.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 from src.api.routes.observability import router
 
+pytestmark = pytest.mark.unit
+
 
 class MockEngineManager:
     def get_available_engines(self):

--- a/tests/unit/api/test_routes_putting_green.py
+++ b/tests/unit/api/test_routes_putting_green.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 from src.api.routes.putting_green import router
 from src.api.dependencies import get_engine_manager, get_task_manager
 
+pytestmark = pytest.mark.unit
+
 
 class MockGreen:
     def __init__(self):

--- a/tests/unit/api/test_simulation_service_async.py
+++ b/tests/unit/api/test_simulation_service_async.py
@@ -16,7 +16,7 @@ import pytest
 
 from src.api.services.simulation_service import SimulationService
 
-pytestmark = pytest.mark.anyio
+pytestmark = [pytest.mark.anyio, pytest.mark.unit]
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/engines/mujoco/test_biomechanics.py
+++ b/tests/unit/engines/mujoco/test_biomechanics.py
@@ -10,6 +10,8 @@ from mujoco_humanoid_golf.biomechanics import (
 )
 from mujoco_humanoid_golf.models import DOUBLE_PENDULUM_XML
 
+pytestmark = pytest.mark.unit
+
 
 class TestBiomechanicalData:
     """Tests for BiomechanicalData dataclass."""

--- a/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675_services.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_apps_coverage_4675_services.py
@@ -17,6 +17,8 @@ import pytest
 
 from ._apps_coverage_helpers import make_model
 
+pytestmark = pytest.mark.unit
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 os.environ.setdefault("MPLBACKEND", "Agg")
 

--- a/tests/unit/engines/simscape/three_d_gui/test_segment_editor.py
+++ b/tests/unit/engines/simscape/three_d_gui/test_segment_editor.py
@@ -8,6 +8,8 @@ import pytest
 
 from ._viewer_test_helpers import ANATOMICAL_28, make_synthetic_model
 
+pytestmark = pytest.mark.unit
+
 pytest.importorskip("PyQt6")
 
 

--- a/tests/unit/launcher/test_sidekick_readiness.py
+++ b/tests/unit/launcher/test_sidekick_readiness.py
@@ -8,6 +8,8 @@ import pytest
 
 from src.launchers import sidekick_readiness as readiness
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeHttpResponse:
     def __init__(self, status: int, body: bytes = b"") -> None:

--- a/tests/unit/launchers/test_custom_title_bar.py
+++ b/tests/unit/launchers/test_custom_title_bar.py
@@ -1,8 +1,11 @@
 from PyQt6.QtCore import Qt, QPointF
 from PyQt6.QtGui import QMouseEvent
+import pytest
 from unittest.mock import MagicMock
 from src.launchers import about_dialog
 from src.launchers.custom_title_bar import CustomTitleBar
+
+pytestmark = pytest.mark.unit
 
 
 def test_custom_title_bar_signals(qapp):

--- a/tests/unit/launchers/test_launcher_diagnostics_fixes.py
+++ b/tests/unit/launchers/test_launcher_diagnostics_fixes.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 
 class TestExpectedTileIdsMatchesModelsYaml:
     """#5476 — EXPECTED_TILE_IDS must be derived from models.yaml."""

--- a/tests/unit/motion_pipeline/ik/test_default_backend_works.py
+++ b/tests/unit/motion_pipeline/ik/test_default_backend_works.py
@@ -8,6 +8,8 @@ IK stage must always point at a working solver.
 
 from __future__ import annotations
 
+import pytest
+
 from src.shared.python.motion_pipeline.contracts import (
     Marker,
     MarkerFrame,
@@ -20,6 +22,8 @@ from src.shared.python.motion_pipeline.orchestrator import (
 )
 
 from ._local_fixtures import make_3dof_phantom_rig
+
+pytestmark = pytest.mark.unit
 
 
 def test_default_ik_backend_is_geometric() -> None:

--- a/tests/unit/motion_pipeline/ik/test_pinocchio_backend.py
+++ b/tests/unit/motion_pipeline/ik/test_pinocchio_backend.py
@@ -15,6 +15,8 @@ from src.shared.python.motion_pipeline.ik.pinocchio_backend import PinocchioIKSo
 
 from ._local_fixtures import make_3dof_phantom_rig, make_phantom_marker_trajectory
 
+pytestmark = pytest.mark.unit
+
 
 def test_pinocchio_solver_constructs_without_pinocchio() -> None:
     solver = PinocchioIKSolver()

--- a/tests/unit/motion_pipeline/ik/test_stub_backends_raise.py
+++ b/tests/unit/motion_pipeline/ik/test_stub_backends_raise.py
@@ -23,6 +23,8 @@ from src.shared.python.motion_pipeline.ik.pinocchio_backend import PinocchioIKSo
 
 from ._local_fixtures import make_3dof_phantom_rig, make_phantom_marker_trajectory
 
+pytestmark = pytest.mark.unit
+
 _STUB_SOLVERS = [
     ("mujoco", MuJoCoIKSolver),
     ("drake", DrakeIKSolver),

--- a/tests/unit/motion_pipeline/matching/test_trajopt_drake.py
+++ b/tests/unit/motion_pipeline/matching/test_trajopt_drake.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 from unittest.mock import patch
 
 
+import pytest
+
 from src.shared.python.motion_pipeline.matching.base import MotionMatchingResult
 from src.shared.python.motion_pipeline.matching.trajopt_drake import (
     DrakeTrajoptMatchingSolver,
 )
 
 from ._local_fixtures import make_pendulum_reference_trajectory, make_simple_rig
+
+pytestmark = pytest.mark.unit
 
 
 def test_drake_trajopt_solver_constructs() -> None:

--- a/tests/unit/motion_pipeline/test_model_bridge.py
+++ b/tests/unit/motion_pipeline/test_model_bridge.py
@@ -16,6 +16,8 @@ from src.shared.python.motion_pipeline.model_bridge import (
     rig_to_urdf,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _rig() -> SkeletonRig:
     joints = {

--- a/tests/unit/optimization/test_batch_swing_optimizer.py
+++ b/tests/unit/optimization/test_batch_swing_optimizer.py
@@ -19,6 +19,8 @@ from src.shared.python.optimization.batch_swing_optimizer import (
 from src.shared.python.simulation_backends.model_params import GolfModelParams
 from src.shared.python.simulation_backends.protocol import BatchTrace
 
+pytestmark = pytest.mark.unit
+
 
 def _trace(q: np.ndarray, v: np.ndarray, dt: float = 0.01) -> BatchTrace:
     t = np.arange(q.shape[1]) * dt

--- a/tests/unit/optimization/test_casadi_backend_unit.py
+++ b/tests/unit/optimization/test_casadi_backend_unit.py
@@ -24,6 +24,8 @@ from src.shared.python.optimization.casadi_backend import (
 )
 from src.shared.python.optimization.model_provider import swing_joint_limits
 
+pytestmark = pytest.mark.unit
+
 
 def test_mocked_casadi_counts_as_unavailable() -> None:
     assert casadi_available() is False

--- a/tests/unit/optimization/test_crocoddyl_backend_unit.py
+++ b/tests/unit/optimization/test_crocoddyl_backend_unit.py
@@ -18,6 +18,8 @@ from src.shared.python.optimization.crocoddyl_backend import (
     solve_swing_ddp,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_mocked_stack_counts_as_unavailable() -> None:
     assert crocoddyl_available() is False

--- a/tests/unit/optimization/test_model_provider.py
+++ b/tests/unit/optimization/test_model_provider.py
@@ -14,6 +14,8 @@ from src.shared.python.optimization.model_provider import (
     swing_urdf,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_rig_has_one_dof_per_swing_joint() -> None:
     rig = build_swing_rig()

--- a/tests/unit/optimization/test_smooth_costs.py
+++ b/tests/unit/optimization/test_smooth_costs.py
@@ -20,6 +20,8 @@ from src.shared.python.optimization.smooth_costs import (
     softplus_excess,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _trajectory(vel_scale: float, torque_scale: float, trunk_peak: float):
     t = np.linspace(0.0, 1.0, 50)

--- a/tests/unit/packaging/test_pyinstaller_spec.py
+++ b/tests/unit/packaging/test_pyinstaller_spec.py
@@ -8,6 +8,8 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).parent.parent.parent.parent
 SPEC_PATH = ROOT / "sidekick.spec"
 BUILD_SCRIPT = ROOT / "scripts" / "packaging" / "build_sidekick_binary.py"

--- a/tests/unit/packaging/test_standalone_sidekick_workflows.py
+++ b/tests/unit/packaging/test_standalone_sidekick_workflows.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import yaml
+import pytest
+
+pytestmark = pytest.mark.unit
 
 ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_WORKFLOW = ROOT / ".github" / "workflows" / "package-standalone-sidekick.yml"

--- a/tests/unit/pose_estimation/test_registry.py
+++ b/tests/unit/pose_estimation/test_registry.py
@@ -23,6 +23,8 @@ from src.shared.python.pose_estimation.registry import (
     unregister_estimator,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeEstimator:
     def __init__(self, **options: Any) -> None:

--- a/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
+++ b/tests/unit/repo_hygiene/test_no_shadow_of_tools_shared.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
 VENDOR_SRC = ROOT / "vendor" / "ud-tools" / "src" / "shared" / "python"
 LOCAL_SRC = ROOT / "src" / "shared" / "python"

--- a/tests/unit/repo_hygiene/test_vendor_submodule_clean.py
+++ b/tests/unit/repo_hygiene/test_vendor_submodule_clean.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
 VENDOR_DIR = ROOT / "vendor" / "ud-tools"
 

--- a/tests/unit/research/test_momentum_question_readiness.py
+++ b/tests/unit/research/test_momentum_question_readiness.py
@@ -9,6 +9,8 @@ from scripts.research.proximal_distal_energy.momentum_question_readiness import 
     build_readiness_audit,
 )
 
+pytestmark = pytest.mark.unit
+
 ROOT = Path(__file__).resolve().parents[3]
 ARTICLE = ROOT / "docs/research/proximal_distal_energy_transfer"
 

--- a/tests/unit/test_estimator_type_consistency.py
+++ b/tests/unit/test_estimator_type_consistency.py
@@ -9,8 +9,12 @@ two Python surfaces to a single set; the UI list is pinned by
 
 from __future__ import annotations
 
+import pytest
+
 from src.api.config import VALID_ESTIMATOR_TYPES
 from src.shared.python.pose_estimation.interface import IMPLEMENTED_ESTIMATOR_TYPES
+
+pytestmark = pytest.mark.unit
 
 
 def test_api_estimator_set_matches_pipeline_implementations() -> None:

--- a/tests/unit/test_mujoco_physics_engine.py
+++ b/tests/unit/test_mujoco_physics_engine.py
@@ -15,7 +15,7 @@ from src.shared.python.engine_core.engine_availability import (
 )
 
 # Skip entire module if MuJoCo is not available
-pytestmark = skip_if_unavailable("mujoco")
+pytestmark = [skip_if_unavailable("mujoco"), pytest.mark.unit]
 
 # Explicit attribute lists for MuJoCo C++ types that may not be importable
 # as Python classes for spec=.

--- a/tests/unit/test_security_and_module_fixes.py
+++ b/tests/unit/test_security_and_module_fixes.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Issue #1779 – SECRET_KEY fallback
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_unreal_integration/test_mesh_loader.py
+++ b/tests/unit/test_unreal_integration/test_mesh_loader.py
@@ -23,6 +23,8 @@ from src.unreal_integration.mesh_loader import (
     UnsupportedFormatError,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestMeshFormat:
     """Tests for MeshFormat enum."""

--- a/tests/unit/tools/humanoid_character_builder/test_smplx_betas.py
+++ b/tests/unit/tools/humanoid_character_builder/test_smplx_betas.py
@@ -23,6 +23,8 @@ from src.shared.python.humanoid_character_builder.generators._smplx_generator im
     SMPLXMeshGenerator,
 )
 
+pytestmark = pytest.mark.unit
+
 _MEASURED_BETAS = [0.5, -1.2, 0.0, 0.3, -0.7, 1.1, 0.05, -0.4, 0.9, 0.2]
 
 

--- a/tests/unit/validation_pkg/test_kaggle_validation.py
+++ b/tests/unit/validation_pkg/test_kaggle_validation.py
@@ -14,6 +14,8 @@ from src.shared.python.validation_pkg.kaggle_validation import (
     load_kaggle_dataset,
 )
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # ShotRecord dataclass
 # ---------------------------------------------------------------------------

--- a/tests/unit/visualization/test_rerun_renderer.py
+++ b/tests/unit/visualization/test_rerun_renderer.py
@@ -24,6 +24,8 @@ from src.shared.python.visualization.rerun_renderer import (
 )
 from src.shared.python.visualization.viewport import ViewportOverlayPayload
 
+pytestmark = pytest.mark.unit
+
 
 def _payload(*, with_markers: bool = False, with_wrench: bool = False):
     n = 4


### PR DESCRIPTION
Closes #8656.

`scripts/ci/check_suite_marker_ratchet.py` has been **red on `main`**. This makes it exit **0 without `--update-baseline`**.

88 files, one module-level `pytestmark` each: **67 `unit`, 19 `scientific`, 3 `integration`** — classifying **1017 previously-unmarked tests** (365 net-new drift plus 652 grandfathered baseline entries the same file-level markers also cover).

## Why not `--update-baseline`

It is the one-line fix and it is wrong: it would accept all of them as permanent debt without anyone deciding what any of them should be, leaving a green gate that asserts nothing. A permanently-red gate is bad; a permanently-green gate that asserts nothing is worse, because it teaches people to trust it.

The marker is not decoration — it selects the CI lane. Several of these files carried only a *capability* marker (`requires_rerun`) which says what a test needs, not which suite it belongs to.

## Lane changes — the material consequence

**Default lane: zero tests moved, in or out.** `pytest --collect-only -q` is byte-identical before and after (2136 files, same per-file counts), verified by revert → collect → re-apply → collect → diff. No `slow`/`live_simulation`/`e2e`/`requires_network` was added anywhere.

**One lane does change:** the 67 `unit` files newly enter the required Green-Suite Unit Gate (`-m unit --timeout=60 -n 4`), which is merge-blocking — **1004 collected tests**. I verified independently that the slowest is **4.45 s**, far under the 60 s timeout.

Capability markers were preserved, not replaced: `requires_rerun` per-test; `anyio` and `skip_if_unavailable("mujoco")` became list-form `pytestmark`.

## Judgement calls worth a reviewer's eye

1. **A 163 s test is deliberately NOT marked `slow`.** No CI lane in this repo runs slow tests — every invocation says `not slow`, and even the mujoco lane is `requires_mujoco and not slow`. Marking it `slow` would **delete its coverage**, not relocate it. Left `scientific` with the author's existing `timeout(360)`. Same reasoning kept the 103 s `test_dependency_direction.py` at `integration` rather than `slow` — which also keeps it out of the 60 s unit gate.
2. `tests/acceptance/test_counterfactual_experiments.py` → `scientific`; no marked siblings there, and `integration` is equally arguable.
3. Four research *governance* files → `unit`, not `scientific`: they assert registry structure with no numerics, so `scientific` would be a false claim — though they sit in a directory where `scientific` dominates.

## Deliberately not done

The ratchet now reports "baseline can shrink by 1891 entries" — 652 are the debt this pays down, ~1239 were already stale on `main` (renamed/deleted tests). `suite_marker_baseline.json` is untouched so that shrink is a separate reviewable diff rather than 1891 lines buried here.