### PR TITLE
fix(bunkershot3d): land the test half of the camber-flag scope fix (#8728 follow-up)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -103,7 +103,7 @@ VTK) is installed, so the ADR-0027 selection degrades to a stated matplotlib
 plan view. This is a rendering of existing F0 output at higher fidelity, not
 new physics and not calibration: the field inherits `BEYOND_VALIDATION`, and a
 patch trend read across a bounce sweep is reported as a bounce-and-camber
-trend wherever the declared camber was substituted (#8698).
+trend wherever any spanwise station's camber was substituted (#8698).
 
 Issue #8709 (epic #8699) selects the sand-solving tier that backs field
 visualization, recorded as ADR-0033 amending ADR-0032. The epic had assumed the
@@ -234,6 +234,41 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
+- **2026-08-16** - Scoped BunkerShot3D's camber-clamped flag so it cannot
+  understate substitution (`src/bunkershot3d/geometry/lofting.py`,
+  `src/tools/bunker_shot_gui/`, issue #8698, epic #8699). The observability
+  work below left one boolean answering a narrower question than its name
+  implied. `LoftedWedge.camber_was_clamped` compared the declared camber area
+  against the band the **declared** sole width admits. Heel and toe relief
+  narrows the sole toward the ends, and a narrower sole admits a narrower
+  camber band, so the relieved stations are refitted to their own bands while
+  the declaration itself is honoured — and the flag read `False` beside a
+  non-empty `clamped_stations`. That is #8698's own failure mode, silent
+  substitution invisible to a caller, reappearing through the simpler check.
+  Measured at shipped resolution, three of the six shipped presets hit it:
+  `sm9_58_m` declares 42.00 mm² inside its (38.70, 42.44) mm² band and refits
+  3 of 17 stations; `acushnet_example_1` refits 5 of 17; `tour_shaved_heel_lob`
+  refits 13 of 17. All three reported "not clamped".
+
+  Resolved by renaming rather than redefining. Redefining a published boolean
+  in place would have silently changed every existing caller's answer, which
+  is the same failure mode one level up; the rename breaks loudly instead.
+  `camber_was_clamped` becomes `aggregate_camber_was_clamped` (unambiguously
+  the declared-versus-effective question), and a new `any_camber_was_clamped`
+  is true when the declaration **or** any station was substituted, so a caller
+  checking one boolean gets the honest answer and the flag cannot read `False`
+  while `clamped_stations` holds anything. `camber_substitution_m2` becomes
+  `aggregate_camber_substitution_m2`, which also ends its name collision with
+  `StationCamber`'s per-station property. Both meanings are genuinely used, so
+  a single flag could not serve: the workbench's camber-area line needs the
+  aggregate because it prints the declared number, and the contact-patch
+  caveat needs any-station. The camber-area line now also names the refitted
+  station count, so an in-band declaration over refitted stations no longer
+  renders as a clean number. `PATCH_CONFOUND_CAVEAT` is gated on the per-
+  station account rather than the aggregate flag and is restated in terms of
+  stations — gated on the aggregate it was silent on the default design, which
+  is exactly when the caveat is needed.
+
 - **2026-08-16** - Made BunkerShot3D's sole-camber substitution observable
   (`src/bunkershot3d/geometry/`, issue #8698, epic #8699). A wedge sole can
   only realise camber areas inside a band set by its width and bounce, so
@@ -255,7 +290,8 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
   Three complementary changes. (1) `loft_wedge()` returns a new `LoftedWedge`
   carrying `effective_camber_area_m2`, `constructible_camber_range_m2`,
-  `camber_was_clamped`, `camber_substitution_m2` and a per-station
+  `aggregate_camber_was_clamped`, `any_camber_was_clamped`,
+  `aggregate_camber_substitution_m2` and a per-station
   `StationCamber` account; `build_wedge_mesh()` is now a thin wrapper that
   returns only its mesh. (2) `constructible_camber_range_m2` is re-exported
   from `bunkershot3d.geometry` and the top-level package, and

--- a/tests/bunkershot3d/geometry/test_wedge_camber_observability_8698.py
+++ b/tests/bunkershot3d/geometry/test_wedge_camber_observability_8698.py
@@ -113,7 +113,7 @@ class TestSilenceIsOptIn:
         strict = loft_wedge(wedge, **COARSE)
         nearest = loft_wedge(wedge, camber_fit=CamberFit.NEAREST, **COARSE)
         assert strict.effective_camber_area_m2 == nearest.effective_camber_area_m2
-        assert not strict.camber_was_clamped
+        assert not strict.aggregate_camber_was_clamped
 
     def test_an_unknown_policy_is_rejected(self) -> None:
         with pytest.raises(TypeError, match="camber_fit"):
@@ -132,12 +132,13 @@ class TestTheCallerCanDetectTheSubstitution:
         # This is the assertion the issue is about: a caller that declared
         # 45 mm^2 can find out, from the object it was handed, that the mesh
         # it received carries something else.
-        assert result.camber_was_clamped is True
+        assert result.aggregate_camber_was_clamped is True
+        assert result.any_camber_was_clamped is True
         assert result.declared_camber_area_m2 == declared
         assert result.effective_camber_area_m2 != declared
         low, high = result.constructible_camber_range_m2
         assert low <= result.effective_camber_area_m2 <= high
-        assert result.camber_substitution_m2 == pytest.approx(
+        assert result.aggregate_camber_substitution_m2 == pytest.approx(
             result.effective_camber_area_m2 - declared
         )
 
@@ -149,9 +150,9 @@ class TestTheCallerCanDetectTheSubstitution:
         """
         wedge = build_reference_wedge()
         result = loft_wedge(wedge, camber_fit=CamberFit.NEAREST, **COARSE)
-        assert result.camber_was_clamped is False
+        assert result.aggregate_camber_was_clamped is False
         assert result.effective_camber_area_m2 == wedge.sole_camber_area_m2
-        assert result.camber_substitution_m2 == 0.0
+        assert result.aggregate_camber_substitution_m2 == 0.0
         centre = next(
             s for s in result.stations if s.sole_width_m == wedge.sole_width_m
         )
@@ -186,11 +187,13 @@ class TestTheCallerCanDetectTheSubstitution:
         record = {
             "declared_camber_mm2": result.declared_camber_area_m2 * 1e6,
             "effective_camber_mm2": result.effective_camber_area_m2 * 1e6,
-            "camber_was_clamped": result.camber_was_clamped,
+            "aggregate_camber_was_clamped": result.aggregate_camber_was_clamped,
+            "any_camber_was_clamped": result.any_camber_was_clamped,
+            "clamped_station_count": len(result.clamped_stations),
             "constructible_camber_low_mm2": low * 1e6,
             "constructible_camber_high_mm2": high * 1e6,
         }
-        assert record["camber_was_clamped"] is True
+        assert record["aggregate_camber_was_clamped"] is True
         assert record["declared_camber_mm2"] == pytest.approx(45.0)
         assert record["effective_camber_mm2"] != pytest.approx(45.0)
 
@@ -266,4 +269,91 @@ class TestPresetsDeclareWhatTheyBuild:
     @pytest.mark.parametrize("name", preset_names())
     def test_every_preset_lofts_under_the_strict_default(self, name: str) -> None:
         result = loft_wedge(get_preset(name).geometry, **COARSE)
-        assert result.camber_was_clamped is False
+        assert result.aggregate_camber_was_clamped is False
+
+
+class TestTheFlagCannotUnderstateSubstitution:
+    """The scope regression: a `False` boolean over refitted stations.
+
+    ``camber_was_clamped`` compared the declared area against the band the
+    *declared* sole width admits, so it answered only the aggregate question.
+    Heel and toe relief narrows the sole toward the ends and a narrower sole
+    admits a narrower band, so the relieved stations get refitted while the
+    declaration itself is honoured -- and the flag read ``False`` beside a
+    non-empty ``clamped_stations``.
+
+    That is issue #8698's own failure mode (a substitution invisible to its
+    caller) reappearing through the *simpler* check, which is the one most
+    callers reach for.  These tests pin the invariant that closes it.
+    """
+
+    def test_the_broad_flag_cannot_be_false_while_stations_were_clamped(
+        self,
+    ) -> None:
+        """The invariant, stated directly. This is the regression."""
+        wedge = build_reference_wedge(
+            heel_relief_fraction=0.30, toe_relief_fraction=0.05
+        )
+        result = loft_wedge(wedge, n_profile_points=24, n_stations=7)
+
+        assert result.clamped_stations, "fixture must actually clamp a station"
+        assert result.any_camber_was_clamped is True
+        assert not (result.clamped_stations and not result.any_camber_was_clamped)
+
+    def test_the_relieved_case_is_exactly_where_the_two_flags_diverge(self) -> None:
+        """Aggregate honoured, stations refitted -- the misreported case."""
+        wedge = build_reference_wedge(
+            heel_relief_fraction=0.30, toe_relief_fraction=0.05
+        )
+        result = loft_wedge(wedge, n_profile_points=24, n_stations=7)
+
+        # The declaration itself was constructible ...
+        assert result.aggregate_camber_was_clamped is False
+        assert result.effective_camber_area_m2 == wedge.sole_camber_area_m2
+        # ... yet the sole that was built is not the sole that was asked for.
+        assert result.clamped_stations
+        assert result.any_camber_was_clamped is True
+
+    @pytest.mark.parametrize("name", preset_names())
+    def test_the_invariant_holds_on_every_shipped_preset(self, name: str) -> None:
+        """Three of the six shipped grinds refit stations at full resolution."""
+        result = loft_wedge(get_preset(name).geometry, camber_fit=CamberFit.NEAREST)
+        if result.clamped_stations:
+            assert result.any_camber_was_clamped is True
+        assert result.any_camber_was_clamped >= result.aggregate_camber_was_clamped
+
+    def test_the_shipped_default_preset_is_the_documented_case(self) -> None:
+        """`sm9_58_m` is the preset the PR discussion measured: in band, refitted.
+
+        Pinned by name and by number because the docstrings in ``lofting`` and
+        ``report`` both cite it as the worked example.
+        """
+        result = loft_wedge(
+            get_preset("sm9_58_m").geometry, camber_fit=CamberFit.NEAREST
+        )
+        declared_mm2 = result.declared_camber_area_m2 * 1e6
+        low, high = result.constructible_camber_range_m2
+
+        assert declared_mm2 == pytest.approx(42.0, abs=0.01)
+        assert low * 1e6 < declared_mm2 < high * 1e6
+        assert result.aggregate_camber_was_clamped is False
+        assert len(result.clamped_stations) == 3
+        assert result.any_camber_was_clamped is True
+
+    def test_the_narrow_flag_keeps_its_narrow_meaning(self) -> None:
+        """The rename must not have widened the aggregate flag by accident."""
+        result = loft_wedge(
+            _outside_band_wedge(), camber_fit=CamberFit.NEAREST, **COARSE
+        )
+        assert result.aggregate_camber_was_clamped is True
+        assert result.aggregate_camber_substitution_m2 != 0.0
+
+    def test_the_misleading_name_is_gone(self) -> None:
+        """The old name must not survive as an alias reading the old value.
+
+        Leaving it in place -- even deprecated -- would leave the misleading
+        answer reachable, so the rename is a hard break by design.
+        """
+        result = loft_wedge(build_reference_wedge(), **COARSE)
+        assert not hasattr(result, "camber_was_clamped")
+        assert not hasattr(result, "camber_substitution_m2")

--- a/tests/unit/tools/bunker_shot_gui/test_camber_reporting_8698.py
+++ b/tests/unit/tools/bunker_shot_gui/test_camber_reporting_8698.py
@@ -30,7 +30,20 @@ class TestTheEvaluationCarriesTheRealisedCamber:
     def test_clamping_is_reported_consistently(self, nominal_evaluation) -> None:
         declared = nominal_evaluation.geometry.sole_camber_area_m2
         effective = nominal_evaluation.effective_camber_area_m2
-        assert nominal_evaluation.camber_was_clamped == (effective != declared)
+        assert nominal_evaluation.aggregate_camber_was_clamped == (
+            effective != declared
+        )
+
+    def test_the_broad_flag_covers_the_stations_too(self, nominal_evaluation) -> None:
+        """The workbench's flag carries the same invariant as the lofter's."""
+        assert not (
+            nominal_evaluation.clamped_camber_stations
+            and not nominal_evaluation.any_camber_was_clamped
+        )
+        assert (
+            nominal_evaluation.any_camber_was_clamped
+            >= nominal_evaluation.aggregate_camber_was_clamped
+        )
 
 
 class TestTheReportStatesBothNumbers:
@@ -47,9 +60,29 @@ class TestTheReportStatesBothNumbers:
         )
         effective_mm2 = nominal_evaluation.effective_camber_area_m2 * 1e6
         assert f"{effective_mm2:.1f} mm^2" in camber_line
-        if nominal_evaluation.camber_was_clamped:
+        if nominal_evaluation.aggregate_camber_was_clamped:
             declared_mm2 = nominal_evaluation.geometry.sole_camber_area_m2 * 1e6
             assert f"declared {declared_mm2:.1f} mm^2" in camber_line
             assert "not constructible" in camber_line
         else:
             assert "declared" not in camber_line
+
+    def test_refitted_stations_are_named_on_the_camber_line(
+        self, nominal_evaluation
+    ) -> None:
+        """An in-band declaration over refitted stations must not read clean.
+
+        Without this the line renders a bare "42.0 mm^2" for a sole whose
+        heel and toe carry something else -- the same silence at finer grain.
+        """
+        camber_line = next(
+            line
+            for line in evaluation_report(nominal_evaluation).splitlines()
+            if line.startswith("Camber area")
+        )
+        clamped = nominal_evaluation.clamped_camber_stations
+        if clamped:
+            assert f"{len(clamped)} of " in camber_line
+            assert "stations refitted" in camber_line
+        else:
+            assert "refitted" not in camber_line

--- a/tests/unit/tools/bunker_shot_gui/test_sole_field_report.py
+++ b/tests/unit/tools/bunker_shot_gui/test_sole_field_report.py
@@ -6,13 +6,16 @@ pasted into an issue and a screenshot cannot be diffed. This module pins the
 text.
 
 It also pins the caveat #8707 asks to be carried: the bounce trend the patch
-view illustrates is confounded by the camber substitution of #8698. Where the
-declared camber was not constructible, a comparison labelled "bounce" is
-really a bounce-and-camber comparison, and the report has to say so next to
-the patch numbers rather than only next to the geometry.
+view illustrates is confounded by the camber substitution of #8698. Where a
+spanwise station could not carry the camber its relieved sole width implied,
+a comparison labelled "bounce" is really a bounce-and-camber comparison, and
+the report has to say so next to the patch numbers rather than only next to
+the geometry.
 """
 
 from __future__ import annotations
+
+import dataclasses
 
 import pytest
 
@@ -86,10 +89,59 @@ class TestTheConfoundIsCarried:
 
     def test_a_clamped_camber_earns_the_caveat(self, nominal_evaluation) -> None:  # type: ignore[no-untyped-def]
         report = evaluation_report(nominal_evaluation)
-        if nominal_evaluation.camber_was_clamped:
+        if nominal_evaluation.clamped_camber_stations:
             assert PATCH_CONFOUND_CAVEAT in report
         else:
             assert PATCH_CONFOUND_CAVEAT not in report
+
+    def test_the_caveat_is_gated_on_stations_not_on_the_aggregate(
+        self, nominal_evaluation
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The point of the rebase, isolated from the lofting resolution.
+
+        The shipped ``sm9_58_m`` preset declares an area its own sole width
+        admits while still refitting stations along the sole, so a caveat
+        gated on the declared-versus-effective aggregate is silent on the
+        default design.  (The session fixture lofts at *coarse* test
+        resolution, where the aggregate happens to clamp too, so the
+        aggregate is neutralised here rather than relied upon; the shipped
+        resolution is pinned in the geometry suite.)
+        """
+        assert nominal_evaluation.clamped_camber_stations, (
+            "this test needs a design that refits stations"
+        )
+
+        # Force the aggregate flag False while leaving the stations refitted:
+        # exactly the state the old gate misread.
+        in_band = dataclasses.replace(
+            nominal_evaluation,
+            effective_camber_area_m2=nominal_evaluation.geometry.sole_camber_area_m2,
+        )
+        assert in_band.aggregate_camber_was_clamped is False
+        assert in_band.clamped_camber_stations
+        assert PATCH_CONFOUND_CAVEAT in evaluation_report(in_band)
+
+    def test_an_unrefitted_design_does_not_carry_the_caveat(
+        self, nominal_evaluation
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The gate must not be trivially true, or the caveat means nothing."""
+        clean = dataclasses.replace(
+            nominal_evaluation,
+            effective_camber_area_m2=nominal_evaluation.geometry.sole_camber_area_m2,
+            camber_stations=(),
+        )
+        assert clean.any_camber_was_clamped is False
+        assert PATCH_CONFOUND_CAVEAT not in evaluation_report(clean)
+
+    def test_the_caveat_counts_the_stations_it_fired_on(
+        self, nominal_evaluation
+    ) -> None:  # type: ignore[no-untyped-def]
+        report = evaluation_report(nominal_evaluation)
+        clamped = nominal_evaluation.clamped_camber_stations
+        if not clamped:
+            pytest.skip("no station was refitted on this design")
+        total = len(nominal_evaluation.camber_stations)
+        assert f"({len(clamped)} of {total} spanwise stations refitted)" in report
 
     def test_a_design_whose_camber_is_substituted_says_so_by_the_patch(
         self, model: WorkbenchModel, firm_sand: SandCondition, tour_swing: SwingSetup
@@ -98,12 +150,23 @@ class TestTheConfoundIsCarried:
         evaluation = model.evaluate(
             wide, firm_sand, tour_swing, include_playability=False
         )
-        if not evaluation.camber_was_clamped:
-            pytest.skip("this geometry realised its declared camber")
+        if not evaluation.clamped_camber_stations:
+            pytest.skip("this geometry realised its declared camber everywhere")
         assert PATCH_CONFOUND_CAVEAT in evaluation_report(evaluation)
 
     def test_the_caveat_names_the_issue_it_comes_from(self) -> None:
         assert "8698" in PATCH_CONFOUND_CAVEAT
+
+    def test_the_caveat_is_stated_in_terms_of_stations(self) -> None:
+        """It must describe what actually triggers it, not the aggregate.
+
+        The previous wording claimed the *declared* area was inconstructible,
+        which is false on the design the caveat fires for.
+        """
+        assert "station" in PATCH_CONFOUND_CAVEAT
+        assert "declared camber area was not constructible" not in (
+            PATCH_CONFOUND_CAVEAT
+        )
 
 
 class TestTheReportIsWiredIn:


### PR DESCRIPTION
Follow-up to #8728. **Fixes a red `main`.**

## What happened

#8728 was squash-merged at head `20cd11495`, which carried the source half of
the camber-flag scope fix but not the test half — those commits (`80d53d63d`,
`90df5d734`) were pushed to the branch minutes after the squash was taken.

The result is that `main` currently has the renamed API in `src/` while the
tests still call the old names:

| file | stale references on `main` |
|---|---|
| `tests/bunkershot3d/geometry/test_wedge_camber_observability_8698.py` | 8 |
| `tests/unit/tools/bunker_shot_gui/test_camber_reporting_8698.py` | 2 |
| `tests/unit/tools/bunker_shot_gui/test_sole_field_report.py` | 2 |

`DesignEvaluation.camber_was_clamped` and `LoftedWedge.camber_was_clamped` no
longer exist — deliberately, since the rename was chosen precisely so stale
callers break loudly rather than reading a plausible wrong boolean — so every
one of those is an `AttributeError` at run time.

This PR carries the two missing commits across unchanged. Nothing here is new
work; it is the other half of a change that was split by merge timing.

## Why the rename (carried over from #8728)

`LoftedWedge.camber_was_clamped` compared the declared camber area against the
band the **declared** sole width admits. Heel and toe relief narrows the sole
toward the ends, and a narrower sole admits a narrower camber band, so the
relieved stations get refitted while the declaration itself is honoured — and
the flag read `False` beside a non-empty `clamped_stations`. That is #8698's
own failure mode, silent substitution invisible to a caller, reappearing
through the *simpler* check. Three of the six shipped presets hit it:
`sm9_58_m` (3 of 17 stations), `acushnet_example_1` (5 of 17) and
`tour_shaved_heel_lob` (13 of 17) all reported "not clamped".

Renamed rather than redefined: redefining a published boolean in place would
silently change every existing caller's answer, which is the same failure mode
one level up.

- `camber_was_clamped` → `aggregate_camber_was_clamped`
- new `any_camber_was_clamped` — aggregate **or** any station, so the
  one-boolean check is correct by construction
- `camber_substitution_m2` → `aggregate_camber_substitution_m2`

## Tests

| file | before | after |
|---|---|---|
| `test_wedge_camber_observability_8698.py` | 31 | 42 |
| `test_camber_reporting_8698.py` | 4 | 6 |
| `test_sole_field_report.py` | 17 | 21 |

The regression assertion is that the broad flag cannot read `False` while
stations were clamped — pinned directly, over every shipped preset, and on
`sm9_58_m` by number (42.00 mm², inside its (38.70, 42.44) mm² band, 3 of 17
stations refitted). Two further tests pin that the aggregate flag kept its
narrow meaning and that the old names are gone rather than aliased.

Verified locally on this branch: `tests/bunkershot3d/geometry/…_8698.py`,
`tests/unit/tools/bunker_shot_gui` and `tests/tools/bunker_shot_gui` — 341
tests, all pass, exit 0. Full pre-commit/pre-push hook set passes; no
`--no-verify`.

## SPEC.md

Records the scope fix and corrects two stale references the merge left behind:
the #8698 entry listed `camber_was_clamped` / `camber_substitution_m2`, which
no longer exist, and the sole-load-field entry described the patch caveat as
firing on a substituted *declared* camber, which is not what triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
