### PR TITLE
fix(calc-backend): restore expression validation on symbolic solver (#8675)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -115,6 +115,41 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-08-15** - Restored input validation on the symbolic solver router
+  (`src/shared/python/calc_backend/routers/symbolic_solver.py`, issue #8675).
+  This file is a shadow copy of a module owned by the Tools repository. Tools
+  hardened its copy on 2026-07-22 by guarding every `parse_expr` call with
+  `validate_expression`; the shadow was forked on 2026-05-20 and never received
+  that change, so it carried six fewer guards than upstream while keeping all
+  four parse sites. The removal was not deliberate — `validate_expression` has
+  no history in this file at all — it is drift by omission.
+
+  The exposure was not theoretical. `sympy.parse_expr` is an _evaluating_
+  parser, and all three affected endpoints (`/api/calc/symbolic/solve`,
+  `/derivative`, `/simplify`) take their expression from the request body, so
+  the input is remote by construction. Against the unguarded module,
+  `__import__("os").getcwd()` executed and returned the server's working
+  directory in the response error string, and `9**9**9**9` hung the worker
+  in an uninterruptible bignum computation that the thread-based pytest
+  timeout could not kill.
+
+  The fix re-adds `from src.shared.python.safe_eval import validate_expression`
+  (UD's own `src.`-prefixed convention, matching the sibling `ode_solver`
+  router) and the four upstream call sites: both sides of an `lhs = rhs`
+  equation, the bare-expression branch of `/solve`, and the single expression
+  on `/derivative` and `/simplify`. Note that a `vendor/ud-tools` submodule
+  bump cannot fix this: the submodule is unpopulated, and
+  `src/shared/python` precedes it in resolution, so the shadow is what is
+  actually imported.
+
+  Regression coverage pins the guard to behaviour rather than to its presence:
+  each endpoint must reject attribute-based calls, attribute access, and
+  exponentiation bombs; legitimate work (`x**2 - 4 = 0`, `x^2` via
+  `convert_xor`, `sin(x)**2 + cos(x)**2`) must still solve; the payload's
+  observable side effect must never appear in a response; and an
+  instrumented-ordering test asserts `parse_expr` never runs ahead of
+  `validate_expression` on any path.
+
 - **2026-08-14** - Rebuilt BunkerShot3D as a multi-fidelity wedge-design tool
   under epic #8607 (ADR-0032). The package is now organised around the design
   question — given two sole geometries, which performs better, in what

--- a/src/shared/python/calc_backend/routers/symbolic_solver.py
+++ b/src/shared/python/calc_backend/routers/symbolic_solver.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
+from src.shared.python.safe_eval import validate_expression
+
 try:
     import sympy as sp
     from sympy.parsing.sympy_parser import (
@@ -125,6 +127,8 @@ def solve_equation(request: SymbolicSolveRequest) -> SymbolicSolveResponse:
         # Parse the equation
         if "=" in request.equation:
             lhs, rhs = request.equation.split("=", 1)
+            validate_expression(lhs.strip())
+            validate_expression(rhs.strip())
             lhs_expr = parse_expr(
                 lhs.strip(),
                 transformations=standard_transformations + (convert_xor,),
@@ -136,6 +140,7 @@ def solve_equation(request: SymbolicSolveRequest) -> SymbolicSolveResponse:
             equation = sp.Eq(lhs_expr, rhs_expr)
         else:
             # Assume expression equals zero
+            validate_expression(request.equation.strip())
             expr = parse_expr(
                 request.equation,
                 transformations=standard_transformations + (convert_xor,),
@@ -171,6 +176,7 @@ def compute_derivative(
         )
 
     try:
+        validate_expression(request.expression.strip())
         expr = parse_expr(
             request.expression,
             transformations=standard_transformations + (convert_xor,),
@@ -193,6 +199,7 @@ def simplify_expression(request: SymbolicSimplifyRequest) -> SymbolicSimplifyRes
         )
 
     try:
+        validate_expression(request.expression.strip())
         expr = parse_expr(
             request.expression,
             transformations=standard_transformations + (convert_xor,),

--- a/src/shared/python/calc_backend/tests/test_symbolic_solver.py
+++ b/src/shared/python/calc_backend/tests/test_symbolic_solver.py
@@ -54,9 +54,9 @@ class TestSymbolicSolve:
             "/api/calc/symbolic/solve",
             json={"equation": "x**2 - 4 = 0", "variable": "x"},
         )
-        if response.json().get("available"):
+        data = response.json()
+        if data.get("available"):
             assert response.status_code == 200
-            data = response.json()
             assert "-2" in data["solutions"] or "2" in data["solutions"]
         else:
             assert response.status_code == 200
@@ -99,9 +99,9 @@ class TestSymbolicDerivative:
             "/api/calc/symbolic/derivative",
             json={"expression": "x**3 + 2*x", "variable": "x"},
         )
-        if response.json().get("available"):
+        data = response.json()
+        if data.get("available"):
             assert response.status_code == 200
-            data = response.json()
             assert "3*x**2" in data["derivative"] or "3*x^2" in data["derivative"]
         else:
             assert response.status_code == 200
@@ -136,11 +136,312 @@ class TestSymbolicSimplify:
             "/api/calc/symbolic/simplify",
             json={"expression": "(x**2 - 1)/(x - 1)"},
         )
-        if response.json().get("available"):
+        data = response.json()
+        if data.get("available"):
             assert response.status_code == 200
-            data = response.json()
             # (x^2 - 1)/(x - 1) = x + 1
             assert "x" in str(data.get("simplified", ""))
         else:
             assert response.status_code == 200
             assert data["available"] is False
+
+
+# ── Input validation (issue #8675) ──────────────────────────────────────
+# ``sympy.parse_expr`` is an *evaluating* parser: without a guard, an
+# attribute-based call such as ``__import__("os").getcwd()`` is executed by
+# the parser itself. These endpoints are remote by construction, so every
+# ``parse_expr`` call site must be preceded by ``validate_expression``.
+
+#: Payload that ``parse_expr`` would otherwise execute (arbitrary import +
+#: attribute call). ``validate_expression`` rejects it as an
+#: "Attribute-based function call".
+ATTRIBUTE_CALL_PAYLOAD = '__import__("os").getcwd()'
+
+#: Payload rejected by the node-type allowlist (``ast.Attribute``).
+ATTRIBUTE_ACCESS_PAYLOAD = "x.__class__"
+
+#: Payload rejected by the exponentiation-bomb bound (MAX_POW_EXPONENT).
+POW_BOMB_PAYLOAD = "9**9**9**9"
+
+
+class TestSymbolicSolverRejectsUnsafeInput:
+    """Every endpoint must refuse expressions the validator blocks."""
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (ATTRIBUTE_CALL_PAYLOAD, "Attribute-based function calls not allowed"),
+            (ATTRIBUTE_ACCESS_PAYLOAD, "Unsafe operation detected: Attribute"),
+            (POW_BOMB_PAYLOAD, "Exponent too large"),
+        ],
+    )
+    def test_solve_rejects_unsafe_bare_equation(
+        self, client: TestClient, payload: str, expected: str
+    ) -> None:
+        """Solve rejects unsafe input on the no-``=`` (bare expression) branch."""
+        response = client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": payload, "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is not None, f"{payload!r} was not rejected"
+        assert expected in data["error"]
+        assert not data["solutions"]
+
+    @pytest.mark.parametrize(
+        "equation",
+        [
+            f"{ATTRIBUTE_CALL_PAYLOAD} = 0",  # unsafe on the left-hand side
+            f"0 = {ATTRIBUTE_CALL_PAYLOAD}",  # unsafe on the right-hand side
+        ],
+    )
+    def test_solve_rejects_unsafe_either_side_of_equals(
+        self, client: TestClient, equation: str
+    ) -> None:
+        """Solve validates *both* sides of an ``lhs = rhs`` equation."""
+        response = client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": equation, "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is not None, f"{equation!r} was not rejected"
+        assert "Attribute-based function calls not allowed" in data["error"]
+        assert not data["solutions"]
+
+    def test_derivative_rejects_unsafe_expression(self, client: TestClient) -> None:
+        """Derivative rejects an attribute-based call payload."""
+        response = client.post(
+            "/api/calc/symbolic/derivative",
+            json={"expression": ATTRIBUTE_CALL_PAYLOAD, "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is not None
+        assert "Attribute-based function calls not allowed" in data["error"]
+        assert data["derivative"] is None
+
+    def test_simplify_rejects_unsafe_expression(self, client: TestClient) -> None:
+        """Simplify rejects an attribute-based call payload."""
+        response = client.post(
+            "/api/calc/symbolic/simplify",
+            json={"expression": ATTRIBUTE_CALL_PAYLOAD},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is not None
+        assert "Attribute-based function calls not allowed" in data["error"]
+        assert data["simplified"] is None
+
+    def test_unsafe_payload_is_never_evaluated(self, client: TestClient) -> None:
+        """The rejected payload must not reach the evaluating parser.
+
+        ``__import__("os").getcwd()`` returns the server's working directory
+        when it is actually executed, so leaking that string into the response
+        is direct evidence the guard was bypassed.
+        """
+        import os
+
+        # Compare against the *parsed* body: on Windows the raw response text
+        # JSON-escapes backslashes, which would hide a leaked path. The leaf
+        # directory name contains no separators and survives either way.
+        cwd = os.getcwd()
+        leaf = os.path.basename(cwd)
+        for endpoint, body in (
+            (
+                "/api/calc/symbolic/solve",
+                {"equation": ATTRIBUTE_CALL_PAYLOAD, "variable": "x"},
+            ),
+            (
+                "/api/calc/symbolic/derivative",
+                {"expression": ATTRIBUTE_CALL_PAYLOAD, "variable": "x"},
+            ),
+            (
+                "/api/calc/symbolic/simplify",
+                {"expression": ATTRIBUTE_CALL_PAYLOAD},
+            ),
+        ):
+            response = client.post(endpoint, json=body)
+            rendered = " ".join(
+                str(value) for value in response.json().values() if value is not None
+            )
+            for marker in (cwd, leaf):
+                assert marker not in rendered, (
+                    f"{endpoint} evaluated the payload and leaked "
+                    f"the working directory ({marker!r})"
+                )
+
+
+class TestSymbolicSolverAcceptsLegitimateInput:
+    """The guard must not break ordinary symbolic work."""
+
+    def test_solve_accepts_equation_with_equals(self, client: TestClient) -> None:
+        """A normal ``lhs = rhs`` equation still solves."""
+        response = client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": "x**2 - 4 = 0", "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert sorted(data["solutions"]) == ["-2", "2"]
+
+    def test_solve_accepts_bare_expression(self, client: TestClient) -> None:
+        """A bare expression (implicitly ``== 0``) still solves."""
+        response = client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": "x**2 - 9", "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert sorted(data["solutions"]) == ["-3", "3"]
+
+    def test_solve_accepts_caret_exponent(self, client: TestClient) -> None:
+        """``convert_xor`` input (``x^2``) survives validation.
+
+        ``^`` is a legal ``ast.BinOp``/``BitXor`` to Python's parser only if
+        the validator allows it; this pins the interaction between the guard
+        and the ``convert_xor`` transformation.
+        """
+        response = client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": "x^2 - 4 = 0", "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert sorted(data["solutions"]) == ["-2", "2"]
+
+    def test_derivative_accepts_polynomial(self, client: TestClient) -> None:
+        """A normal derivative still computes."""
+        response = client.post(
+            "/api/calc/symbolic/derivative",
+            json={"expression": "x**3 + 2*x", "variable": "x"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert data["derivative"] == "3*x**2 + 2"
+
+    def test_simplify_accepts_rational(self, client: TestClient) -> None:
+        """A normal simplification still runs."""
+        response = client.post(
+            "/api/calc/symbolic/simplify",
+            json={"expression": "(x**2 - 1)/(x - 1)"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert data["simplified"] == "x + 1"
+
+    def test_simplify_accepts_function_call(self, client: TestClient) -> None:
+        """Bare-name function calls (``sin(x)``) are still permitted."""
+        response = client.post(
+            "/api/calc/symbolic/simplify",
+            json={"expression": "sin(x)**2 + cos(x)**2"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert data["simplified"] == "1"
+
+
+class TestParseExprIsUnreachableWithoutValidation:
+    """``parse_expr`` must never run on input the validator has not cleared."""
+
+    @staticmethod
+    def _instrument(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+        """Record the interleaving of validate/parse calls on the router."""
+        import calc_backend.routers.symbolic_solver as mod
+
+        events: list[tuple[str, str]] = []
+        real_validate = mod.validate_expression
+        real_parse = mod.parse_expr
+
+        def recording_validate(expression: str, *args: object, **kwargs: object):
+            events.append(("validate", expression))
+            return real_validate(expression, *args, **kwargs)
+
+        def recording_parse(expression: str, *args: object, **kwargs: object):
+            events.append(("parse", expression))
+            return real_parse(expression, *args, **kwargs)
+
+        monkeypatch.setattr(mod, "validate_expression", recording_validate)
+        monkeypatch.setattr(mod, "parse_expr", recording_parse)
+        return events
+
+    @staticmethod
+    def _assert_never_parses_unvalidated(events: list[tuple[str, str]]) -> None:
+        """Assert no ``parse`` ever outruns the validations preceding it."""
+        assert events, "endpoint performed no parsing at all"
+        assert events[0][0] == "validate", (
+            f"first operation was {events[0][0]!r}, expected 'validate'"
+        )
+        validated = 0
+        parsed = 0
+        for kind, _ in events:
+            if kind == "validate":
+                validated += 1
+            else:
+                parsed += 1
+            assert parsed <= validated, (
+                f"parse_expr ran ahead of validate_expression: {events}"
+            )
+        assert parsed == validated, (
+            f"expected one validation per parse, got {validated} validations "
+            f"for {parsed} parses: {events}"
+        )
+
+    def test_solve_with_equals_validates_every_parse(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both sides of an equation are validated before either is parsed."""
+        events = self._instrument(monkeypatch)
+        client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": "x**2 - 4 = 0", "variable": "x"},
+        )
+        self._assert_never_parses_unvalidated(events)
+        assert [e[0] for e in events] == ["validate", "validate", "parse", "parse"]
+
+    def test_solve_bare_expression_validates_every_parse(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The implicit ``== 0`` branch validates before parsing."""
+        events = self._instrument(monkeypatch)
+        client.post(
+            "/api/calc/symbolic/solve",
+            json={"equation": "x**2 - 4", "variable": "x"},
+        )
+        self._assert_never_parses_unvalidated(events)
+
+    def test_derivative_validates_every_parse(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The derivative endpoint validates before parsing."""
+        events = self._instrument(monkeypatch)
+        client.post(
+            "/api/calc/symbolic/derivative",
+            json={"expression": "x**3 + 2*x", "variable": "x"},
+        )
+        self._assert_never_parses_unvalidated(events)
+
+    def test_simplify_validates_every_parse(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The simplify endpoint validates before parsing."""
+        events = self._instrument(monkeypatch)
+        client.post(
+            "/api/calc/symbolic/simplify",
+            json={"expression": "(x**2 - 1)/(x - 1)"},
+        )
+        self._assert_never_parses_unvalidated(events)
+
+    def test_router_imports_the_validator(self) -> None:
+        """The router module must expose the shared validator (not a local stub)."""
+        import calc_backend.routers.symbolic_solver as mod
+        from src.shared.python.safe_eval import validate_expression
+
+        assert mod.validate_expression is validate_expression


### PR DESCRIPTION
Fixes #8675.

## What this is

`src/shared/python/calc_backend/routers/symbolic_solver.py` is UpstreamDrift's shadow copy of a module the **Tools** repository owns. The shadow kept every `parse_expr` call and dropped every guard in front of them.

| | Tools `origin/main` | UpstreamDrift (before) | UpstreamDrift (after) |
|---|---|---|---|
| `validate_expression` occurrences | **6** | **0** | **6** |
| `parse_expr(` call sites | 5 | 5 | 5 |

**This restores upstream behaviour rather than adding something new.** Every line here already exists in Tools; nothing is invented. Unlike most drift in this audit, Tools is the correct side and the local copy is the one that regressed.

## Was the removal deliberate?

**No.** `git log -S validate_expression` on this file returns *nothing* — the guard has no history in UpstreamDrift at all, so there is no commit removing it and no message justifying it. The timeline is a missed sync:

- **2026-05-20** — shadow copy lands in UD (`8bb184cfb`), mirroring Tools as it stood then, ungurded on both sides.
- **2026-07-22** — Tools hardens *its* copy with `validate_expression` (`dc5291949`).
- That change was never propagated downstream.

Drift by omission, not a decision.

## Why it matters

`sympy.parse_expr` is an **evaluating** parser, and all three endpoints take the expression straight from the request body, so the input is remote by construction. This was not theoretical — against the unguarded module:

- `__import__("os").getcwd()` **executed** and its result came back to the caller inside the response error string (arbitrary import + attribute call, plus path disclosure).
- `9**9**9**9` **hung the worker** in an uninterruptible bignum computation — pytest's thread-based `--timeout` could not kill it.

## A vendor bump will not fix this

`vendor/ud-tools` is an **unpopulated** submodule, and `src/shared/python` precedes it in resolution. `calc_backend.routers.symbolic_solver` resolves to the shadow, verified directly:

```
RESOLVED TO: ...\src/shared/python\calc_backend\routers\symbolic_solver.py
has validate_expression? False
```

## The change

Restores `from src.shared.python.safe_eval import validate_expression` — UD's own `src.`-prefixed convention, matching the sibling `ode_solver` router — and the four upstream call sites: both sides of an `lhs = rhs` equation, the bare-expression branch of `/solve`, and the single expression on `/derivative` and `/simplify`.

## Tests

Written first and confirmed failing against the unguarded module (12 failures), now passing. They pin *behaviour*, not the guard's presence:

- **Rejection** — each endpoint refuses attribute-based calls, attribute access, and exponentiation bombs, asserting the validator's own message so a coincidental sympy parse error cannot pass for a block. Both `lhs` and `rhs` of an equation are covered separately.
- **No evaluation** — the payload's observable side effect (the server's working directory) must never appear in a response. Compares against the *parsed* body: on Windows the raw text JSON-escapes backslashes, which initially masked a real leak.
- **Legitimate use still works** — `x**2 - 4 = 0`, the bare `x**2 - 9` branch, `x^2` via `convert_xor`, `sin(x)**2 + cos(x)**2`, and a normal derivative all still solve.
- **`parse_expr` unreachable without validation** — instruments both functions and asserts the interleaving: the first operation is always a validation, parses never outrun validations at any prefix, and counts match one-to-one on every path.

Also hoists `data = response.json()` above the branch in three pre-existing tests where it was bound only in the `if` arm and read in the `else` — a latent `NameError`, and a pre-push mypy blocker once this file is touched.

## Verification

- `pytest src/shared/python/calc_backend/tests` — all pass (the pow-bomb case now resolves in 0.02 s instead of hanging).
- `ruff check` + `ruff format --check` — clean.
- `mypy` — clean on both changed Python files.
- SPEC.md updated (dated 2026-08-15) for the `src/**` freshness gate.

One unrelated pre-existing failure, `tests/unit/calc_backend/test_contracts_ode_solver.py::TestODESolverResponse::test_default_success_true`, fails identically with this branch's changes stashed. `tests/` also has 82 pre-existing collection errors (`No module named 'utils'`, missing `cv2`); none are in calc_backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
