### PR TITLE
ci: route the required quality-gate check (and the rust lanes) to hosted runners

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -985,7 +985,19 @@ jobs:
         rust-wheel-parity,
       ]
     if: always()
-    runs-on: d-sorg-fleet-docker
+    # This job is the ONLY required branch-protection check on `main`, and it
+    # carries no gate logic of its own - it just echoes six `needs` results.
+    # Pinning it to the fleet meant every merge in the repo waited on a
+    # self-hosted Docker slot for a five-second summary job. It deliberately
+    # does NOT consume `needs.pick-runner.outputs.runner`: the required check
+    # must not inherit the dispatcher as an extra failure mode. Public repos
+    # get free unmetered hosted runners; private repos still fall through to
+    # the fleet, so no Actions minutes are ever billed.
+    #
+    # Reverting: set the repo variable CI_RUNNER_MODE=local.
+    runs-on:
+      ${{ !github.event.repository.private && vars.CI_RUNNER_MODE != 'local' && 'ubuntu-latest' ||
+      'd-sorg-fleet-docker' }}
     timeout-minutes: 5
     steps:
       - name: Aggregate quality gate results
@@ -2112,7 +2124,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-    runs-on: d-sorg-fleet-docker
+    # The matrix already declares `ubuntu-latest` and several steps gate on
+    # `matrix.os == 'ubuntu-latest'`, so the fleet pin was a straight
+    # contradiction: hosted-shaped work queued behind a self-hosted slot.
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 25
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
@@ -2386,7 +2401,11 @@ jobs:
 
   rust-quickstart:
     name: Rust Quickstart
-    runs-on: d-sorg-fleet-docker
+    # No `needs: pick-runner` on this job, so it routes directly rather than
+    # gaining a dependency edge just to learn where to run.
+    runs-on:
+      ${{ !github.event.repository.private && vars.CI_RUNNER_MODE != 'local' && 'ubuntu-latest' ||
+      'd-sorg-fleet-docker' }}
     timeout-minutes: 15
     steps:
       - name: Clean corrupt git objects
@@ -2509,7 +2528,10 @@ jobs:
   rust-wheel-parity:
     name: rust-wheel-parity
     needs: pick-runner
-    runs-on: d-sorg-fleet-docker
+    # In the required `quality-gate` aggregate's `needs`, so a fleet pin here
+    # blocked every merge a second time. Pure `cargo`/`maturin` work with no
+    # fleet-local state, so it follows the dispatcher like its siblings.
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 30
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home


### PR DESCRIPTION
## Problem

`quality-gate` is the **only required branch-protection check** on `main`
(`required_status_checks.contexts == ["quality-gate"]`, verified via the API).
In `ci-standard.yml` that job was pinned to `runs-on: d-sorg-fleet-docker`
despite carrying **no gate logic of its own** — it only echoes six `needs`
results and exits non-zero if any of them is not `success`.

So every merge in this repo waited on a self-hosted Docker slot for a
five-second summary job. `rust-wheel-parity` is in that job's `needs` and was
also fleet-pinned, so the required path was blocked **twice**.

Measured fleet state at the time of this change: 25 self-hosted runners,
5 online / 20 offline. Of the offline, 11 carry `d-sorg-bandwidth-draining`
(deliberate WAN steady state) and 9 carry `d-sorg-fleet,d-sorg-fleet-docker`
and are genuinely down. The 5th online runner carries no `d-sorg-*` label and
cannot serve these jobs, leaving **4 usable fleet runners, all busy**, against
~100 queued runs here and ~100 in `Tools`. No `CI Standard` run in the last 30
reached `success` or `failure` — they were all `pending` or `cancelled`.

## Fix

Reuse the canonical visibility-aware dispatcher from
`Repository_Management/Project_Template/.github/workflows/ci-standard.yml`
(already in production in `runner-dashboard`) rather than inventing a pattern:

```yaml
runs-on: ${{ !github.event.repository.private && vars.CI_RUNNER_MODE != 'local' && 'ubuntu-latest' || 'd-sorg-fleet-docker' }}
```

This repo is public, so standard GitHub-hosted runners are **free and
unmetered**. `orgs/D-sorganization/actions/hosted-runners` reports
`total_count: 0`, so there are no *larger* runners that would bill even on a
public repo. Private repos still fall through to the fleet, so nothing new is
ever billed.

Moving public-repo CI off the self-hosted fleet is also a **security
improvement**: public repo + self-hosted runners is a fork-PR liability.

## What moved

| Job | Was | Now | Why |
| --- | --- | --- | --- |
| `quality-gate` | `d-sorg-fleet-docker` | direct visibility expression | The required check. Deliberately does **not** consume `needs.pick-runner.outputs.runner` — the one check that gates every merge should not inherit the dispatcher as an extra failure mode. |
| `rust-wheel-parity` | `d-sorg-fleet-docker` | `needs.pick-runner.outputs.runner` | In `quality-gate`'s `needs`, so it blocked merges too. Pure `cargo`/`maturin`, no fleet-local state. |
| `rust-quality-gate` | `d-sorg-fleet-docker` | `needs.pick-runner.outputs.runner` | Its matrix already declared `os: [ubuntu-latest]` and several steps gate on `matrix.os == 'ubuntu-latest'` — the fleet pin contradicted the job's own shape. |
| `rust-quickstart` | `d-sorg-fleet-docker` | direct visibility expression | No `needs: pick-runner` to reuse; routing directly avoids adding a dependency edge just to learn where to run. |

`pick-runner` itself was already un-pinned by #8644 and needed no change — it
already resolves on `ubuntu-latest` for this repo, so no downstream job waits
for a self-hosted slot just to learn where to run. After this change
`ci-standard.yml` has **zero** bare `d-sorg-*` pins.

## Left on the fleet, deliberately

- `matlab-tests` — `if: false`, "Requires MATLAB license not available in CI".
  It routes via `pick-runner` already and never executes; the licensed MATLAB
  runner (`ControlTower-windows-matlab-1`) carries no `d-sorg-*` label anyway.
- `arduino-build` — `if: false`, no Arduino components in this project.
- Everything outside `ci-standard.yml` is out of scope for this PR. ~70 job
  definitions across the `Jules-*` bot workflows, `docker-security-scan.yml`,
  `realtime-soak.yml` (`d-sorg-fleet-soak`), `package-standalone-sidekick.yml`
  and others are still bare-pinned to `d-sorg-fleet-docker`. Those are the
  remaining fleet load and deserve their own change; none of them gate merges.

## Guard compatibility

Both local-only guards match **bare** runner strings and skip any value
containing `d-sorg-fleet` / `pick-runner` / `CI_RUNNER_MODE`, so the `${{ }}`
expressions pass. Verified locally against the actual change:

```
$ python scripts/check_local_only_workflows.py
Workflow runner routing is local-only.   # exit 0
```

`scripts/check_local_only_workflows.py` resolves `matrix.os` only when the
`runs-on` value mentions `matrix.os`, which none of these do, so
`rust-quality-gate`'s `os: [ubuntu-latest]` axis does not trip it.

## Reverting

One variable, no code change:

```
gh api -X POST repos/D-sorganization/UpstreamDrift/actions/variables -f name=CI_RUNNER_MODE -f value=local
```

`CI_RUNNER_MODE` is currently **unset** on this repo (only `JULES_ENABLED` is
set), and unset is not `local`, so the hosted branch is taken. The semantics
deliberately treat *unset* as the safe default and `local` as the kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Verification (measured on this PR)

Run [31992176485](https://github.com/D-sorganization/UpstreamDrift/actions/runs/31992176485).
**All 22 `CI Standard` jobs executed on GitHub-hosted runners.** The whole
workflow drained in ~35 minutes, against a baseline where `CI Standard` runs
sat `pending` with **zero jobs allocated** for hours and were then cancelled.

The `quality-gate` job itself (job `95278698680`):

```
Runner Image Provisioner: Hosted Compute Agent
Azure Region: eastus2
Operating System: Ubuntu 24.04.4 LTS
started 03:53:47Z -> completed 03:53:50Z   (3 seconds)
```

### Before / after, same workflow

Baseline run [31905062497](https://github.com/D-sorganization/UpstreamDrift/actions/runs/31905062497) (2026-08-15, before this change):

| Job | Baseline runner | Baseline result | This PR |
| --- | --- | --- | --- |
| `quality-gate` | `d-sorg-local-ControlTower-SSD-3` | failure | hosted, **runs in 3 s** |
| `rust-wheel-parity` | *(never got a slot)* | **cancelled** | hosted, **success** |
| `Rust Quickstart` | `d-sorg-local-Desktop-1` | **failure** | hosted, **success** |
| `rust-quality-gate` | `d-sorg-local-ControlTower-SSD-2` | success | hosted, success |

Net: **11 failing jobs at baseline -> 6 on this PR.** `core-only-install`,
`tests (3.11)`, `tests (3.12)` and `Rust Quickstart` went from failing to
passing, and `rust-wheel-parity` went from starved-and-cancelled to green.

### The remaining 6 failures are pre-existing and unrelated to routing

`dependency-consistency`, `shared-tools-consumer-contracts`,
`repo-structure-gates`, `code-quality`, `unit-test-gate` and
`alembic-postgres-round-trip` all failed at baseline too, and **every one of
them was already routing through `pick-runner` onto a hosted runner before this
PR** — none is a job this PR moved. All four jobs this PR moved pass.

`repo-structure-gates` is the one in `quality-gate`'s `needs`, so it is why the
aggregate still reports red. Its failing step is the DRY Duplication Ratchet,
reproduced locally on this branch (`origin/main` + a workflows-only diff):

```
$ python scripts/ci/check_dry_duplication_gate.py   # exit 1
fc8363562518: 2 occurrences (baseline max 1)
    - src/shared/python/sidekick/calculators/thermo/_vapor_pressure.py:110-118
    - src/shared/python/sidekick/calculators/thermo/steam_engine.py:549-558
... (all findings in src/shared/python/**, which this PR does not touch)
```

So `main` is genuinely red on content gates. That was previously **invisible**,
because `CI Standard` never drained far enough to report it — routing the
workflow to hosted runners is what surfaced it. Fixing those content failures
is out of scope here (this PR is workflows-only by design; `src/` is being
edited concurrently by other agents).

### Guards passed in real CI, not just locally

- `Local-Only Workflow Runner Guard` — **success**
- `Reject hosted runner routing` (`scripts/check_local_only_workflows.py`) — **success**
- `Lint Workflow Files` — **success**

## Separate finding, not fixed here

**Three** workflows define a job named exactly `quality-gate`, and all three
publish check runs under the single required context of that name:
`ci-standard.yml:976` (the real aggregate), `quality-gate.yml:20` (LOD lint),
and `docs-ci.yml:47`. Because branch protection matches on context name, the
merge gate can be satisfied by whichever reported — and since `ci-standard.yml`
carries `paths-ignore: docs/**, **.md`, a docs-only PR never runs the aggregate
at all while `quality-gate` still shows green from the other two. Worth its own
change; renaming a required context has to be coordinated with the
branch-protection `contexts` list and with the bot workflows that resolve the
literal string `quality-gate`.
