### PR TITLE
fix(hygiene): classify chat/_qt/runtime.py so the wheel build stops raising

### DIFF
--- a/scripts/config/shared_python_ownership_exceptions.yaml
+++ b/scripts/config/shared_python_ownership_exceptions.yaml
@@ -1,5 +1,10 @@
 schema_version: 1
 paths:
+  chat/_qt/runtime.py:
+    owner: Unresolved
+    rationale: Extracted from the Tools-owned chat/_chat_dock_widget_qt.py by PR #8553; every sibling in chat/_qt/ has a Tools counterpart, so this helper belongs upstream rather than here.
+    tracking_issue: 8687
+    review_date: "2026-12-31"
   sidekick/calculators/conversion/_concentration.py:
     owner: UpstreamDrift
     rationale: UpstreamDrift-specific process conversion implementation with no same-relative Tools source.


### PR DESCRIPTION
## The build hook, not just a test

`src/shared/python/chat/_qt/runtime.py` is the only module in `chat/_qt/`
without a same-relative counterpart in the pinned Tools revision
(`vendor/ud-tools` @ `4744422d3`). PR #8553 created it by extracting
WebSocket/terminal helpers out of the Tools-owned
`chat/_chat_dock_widget_qt.py`, and no ownership record was added.

That omission breaks two separate things.

**1. CI cannot install the package.** `build_hooks.py::_register_tools_packages`
requires a manifest entry for every local-only `.py` under `chat/` or
`sidekick/`, and raises otherwise. This is the current failure in the
`Install Unit Test Dependencies` step:

```
RuntimeError: Local shared extension lacks ownership classification: chat/_qt/runtime.py
```

**2. The hygiene guard fails.**
`test_no_counterpart_files_have_file_level_ownership_manifest` asserts
`set(entries) == ambiguous_paths`. This file was the sole difference — 33
manifest entries vs 34 ambiguous paths, with no stale entries in the other
direction.

## Why `Unresolved` and not `UpstreamDrift`

The behaviour was extracted from a Tools-owned module, so ownership is
genuinely unsettled — this is not UpstreamDrift-specific domain code like the
33 `sidekick/` process calculators already in the manifest.

`Unresolved` also keeps the file out of the built wheel. That is the correct
outcome here: Tools canonical files win every same-relative path, and Tools''
`_chat_dock_widget_qt.py` imports `_qt.ai_dropdowns`, `_qt.exports`,
`_qt.sessions` and friends but **not** `_qt.runtime`, so the wheel stays
self-consistent without it.

## Verification

Requires the vendor submodule, which CI does not currently check out:

```
git submodule update --init vendor/ud-tools
python -m pytest tests/unit/repo_hygiene/test_tools_child_copy_contract.py -p no:randomly
```

12 passed. That includes `test_current_branch_does_not_edit_tools_child_copies`,
which stays green because this PR touches no shared Python file.

The `build_hooks.py` manifest parser is a hand-rolled regex reader, not
`yaml.safe_load`, so it was checked separately against the edited file: 34
entries parsed, `chat/_qt/runtime.py -> Unresolved`.

## Follow-up

#8687 tracks upstreaming the extraction into `D-sorganization/Tools`. The guard
asserts set equality, so it will demand this entry be **deleted** once Tools
gains a same-relative counterpart — the manifest cannot silently rot.

Part of the `tests/unit/repo_hygiene` failures surfaced by #8674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)