### PR TITLE
feat(bunkershot3d): F1 2-D plane-strain MPM sand solver core and verification (ADR-0033)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -149,6 +149,74 @@ edge, so no F1 output is a physical prediction. The driver defects are tracked
 separately; the tier is not usable until they are repaired or the backend is
 removed.
 
+ADR-0033's F1 solver core now exists at `src/bunkershot3d/solvers/mpm/`,
+implementing the `GranularSolver` protocol so it is swappable with the F0
+`DRFTSolver` and returns the same `SolverResult` carrying tier and verdict. The
+constitutive model is **rate-independent Drucker-Prager elastoplasticity with a
+compressive cap**, integrated as a return mapping on principal Hencky strains
+(Drucker & Prager 1952; Klar et al. 2016, ACM TOG 35(4):103, which is also the
+F2 reference tier's model so one calibration carries between them). The
+`mu(I)` rheology was rejected on well-posedness rather than on cost: Barker,
+Schaeffer, Bohorquez & Gray (2015, J. Fluid Mech. 779:794-818) show its
+incrementally-linearised equations lose hyperbolicity below `I_1` and above
+`I_2`, so perturbation growth is unbounded in wavenumber and grid refinement
+makes the answer worse -- and both ill-posed regimes sit inside a bunker shot,
+the quiescent bed at `I -> 0` and the leading edge at `I ~ 11`. A tier whose
+deliverable is a GCI-reported field cannot rest on equations that are ill-posed
+in the regime being refined. The compressive cap is read off the sand package
+rather than fitted: `eps_v_cap = ln(phi / phi_max)` from the existing
+`PackingState`, so a loose bed compacts about 15 % and a firm one about 2 %
+without a second set of constants existing; the cohesive cone tip comes from the
+moisture model, and a saturated bed raises rather than guessing its dilation
+suction. Transfers are **APIC** (Jiang et al. 2015, ACM TOG 34(4):51) on
+quadratic B-splines: PIC would damp away the shear structure the tier exists to
+show, FLIP leaves null-space noise that a plastic return map reads as spurious
+yielding, and APIC conserves linear and angular momentum exactly across the
+transfer, which is tested to round-off rather than cited. The timestep is a CFL
+condition on the computed dilatational wave speed `sqrt((lambda + 2 mu) / rho)`
+plus the body speed, checked at runtime with a `raise` because `python -O`
+strips assertions. Sand constants come from `usga_reference_sand` and the
+packing/moisture machinery; the only F1-specific additions are a Hardin &
+Richart (1963) small-strain modulus keyed on the existing void ratio and
+angularity, and a conventional drained Poisson ratio, both recorded in the
+provenance. Measured code verification, through the existing `vandv/`
+conservation, convergence and Celik GCI implementations rather than a second
+copy: mass conserved exactly (residual 0.0); linear momentum matching the
+gravity impulse to round-off; total energy first order in the step (observed
+order 1.00 over Courant 0.4/0.2/0.1, 2.2e-8 relative at the coarsest);
+a relaxed 1-D consolidation column at -409.741 Pa against -403.115 Pa
+closed-form, 1.64 %, with its stored strain energy 5.8 % from
+`W (rho g)^2 H^3 / (6 M)`; and monotone grid convergence over dx = 6/4/3 mm at
+3.70 % -> 2.22 % -> 1.64 %, observed order 1.178, Celik apparent order 1.72,
+`GCI_fine` 1.105 % and `u_num` 2.26 Pa. Two verification cases had to be rebuilt
+around real findings: a generously padded grid put the column's "fixed base"
+two cells below the column and its confining walls two cells outside it, so the
+column stood in free space and fell while reporting a mean stress of 3e-9 Pa
+through an entirely plausible-looking run; and the conventional elastic energy
+case does not exist for cohesionless sand, because a pre-compressed block
+released to oscillate rebounds into tension where the return map correctly
+annihilates the deviatoric strain at the cone tip (129 of 144 particles per
+step), which is physical plastic dissipation and not truncation error. Bagnold
+is unavailable for the same class of reason: it is a consequence of `mu(I)` rate
+dependence, which this solver deliberately does not have. The F0 cross-check on
+a 40 x 16 mm sole section at 20 deg attack, 30 mm declared effective width,
+reports the divergence rather than asserting agreement: `|F1|/|F0|` of 1.96,
+1.49 and 2.68 at 5, 12 and 25 m/s with direction cosines 0.85, 0.65 and 0.87,
+and -- the informative part -- F0's inertial share climbing 0.52 -> 0.93 -> 0.99
+with speed while F1's momentum-flux share stays flat at 0.68 / 0.69 / 0.65. F0's
+`lambda rho v_n^2` term grows quadratically with nothing to bound it, whereas
+the continuum's reaction is limited by how fast the yield surface lets sand be
+accelerated out of the way, so the two tiers disagree by construction in exactly
+the regime a greenside shot occupies. F1 is therefore **verified but not
+validated**: the suite shows it solves its equations correctly and is no
+evidence at all that those equations describe golf bunker sand. Validation stays
+at NASA-STD-7009B level 0 of 4 and the F1 envelope enforces a
+`BEYOND_VALIDATION` floor that no query can beat, since `EXTRAPOLATED` would
+require a published validation set that issue #8616 established does not exist.
+Field extraction and schema (#8710), the visual layers (#8711-#8713), the ball
+as a plane-strain body, and F1's own `simulate_shot` integration are
+deliberately out of this change.
+
 Child issue #8697 then couples two first bending modes and one torsional mode
 to that distributed-grip authority. Its registered 0.25/0.125 ms atlas covers
 384 trajectories and 1,536 nested-horizon summaries. Domain, activation,

--- a/src/bunkershot3d/solvers/__init__.py
+++ b/src/bunkershot3d/solvers/__init__.py
@@ -26,6 +26,12 @@ Layout
 * :mod:`.elements` -- the structure-of-arrays surface discretisation.
 * :mod:`.drft` -- the solver.
 * :mod:`.shot` -- time-marching one shot, under the 50 ms budget.
+* :mod:`.mpm` -- the **F1** tier (ADR-0033): a 2-D plane-strain material
+  point method. It exists because F0 never forms a sand velocity at any
+  resolution, so the fields epic #8699 needs cannot be post-processed out
+  of it. F1 is imported lazily-by-submodule rather than re-exported here,
+  because it is a study tier costing seconds per shot against F0's
+  milliseconds and should be reached for deliberately.
 
 Honesty summary
 ---------------

--- a/src/bunkershot3d/solvers/envelope.py
+++ b/src/bunkershot3d/solvers/envelope.py
@@ -181,6 +181,15 @@ class Caveat(StrEnum):
     MARGINAL_CONTINUUM = "marginal_continuum"
     ELEMENT_SIZE_EFFECTS = "element_size_effects"
 
+    # F1 (2-D plane-strain MPM, ADR-0033). Structural rather than
+    # empirical: these say what the tier's *formulation* cannot carry, not
+    # how far a fit has been stretched.
+    PLANE_STRAIN_NO_OUT_OF_PLANE = "plane_strain_no_out_of_plane"
+    UNDER_RESOLVED_LEADING_EDGE = "under_resolved_leading_edge"
+    DECLARED_EFFECTIVE_WIDTH = "declared_effective_width"
+    RATE_INDEPENDENT_PLASTICITY = "rate_independent_plasticity"
+    NO_MEASURED_COMPARISON = "no_measured_comparison"
+
 
 _CAVEAT_TEXT: Mapping[Caveat, str] = MappingProxyType(
     {
@@ -248,6 +257,37 @@ _CAVEAT_TEXT: Mapping[Caveat, str] = MappingProxyType(
             "length survives in the dimensionless response and RFT's "
             "superposition argument is no longer exact. Refining the mesh "
             "makes this worse, not better."
+        ),
+        Caveat.PLANE_STRAIN_NO_OUT_OF_PLANE: (
+            "Plane strain has no out-of-plane flow. Sand moving heel to toe "
+            "along the face does not exist in this model, and no refinement "
+            "adds it: it is a property of the formulation, not a setting."
+        ),
+        Caveat.UNDER_RESOLVED_LEADING_EDGE: (
+            "The grid is at bulk resolution, so the leading edge spans only a "
+            "few cells and its local flow is not resolved. This is ADR-0033's "
+            "deliberate choice -- resolving it would drive cell count and CFL "
+            "step into the same intractability trap as DEM -- and it is why "
+            "club force stays F0's to report."
+        ),
+        Caveat.DECLARED_EFFECTIVE_WIDTH: (
+            "A plane-strain load is per unit out-of-plane width. The force "
+            "reported here has been multiplied by a declared effective width, "
+            "which is a modelling assumption and not a result; ADR-0033 "
+            "requires it in the run manifest before any magnitude comparison."
+        ),
+        Caveat.RATE_INDEPENDENT_PLASTICITY: (
+            "The constitutive model is rate-independent Drucker-Prager, so no "
+            "grain-inertial rate dependence is represented. The mu(I) rheology "
+            "would represent it and is ill-posed at both low and high inertial "
+            "number (Barker et al. 2015), which is why it was not used."
+        ),
+        Caveat.NO_MEASURED_COMPARISON: (
+            "No published measurement exists for any quantity this tier "
+            "produces, so its NASA-STD-7009B validation level is 0 of 4 and "
+            "nothing it reports is a physical prediction. Agreement with "
+            "another tier is a consistency check between two uncalibrated "
+            "models, not a validation of either."
         ),
     }
 )

--- a/src/bunkershot3d/solvers/mpm/__init__.py
+++ b/src/bunkershot3d/solvers/mpm/__init__.py
@@ -54,13 +54,27 @@ from .constitutive import (
     reconstruct,
     yield_function,
 )
+from .grid import (
+    NODES_PER_PARTICLE,
+    STENCIL_WIDTH,
+    GridInterpolation,
+    PlaneStrainGrid,
+    apic_angular_momentum,
+    cross_2d,
+)
 
 __all__ = [
     "HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA",
     "HARDIN_RICHART_ROUND_COEFFICIENT_KPA",
+    "NODES_PER_PARTICLE",
     "PLANE_STRAIN_DIMENSION",
     "SAND_POISSON_RATIO",
+    "STENCIL_WIDTH",
+    "GridInterpolation",
+    "PlaneStrainGrid",
     "SandContinuum",
+    "apic_angular_momentum",
+    "cross_2d",
     "drucker_prager_alpha",
     "hencky_kirchhoff_principal",
     "principal_stretches",

--- a/src/bunkershot3d/solvers/mpm/__init__.py
+++ b/src/bunkershot3d/solvers/mpm/__init__.py
@@ -17,6 +17,7 @@ What this package is
 * :mod:`.grid` -- the Eulerian background grid, quadratic B-splines and
   the **APIC** transfers, which conserve linear *and* angular momentum
   where PIC damps and FLIP rings.
+* :mod:`.state` -- particles, bed initialisation and the domain walls.
 * :mod:`.body` -- the clubhead as a rigid moving plane-strain section,
   with the contact treatment that stops material tunnelling through it.
 * :mod:`.solver` -- :class:`~bunkershot3d.solvers.mpm.solver.PlaneStrainMPMSolver`,
@@ -24,8 +25,21 @@ What this package is
   protocol so F1 is swappable with F0.
 * :mod:`.envelope` -- the F1 validity verdict, its caveats, and the
   quantities ADR-0033 refuses outright.
-* :mod:`.verification` -- conservation residuals, the analytic cases, the
+* :mod:`.verification` -- conservation residuals, the analytic case, the
   grid-convergence study and the F0 cross-check.
+
+Verified is not validated
+-------------------------
+
+The :mod:`.verification` suite shows this solver **solves its equations
+correctly**: mass exactly, momentum to round-off, energy at first order
+in the step, a 1.6% match to a closed-form consolidation answer, and
+monotone grid convergence with a 1.1% GCI.  None of that is evidence that
+the equations describe golf bunker sand.  Validation for this package
+stands at NASA-STD-7009B level **0 of 4** because issue #8616 found no
+published measurement of any quantity it produces, so every verdict this
+tier issues is :attr:`~bunkershot3d.solvers.envelope.EnvelopeStatus.BEYOND_VALIDATION`
+and cannot be better.
 
 What it is not
 --------------
@@ -34,13 +48,14 @@ Plane strain has **no out-of-plane flow**: sand moving heel-to-toe along
 the face does not exist in this model, and no refinement adds it.  F1 is
 specified at bulk resolution (``dx ~ 1-2 mm``) for the 10-100 mm flow
 features, so the ~0.5 mm leading edge is deliberately under-resolved and
-**club force remains F0's to report**.  Validation for this package
-stands at NASA-STD-7009B level 0 of 4; nothing here is a physical
-prediction.
+**club force remains F0's to report** --
+:func:`~bunkershot3d.solvers.mpm.envelope.require_quotable` raises rather
+than leaving that to documentation.
 """
 
 from __future__ import annotations
 
+from .body import ContactImpulse, RigidSection, convex_hull_2d, plane_torque_about_y
 from .constitutive import (
     HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA,
     HARDIN_RICHART_ROUND_COEFFICIENT_KPA,
@@ -54,6 +69,14 @@ from .constitutive import (
     reconstruct,
     yield_function,
 )
+from .envelope import (
+    F1_STANDING_CAVEATS,
+    MIN_CELLS_PER_GRAIN,
+    MIN_CELLS_PER_RESOLVED_FEATURE,
+    RefusedQuantity,
+    evaluate_f1_envelope,
+    require_quotable,
+)
 from .grid import (
     NODES_PER_PARTICLE,
     STENCIL_WIDTH,
@@ -62,23 +85,73 @@ from .grid import (
     apic_angular_momentum,
     cross_2d,
 )
+from .solver import (
+    DEFAULT_CFL_NUMBER,
+    MPMRun,
+    PlaneStrainMPMSolver,
+    StepDiagnostics,
+    cfl_time_step_s,
+)
+from .state import (
+    DomainWalls,
+    ParticleState,
+    WallCondition,
+    settled_bed,
+    surface_profile_m,
+)
+from .verification import (
+    ColumnEquilibrium,
+    F0CrossCheck,
+    column_grid_convergence,
+    cross_check_against_f0,
+    elastic_column_equilibrium,
+    energy_residuals,
+    free_fall_residuals,
+)
 
 __all__ = [
+    "DEFAULT_CFL_NUMBER",
+    "F1_STANDING_CAVEATS",
     "HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA",
     "HARDIN_RICHART_ROUND_COEFFICIENT_KPA",
+    "MIN_CELLS_PER_GRAIN",
+    "MIN_CELLS_PER_RESOLVED_FEATURE",
     "NODES_PER_PARTICLE",
     "PLANE_STRAIN_DIMENSION",
     "SAND_POISSON_RATIO",
     "STENCIL_WIDTH",
+    "ColumnEquilibrium",
+    "ContactImpulse",
+    "DomainWalls",
+    "F0CrossCheck",
     "GridInterpolation",
+    "MPMRun",
+    "ParticleState",
     "PlaneStrainGrid",
+    "PlaneStrainMPMSolver",
+    "RefusedQuantity",
+    "RigidSection",
     "SandContinuum",
+    "StepDiagnostics",
+    "WallCondition",
     "apic_angular_momentum",
+    "cfl_time_step_s",
+    "column_grid_convergence",
+    "convex_hull_2d",
     "cross_2d",
+    "cross_check_against_f0",
     "drucker_prager_alpha",
+    "elastic_column_equilibrium",
+    "energy_residuals",
+    "evaluate_f1_envelope",
+    "free_fall_residuals",
     "hencky_kirchhoff_principal",
+    "plane_torque_about_y",
     "principal_stretches",
     "project_to_yield_surface",
     "reconstruct",
+    "require_quotable",
+    "settled_bed",
+    "surface_profile_m",
     "yield_function",
 ]

--- a/src/bunkershot3d/solvers/mpm/__init__.py
+++ b/src/bunkershot3d/solvers/mpm/__init__.py
@@ -1,0 +1,70 @@
+"""The F1 tier: a 2-D plane-strain material-point sand solver (ADR-0033).
+
+F0 (:mod:`bunkershot3d.solvers.drft`) integrates an empirical resistive
+stress over the intruder's swept surface.  It never forms a sand
+velocity, at any resolution, so no amount of post-processing yields the
+*fields* Track B of epic #8699 consumes.  A continuum solve produces them
+by construction: every cell carries a velocity, a density and a stress
+because those are the solution variables.
+
+What this package is
+--------------------
+
+* :mod:`.constitutive` -- rate-independent **Drucker-Prager**
+  elastoplasticity with a compressive cap read off the sand's own packing
+  state, and the reason ``mu(I)`` was rejected (it is ill-posed at both
+  low and high inertial number, so refinement makes it worse).
+* :mod:`.grid` -- the Eulerian background grid, quadratic B-splines and
+  the **APIC** transfers, which conserve linear *and* angular momentum
+  where PIC damps and FLIP rings.
+* :mod:`.body` -- the clubhead as a rigid moving plane-strain section,
+  with the contact treatment that stops material tunnelling through it.
+* :mod:`.solver` -- :class:`~bunkershot3d.solvers.mpm.solver.PlaneStrainMPMSolver`,
+  which implements the :class:`~bunkershot3d.solvers.protocol.GranularSolver`
+  protocol so F1 is swappable with F0.
+* :mod:`.envelope` -- the F1 validity verdict, its caveats, and the
+  quantities ADR-0033 refuses outright.
+* :mod:`.verification` -- conservation residuals, the analytic cases, the
+  grid-convergence study and the F0 cross-check.
+
+What it is not
+--------------
+
+Plane strain has **no out-of-plane flow**: sand moving heel-to-toe along
+the face does not exist in this model, and no refinement adds it.  F1 is
+specified at bulk resolution (``dx ~ 1-2 mm``) for the 10-100 mm flow
+features, so the ~0.5 mm leading edge is deliberately under-resolved and
+**club force remains F0's to report**.  Validation for this package
+stands at NASA-STD-7009B level 0 of 4; nothing here is a physical
+prediction.
+"""
+
+from __future__ import annotations
+
+from .constitutive import (
+    HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA,
+    HARDIN_RICHART_ROUND_COEFFICIENT_KPA,
+    PLANE_STRAIN_DIMENSION,
+    SAND_POISSON_RATIO,
+    SandContinuum,
+    drucker_prager_alpha,
+    hencky_kirchhoff_principal,
+    principal_stretches,
+    project_to_yield_surface,
+    reconstruct,
+    yield_function,
+)
+
+__all__ = [
+    "HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA",
+    "HARDIN_RICHART_ROUND_COEFFICIENT_KPA",
+    "PLANE_STRAIN_DIMENSION",
+    "SAND_POISSON_RATIO",
+    "SandContinuum",
+    "drucker_prager_alpha",
+    "hencky_kirchhoff_principal",
+    "principal_stretches",
+    "project_to_yield_surface",
+    "reconstruct",
+    "yield_function",
+]

--- a/src/bunkershot3d/solvers/mpm/body.py
+++ b/src/bunkershot3d/solvers/mpm/body.py
@@ -1,0 +1,616 @@
+"""The clubhead as a rigid moving boundary in the plane-strain section.
+
+The intruder is a **convex polygon** swept through the grid, and the sand
+meets it through a velocity-level collision projection applied on the
+grid nodes (Stomakhin, Schroeder, Chai, Teran & Selle 2013, *"A material
+point method for snow simulation"*, ACM Trans. Graph. **32**(4):102,
+section 8) with a Coulomb friction cone.
+
+Why the projection is on the grid and not on the particles
+----------------------------------------------------------
+
+The grid already carries the momentum for the step, so a projection there
+is an exact momentum exchange: the impulse removed from the sand is the
+impulse delivered to the club, and it can be summed into a wrench without
+a second force model.  Projecting particles instead would leave the grid
+velocity -- which is what advects everything -- still pointing into the
+club, and the reaction would have to be modelled separately.
+
+Not tunnelling through the club
+-------------------------------
+
+Three mechanisms, because a single one is not enough at 25 m/s:
+
+1. **The CFL step includes the body speed**, so the club advances less
+   than a fraction of a cell per step and cannot skip over a node layer
+   (:mod:`bunkershot3d.solvers.mpm.solver` forms and checks it).
+2. **Swept-node collision.**  A node is collided if it is inside the body
+   *now* or will be inside after this step's body motion.  A node the
+   club is about to reach is stopped before the club arrives rather than
+   after it has passed.
+3. **Particle pushout after advection.**  Anything that still ends up
+   inside the body is placed back on its surface with its inward normal
+   velocity removed.  This is the backstop, and the solver reports how
+   often it fires, because a pushout that fires constantly means the
+   first two mechanisms are not doing their job.
+
+The convex-polygon restriction
+------------------------------
+
+A wedge section -- sole, leading edge, bounce, face -- is very nearly
+convex, and convexity buys an exact inside test and an unambiguous
+nearest-point normal.  A non-convex section would need a real level set;
+this is recorded as a limitation rather than approximated, and
+:meth:`RigidSection.from_points` states plainly that it takes the convex
+hull of what it is given.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from ..exceptions import SolverInputError
+
+__all__ = [
+    "ContactImpulse",
+    "RigidSection",
+    "convex_hull_2d",
+    "plane_torque_about_y",
+]
+
+_DIMENSION = 2
+_MIN_EDGE_LENGTH_M = 1e-12
+_DEGENERATE_DISTANCE_M = 1e-15
+
+
+def plane_torque_about_y(
+    lever_m: NDArray[np.float64], force_n: NDArray[np.float64]
+) -> float:
+    """Out-of-plane torque of in-plane levers and forces.
+
+    In the world frame the section spans ``x`` (along the path) and ``z``
+    (up), so the only torque a plane-strain model can produce is about
+    ``y``.  Written out because the sign is easy to get wrong:
+    ``(r x F) . y_hat = r_z F_x - r_x F_z``, which is the *negative* of
+    the usual scalar cross product of the ``(x, z)`` pair.
+
+    Args:
+        lever_m: ``(n, 2)`` levers from the reference point, ``(x, z)``.
+        force_n: ``(n, 2)`` forces, ``(x, z)``.
+
+    Returns:
+        The summed torque about ``+y`` in N m (per unit width).
+    """
+    return float((lever_m[:, 1] * force_n[:, 0] - lever_m[:, 0] * force_n[:, 1]).sum())
+
+
+def convex_hull_2d(points_m: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Counter-clockwise convex hull by Andrew's monotone chain.
+
+    Implemented here rather than taken from SciPy because ADR-0033 scopes
+    F1 to NumPy alone, and a monotone chain is thirty lines.
+
+    Args:
+        points_m: ``(n, 2)`` points.
+
+    Returns:
+        ``(k, 2)`` hull vertices, counter-clockwise, without a repeated
+        first point.
+
+    Raises:
+        SolverInputError: If fewer than three points survive, or if they
+            are collinear -- a section with no area cannot be an
+            intruder, and returning a degenerate polygon would let that
+            failure surface later as a zero force.
+    """
+    points = np.asarray(points_m, dtype=np.float64)
+    if points.ndim != _DIMENSION or points.shape[1] != _DIMENSION:
+        raise SolverInputError(f"points_m must have shape (n, 2), got {points.shape!r}")
+    if not np.all(np.isfinite(points)):
+        raise SolverInputError("hull points contain non-finite values")
+    unique = np.unique(points, axis=0)
+    if unique.shape[0] < 3:
+        raise SolverInputError(
+            f"a section needs at least 3 distinct points, got {unique.shape[0]}"
+        )
+    order = np.lexsort((unique[:, 1], unique[:, 0]))
+    ordered = unique[order]
+
+    def _half(sequence: NDArray[np.float64]) -> list[NDArray[np.float64]]:
+        chain: list[NDArray[np.float64]] = []
+        for point in sequence:
+            while len(chain) >= 2:
+                first = chain[-1] - chain[-2]
+                second = point - chain[-2]
+                if first[0] * second[1] - first[1] * second[0] > 0.0:
+                    break
+                chain.pop()
+            chain.append(point)
+        return chain
+
+    lower = _half(ordered)
+    upper = _half(ordered[::-1])
+    hull = np.array(lower[:-1] + upper[:-1], dtype=np.float64)
+    if hull.shape[0] < 3:
+        raise SolverInputError(
+            "the section's points are collinear, so the intruder has no area; "
+            "a zero-area body would return a zero force rather than an error"
+        )
+    return hull
+
+
+@dataclass(frozen=True, slots=True)
+class ContactImpulse:
+    """What one step's contact projection did, as an exact momentum ledger.
+
+    The force on the club is ``-sum_i J_i / dt`` by Newton's third law, so
+    this is the whole of F1's contact wrench: there is no separate force
+    model to disagree with the momentum accounting.
+
+    Attributes:
+        node_index: Indices of the nodes that were projected.
+        impulse_n_s: ``(k, 2)`` impulse **the body applied to the sand**,
+            in N s per unit width.
+        position_m: ``(k, 2)`` positions the impulses acted at.
+        stress_force_n: ``(2,)`` the stress-and-weight part of the
+            reaction, ``sum_i (f_i^int + m_i g)`` over projected nodes.
+        n_swept: Nodes collided only because the body will reach them
+            within this step, rather than because it already had.
+    """
+
+    node_index: NDArray[np.int64]
+    impulse_n_s: NDArray[np.float64]
+    position_m: NDArray[np.float64]
+    stress_force_n: NDArray[np.float64]
+    n_swept: int
+
+    @property
+    def n_contacts(self) -> int:
+        """Number of projected nodes."""
+        return int(self.node_index.size)
+
+    def force_on_body_n(self, time_step_s: float) -> NDArray[np.float64]:
+        """Total in-plane force on the body, N per unit width."""
+        if self.n_contacts == 0:
+            return np.zeros(_DIMENSION, dtype=np.float64)
+        return -self.impulse_n_s.sum(axis=0) / time_step_s
+
+    def torque_on_body_n_m(
+        self, time_step_s: float, reference_point_m: NDArray[np.float64]
+    ) -> float:
+        """Torque on the body about ``+y``, N m per unit width."""
+        if self.n_contacts == 0:
+            return 0.0
+        forces = -self.impulse_n_s / time_step_s
+        return plane_torque_about_y(self.position_m - reference_point_m, forces)
+
+
+@dataclass(frozen=True)
+class RigidSection:
+    """A convex polygon intruder with a rigid-body velocity.
+
+    Attributes:
+        vertices_m: ``(k, 2)`` counter-clockwise hull vertices in world
+            ``(x, z)``.
+        velocity_m_s: ``(2,)`` linear velocity of ``reference_point_m``.
+        angular_velocity_rad_s: Rotation rate about ``+y``.
+        reference_point_m: ``(2,)`` point the velocity refers to.
+        friction: Coulomb friction coefficient between club and sand.
+    """
+
+    vertices_m: NDArray[np.float64]
+    velocity_m_s: NDArray[np.float64]
+    angular_velocity_rad_s: float
+    reference_point_m: NDArray[np.float64]
+    friction: float
+
+    def __init__(
+        self,
+        vertices_m: ArrayLike,
+        *,
+        velocity_m_s: ArrayLike = (0.0, 0.0),
+        angular_velocity_rad_s: float = 0.0,
+        reference_point_m: ArrayLike | None = None,
+        friction: float = 0.3,
+    ) -> None:
+        vertices = np.array(vertices_m, dtype=np.float64, copy=True)
+        if vertices.ndim != _DIMENSION or vertices.shape[1] != _DIMENSION:
+            raise SolverInputError(
+                f"vertices_m must have shape (k, 2), got {vertices.shape!r}"
+            )
+        if vertices.shape[0] < 3:
+            raise SolverInputError(
+                f"a section needs at least 3 vertices, got {vertices.shape[0]}"
+            )
+        if not np.all(np.isfinite(vertices)):
+            raise SolverInputError("section vertices contain non-finite values")
+        velocity = np.array(velocity_m_s, dtype=np.float64, copy=True).reshape(-1)
+        if velocity.shape != (_DIMENSION,) or not np.all(np.isfinite(velocity)):
+            raise SolverInputError(
+                f"velocity_m_s must be a finite 2-vector, got {velocity_m_s!r}"
+            )
+        spin = float(angular_velocity_rad_s)
+        if not math.isfinite(spin):
+            raise SolverInputError(
+                f"angular_velocity_rad_s must be finite, got {angular_velocity_rad_s!r}"
+            )
+        reference = (
+            vertices.mean(axis=0)
+            if reference_point_m is None
+            else np.array(reference_point_m, dtype=np.float64, copy=True).reshape(-1)
+        )
+        if reference.shape != (_DIMENSION,) or not np.all(np.isfinite(reference)):
+            raise SolverInputError(
+                f"reference_point_m must be a finite 2-vector, got "
+                f"{reference_point_m!r}"
+            )
+        mu = float(friction)
+        if not math.isfinite(mu) or mu < 0.0:
+            raise SolverInputError(f"friction must be non-negative, got {friction!r}")
+        if _signed_area(vertices) < 0.0:
+            vertices = vertices[::-1].copy()
+        for array in (vertices, velocity, reference):
+            array.flags.writeable = False
+        object.__setattr__(self, "vertices_m", vertices)
+        object.__setattr__(self, "velocity_m_s", velocity)
+        object.__setattr__(self, "angular_velocity_rad_s", spin)
+        object.__setattr__(self, "reference_point_m", reference)
+        object.__setattr__(self, "friction", mu)
+
+    # ------------------------------------------------------------ geometry
+
+    @classmethod
+    def from_points(
+        cls,
+        points_m: ArrayLike,
+        *,
+        velocity_m_s: ArrayLike = (0.0, 0.0),
+        angular_velocity_rad_s: float = 0.0,
+        reference_point_m: ArrayLike | None = None,
+        friction: float = 0.3,
+    ) -> RigidSection:
+        """Build from an arbitrary point cloud by taking its convex hull.
+
+        The hull is taken, not assumed: a wedge section is very nearly
+        convex, and saying so here is honest about the one shape feature
+        this tier cannot represent -- a genuinely re-entrant grind is
+        filled in.
+
+        Args:
+            points_m: ``(n, 2)`` points in the section plane.
+            velocity_m_s: Linear velocity of the reference point.
+            angular_velocity_rad_s: Rotation rate about ``+y``.
+            reference_point_m: Point the velocity refers to.
+            friction: Club-on-sand Coulomb friction.
+
+        Returns:
+            The section.
+        """
+        hull = convex_hull_2d(np.asarray(points_m, dtype=np.float64))
+        return cls(
+            hull,
+            velocity_m_s=velocity_m_s,
+            angular_velocity_rad_s=angular_velocity_rad_s,
+            reference_point_m=reference_point_m,
+            friction=friction,
+        )
+
+    @property
+    def area_m2(self) -> float:
+        """Section area, positive."""
+        return abs(_signed_area(self.vertices_m))
+
+    @property
+    def speed_m_s(self) -> float:
+        """Magnitude of the reference-point velocity."""
+        return float(np.hypot(self.velocity_m_s[0], self.velocity_m_s[1]))
+
+    @property
+    def max_speed_m_s(self) -> float:
+        """Fastest material point on the body, vertices included."""
+        return float(np.linalg.norm(self.velocity_at(self.vertices_m), axis=1).max())
+
+    def bounds_m(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """``(lower, upper)`` axis-aligned bounds of the section."""
+        return self.vertices_m.min(axis=0), self.vertices_m.max(axis=0)
+
+    def translated(self, offset_m: ArrayLike) -> RigidSection:
+        """Return the same section moved rigidly by ``offset_m``."""
+        offset = np.asarray(offset_m, dtype=np.float64).reshape(-1)
+        if offset.shape != (_DIMENSION,) or not np.all(np.isfinite(offset)):
+            raise SolverInputError(
+                f"offset_m must be a finite 2-vector, got {offset_m!r}"
+            )
+        return RigidSection(
+            self.vertices_m + offset,
+            velocity_m_s=self.velocity_m_s,
+            angular_velocity_rad_s=self.angular_velocity_rad_s,
+            reference_point_m=self.reference_point_m + offset,
+            friction=self.friction,
+        )
+
+    def advanced(self, time_step_s: float) -> RigidSection:
+        """Return the section after ``time_step_s`` of its own motion.
+
+        Rotation is applied about the reference point, so a spinning head
+        is advanced exactly rather than by its translation alone.
+
+        Args:
+            time_step_s: The step.
+
+        Returns:
+            The advanced section.
+        """
+        step = float(time_step_s)
+        if not math.isfinite(step):
+            raise SolverInputError(f"time_step_s must be finite, got {time_step_s!r}")
+        moved = self.vertices_m + self.velocity_m_s * step
+        reference = self.reference_point_m + self.velocity_m_s * step
+        if self.angular_velocity_rad_s != 0.0:
+            # Rotation about +y takes (x, z) -> (x cos + z sin, -x sin + z cos).
+            angle = self.angular_velocity_rad_s * step
+            cosine = math.cos(angle)
+            sine = math.sin(angle)
+            lever = moved - reference
+            moved = reference + np.stack(
+                [
+                    lever[:, 0] * cosine + lever[:, 1] * sine,
+                    -lever[:, 0] * sine + lever[:, 1] * cosine,
+                ],
+                axis=1,
+            )
+        return RigidSection(
+            moved,
+            velocity_m_s=self.velocity_m_s,
+            angular_velocity_rad_s=self.angular_velocity_rad_s,
+            reference_point_m=reference,
+            friction=self.friction,
+        )
+
+    def velocity_at(self, points_m: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Rigid-body velocity at world points.
+
+        ``v + omega y_hat x r`` which, in the ``(x, z)`` plane, is
+        ``v + omega (r_z, -r_x)``.
+
+        Args:
+            points_m: ``(n, 2)`` world points.
+
+        Returns:
+            ``(n, 2)`` velocities.
+        """
+        points = np.asarray(points_m, dtype=np.float64)
+        if self.angular_velocity_rad_s == 0.0:
+            return np.broadcast_to(self.velocity_m_s, points.shape)
+        lever = points - self.reference_point_m
+        spin = self.angular_velocity_rad_s * np.stack(
+            [lever[:, 1], -lever[:, 0]], axis=1
+        )
+        return self.velocity_m_s + spin
+
+    def signed_distance(
+        self, points_m: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Signed distance to the section and the outward unit normal.
+
+        Negative inside.  The normal is the true gradient direction of the
+        distance field: for an outside point it is the direction away from
+        the nearest boundary point, which is correct in the corner regions
+        where a max-of-half-planes surrogate would give the wrong
+        direction; for an inside point it is the outward normal of the
+        nearest edge.
+
+        Args:
+            points_m: ``(n, 2)`` world points.
+
+        Returns:
+            ``(distance, normal)`` of shapes ``(n,)`` and ``(n, 2)``.
+        """
+        points = np.asarray(points_m, dtype=np.float64)
+        if points.ndim != _DIMENSION or points.shape[1] != _DIMENSION:
+            raise SolverInputError(
+                f"points_m must have shape (n, 2), got {points.shape!r}"
+            )
+        start = self.vertices_m
+        end = np.roll(self.vertices_m, -1, axis=0)
+        edge = end - start
+        length_squared = np.einsum("ij,ij->i", edge, edge)
+        length_squared = np.where(
+            length_squared > _MIN_EDGE_LENGTH_M**2, length_squared, 1.0
+        )
+
+        relative = points[:, None, :] - start[None, :, :]
+        parameter = np.clip(
+            np.einsum("nkj,kj->nk", relative, edge) / length_squared, 0.0, 1.0
+        )
+        closest = start[None, :, :] + parameter[:, :, None] * edge[None, :, :]
+        separation = points[:, None, :] - closest
+        distance = np.sqrt(np.einsum("nkj,nkj->nk", separation, separation))
+
+        nearest = np.argmin(distance, axis=1)
+        rows = np.arange(points.shape[0])
+        magnitude = distance[rows, nearest]
+
+        # Counter-clockwise winding puts the interior to the left of every
+        # edge, so a point inside is left of all of them.
+        left_of = (
+            edge[None, :, 0] * relative[:, :, 1] - edge[None, :, 1] * relative[:, :, 0]
+        )
+        inside = np.all(left_of >= 0.0, axis=1)
+
+        edge_normal = np.stack([edge[:, 1], -edge[:, 0]], axis=1)
+        edge_normal = edge_normal / np.sqrt(length_squared)[:, None]
+        outward = edge_normal[nearest]
+        usable = magnitude > _DEGENERATE_DISTANCE_M
+        away = np.where(
+            usable[:, None],
+            separation[rows, nearest] / np.where(usable, magnitude, 1.0)[:, None],
+            outward,
+        )
+        normal = np.where(inside[:, None], outward, away)
+        return np.where(inside, -magnitude, magnitude), normal
+
+    def contains(self, points_m: NDArray[np.float64]) -> NDArray[np.bool_]:
+        """Per-point inside test."""
+        distance, _ = self.signed_distance(points_m)
+        return distance < 0.0
+
+    # ------------------------------------------------------------- contact
+
+    def project_grid_velocity(
+        self,
+        node_position_m: NDArray[np.float64],
+        node_velocity_m_s: NDArray[np.float64],
+        node_mass_kg: NDArray[np.float64],
+        *,
+        time_step_s: float,
+        stress_force_n: NDArray[np.float64] | None = None,
+    ) -> tuple[NDArray[np.float64], ContactImpulse]:
+        """Apply the collision projection and return the momentum ledger.
+
+        For every node the body occupies now or will occupy after this
+        step, the sand's velocity relative to the body is decomposed on
+        the outward normal.  A separating node is left alone -- sand may
+        leave the club freely, which is what makes a divot open behind the
+        sole instead of the club dragging a vacuum.  An approaching node
+        has its normal component removed and its tangential component
+        reduced inside the Coulomb cone, sticking when the cone closes.
+
+        Args:
+            node_position_m: ``(n_nodes, 2)`` node positions.
+            node_velocity_m_s: ``(n_nodes, 2)`` nodal velocities after the
+                force update.
+            node_mass_kg: ``(n_nodes,)`` nodal masses.
+            time_step_s: The step, used for the swept test and the ledger.
+            stress_force_n: ``(n_nodes, 2)`` internal-plus-weight force at
+                each node, recorded so the reaction can be split into its
+                stress-borne and momentum-flux parts. Optional.
+
+        Returns:
+            ``(projected_velocity, impulse)``.
+
+        Raises:
+            SolverInputError: If the step is not positive and finite.
+        """
+        step = float(time_step_s)
+        if not math.isfinite(step) or step <= 0.0:
+            raise SolverInputError(f"time_step_s must be positive, got {step!r}")
+
+        distance, normal = self.signed_distance(node_position_m)
+        occupied = distance < 0.0
+        # Swept test: where will the body be at the end of the step?
+        swept_section = self.advanced(step)
+        swept_distance, swept_normal = swept_section.signed_distance(node_position_m)
+        swept_only = (~occupied) & (swept_distance < 0.0)
+        active = occupied | swept_only
+        live = active & (node_mass_kg > 0.0)
+        index = np.flatnonzero(live)
+        if index.size == 0:
+            empty = np.zeros((0, _DIMENSION), dtype=np.float64)
+            return node_velocity_m_s, ContactImpulse(
+                node_index=np.zeros(0, dtype=np.int64),
+                impulse_n_s=empty,
+                position_m=empty,
+                stress_force_n=np.zeros(_DIMENSION, dtype=np.float64),
+                n_swept=0,
+            )
+
+        # A node the body has not reached yet is projected on the normal it
+        # will be hit with, not the one it happens to sit near now.
+        contact_normal = np.where(
+            occupied[index, None], normal[index], swept_normal[index]
+        )
+        positions = node_position_m[index]
+        body_velocity = self.velocity_at(positions)
+        relative = node_velocity_m_s[index] - body_velocity
+        normal_speed = np.einsum("ij,ij->i", relative, contact_normal)
+        approaching = normal_speed < 0.0
+
+        tangential = relative - normal_speed[:, None] * contact_normal
+        tangential_speed = np.sqrt(np.einsum("ij,ij->i", tangential, tangential))
+        cone_limit = -self.friction * normal_speed
+        sticking = tangential_speed <= cone_limit
+        safe_speed = np.where(tangential_speed > 0.0, tangential_speed, 1.0)
+        # v_t' = v_t + mu v_n v_t / |v_t| with v_n < 0, i.e. the tangential
+        # speed is *reduced* by the friction bound rather than replaced by
+        # it.  A frictionless club must leave the tangential velocity
+        # untouched, which is the case this scale has to get right.
+        sliding_scale = np.where(sticking, 0.0, 1.0 - cone_limit / safe_speed)
+        projected_relative = np.where(
+            sticking[:, None],
+            0.0,
+            sliding_scale[:, None] * tangential,
+        )
+        new_relative = np.where(approaching[:, None], projected_relative, relative)
+
+        updated = node_velocity_m_s.copy()
+        updated[index] = new_relative + body_velocity
+        impulse = node_mass_kg[index, None] * (
+            updated[index] - node_velocity_m_s[index]
+        )
+
+        stress_total = (
+            np.zeros(_DIMENSION, dtype=np.float64)
+            if stress_force_n is None
+            else stress_force_n[index].sum(axis=0)
+        )
+        return updated, ContactImpulse(
+            node_index=index,
+            impulse_n_s=impulse,
+            position_m=positions,
+            stress_force_n=stress_total,
+            n_swept=int(swept_only[index].sum()),
+        )
+
+    def push_out(
+        self,
+        positions_m: NDArray[np.float64],
+        velocity_m_s: NDArray[np.float64],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64], int]:
+        """Place any particle inside the body back onto its surface.
+
+        The backstop of the three anti-tunnelling mechanisms.  The
+        particle is moved along the outward normal to the surface and its
+        inward normal velocity is removed; the tangential component is
+        left alone, so a particle sliding along the sole is not braked by
+        the geometric repair.
+
+        Args:
+            positions_m: ``(n, 2)`` particle positions after advection.
+            velocity_m_s: ``(n, 2)`` particle velocities.
+
+        Returns:
+            ``(positions, velocities, n_pushed)``.
+        """
+        distance, normal = self.signed_distance(positions_m)
+        inside = distance < 0.0
+        count = int(inside.sum())
+        if count == 0:
+            return positions_m, velocity_m_s, 0
+        positions = positions_m.copy()
+        velocities = velocity_m_s.copy()
+        index = np.flatnonzero(inside)
+        positions[index] -= distance[index, None] * normal[index]
+        body_velocity = self.velocity_at(positions[index])
+        relative = velocities[index] - body_velocity
+        normal_speed = np.einsum("ij,ij->i", relative, normal[index])
+        entering = normal_speed < 0.0
+        relative = np.where(
+            entering[:, None],
+            relative - normal_speed[:, None] * normal[index],
+            relative,
+        )
+        velocities[index] = relative + body_velocity
+        return positions, velocities, count
+
+
+def _signed_area(vertices_m: NDArray[np.float64]) -> float:
+    """Shoelace area; positive for counter-clockwise winding."""
+    following = np.roll(vertices_m, -1, axis=0)
+    return 0.5 * float(
+        (vertices_m[:, 0] * following[:, 1] - following[:, 0] * vertices_m[:, 1]).sum()
+    )

--- a/src/bunkershot3d/solvers/mpm/constitutive.py
+++ b/src/bunkershot3d/solvers/mpm/constitutive.py
@@ -677,6 +677,16 @@ def principal_stretches(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
     """SVD of a stack of deformation gradients, with a stretch floor.
 
+    Plane strain makes every one of these a ``2 x 2``, so the closed form
+    is used instead of ``np.linalg.svd``: LAPACK is called once per matrix
+    and dominated the step profile at 29% of the runtime, while the ``2 x
+    2`` decomposition is four ``arctan2`` calls over the whole array.
+    Only three properties of the result are relied on downstream --
+    ``U diag(s) V^T = F`` exactly, ``s >= 0``, and ``U`` orthogonal (the
+    isotropic Kirchhoff stress is coaxial with it) -- and the test suite
+    checks all three against LAPACK rather than checking that the factors
+    happen to match it, which they need not.
+
     Args:
         deformation_gradient: ``(n, d, d)`` elastic deformation gradients.
 
@@ -685,8 +695,65 @@ def principal_stretches(
         floored at :data:`_SINGULAR_VALUE_FLOOR` so that their logarithm
         exists even for an inverted or degenerate particle.
     """
-    left, stretches, right_transposed = np.linalg.svd(deformation_gradient)
-    return left, np.maximum(stretches, _SINGULAR_VALUE_FLOOR), right_transposed
+    gradient = np.asarray(deformation_gradient, dtype=np.float64)
+    if gradient.ndim != 3 or gradient.shape[1:] != (
+        PLANE_STRAIN_DIMENSION,
+        PLANE_STRAIN_DIMENSION,
+    ):
+        raise CalibrationError(
+            f"deformation_gradient must have shape (n, 2, 2), got {gradient.shape!r}"
+        )
+    upper_left = gradient[:, 0, 0]
+    upper_right = gradient[:, 0, 1]
+    lower_left = gradient[:, 1, 0]
+    lower_right = gradient[:, 1, 1]
+
+    mean_diagonal = 0.5 * (upper_left + lower_right)
+    diagonal_difference = 0.5 * (upper_left - lower_right)
+    mean_off_diagonal = 0.5 * (lower_left + upper_right)
+    off_diagonal_difference = 0.5 * (lower_left - upper_right)
+
+    rotation_radius = np.hypot(mean_diagonal, off_diagonal_difference)
+    shear_radius = np.hypot(diagonal_difference, mean_off_diagonal)
+    larger = rotation_radius + shear_radius
+    smaller = rotation_radius - shear_radius
+
+    # Writing A = R(phi) diag(s) R(theta)^T and expanding gives
+    # atan2(G, F) = phi + theta and atan2(H, E) = phi - theta, so the two
+    # angles are the half-sum and the half-*difference* in that order.
+    shear_angle = np.arctan2(mean_off_diagonal, diagonal_difference)
+    rotation_angle = np.arctan2(off_diagonal_difference, mean_diagonal)
+    right_angle = 0.5 * (shear_angle - rotation_angle)
+    left_angle = 0.5 * (shear_angle + rotation_angle)
+
+    left = _rotation(left_angle)
+    right = _rotation(right_angle)
+    # A negative determinant puts the second singular value below zero.
+    # Flip it and absorb the sign into the matching right singular vector.
+    flipped = smaller < 0.0
+    if bool(flipped.any()):
+        smaller = np.where(flipped, -smaller, smaller)
+        right[:, :, 1] = np.where(flipped[:, None], -right[:, :, 1], right[:, :, 1])
+
+    stretches = np.stack([larger, smaller], axis=1)
+    return (
+        left,
+        np.maximum(stretches, _SINGULAR_VALUE_FLOOR),
+        np.transpose(right, (0, 2, 1)),
+    )
+
+
+def _rotation(angle: NDArray[np.float64]) -> NDArray[np.float64]:
+    """``(n, 2, 2)`` stack of plane rotations by ``angle``."""
+    cosine = np.cos(angle)
+    sine = np.sin(angle)
+    return np.stack(
+        [
+            np.stack([cosine, -sine], axis=1),
+            np.stack([sine, cosine], axis=1),
+        ],
+        axis=1,
+    )
 
 
 def reconstruct(

--- a/src/bunkershot3d/solvers/mpm/constitutive.py
+++ b/src/bunkershot3d/solvers/mpm/constitutive.py
@@ -1,0 +1,707 @@
+"""The F1 constitutive model: Drucker-Prager sand with a compressive cap.
+
+Why not the mu(I) rheology
+--------------------------
+
+The obvious constitutive choice for flowing sand is the ``mu(I)``
+rheology, and it is the wrong one to ship here.  Barker, Schaeffer,
+Bohorquez & Gray (2015), *"Well-posed and ill-posed behaviour of the
+mu(I)-rheology for granular flow"*, J. Fluid Mech. **779**:794-818, show
+that the incrementally-linearised equations **lose hyperbolicity** -- the
+initial-value problem becomes Hadamard-unstable -- for inertial numbers
+below ``I_1`` and above ``I_2``.  The perturbation growth rate then rises
+without bound with wavenumber, so the computation does not converge under
+refinement: **a finer grid makes the answer worse, not better**, and any
+apparently converged result is the discretisation quietly acting as the
+regulariser.  A tier whose entire deliverable is a *field* that will be
+grid-refined and GCI-reported (ADR-0033) cannot be built on equations
+that are ill-posed in exactly the regime being refined.
+
+Both of ``mu(I)``'s ill-posed regimes are inside a bunker shot, not
+outside it: the quiescent bed far from the club sits at ``I -> 0``, and
+the leading edge reaches ``I ~ 11`` (see
+:mod:`bunkershot3d.solvers.envelope`).  Regularising ``mu(I)`` into a
+well-posed band (Barker & Gray 2017, JFM **828**:5-32) is possible, but
+the regularisation constants are fitted, unmeasured for this sand, and
+would become a second uncalibrated parameter set beside the one issue
+#7999 already records.
+
+What is shipped instead
+-----------------------
+
+**Rate-independent Drucker-Prager elastoplasticity with a compressive
+cap**, integrated as a return mapping on the principal Hencky
+(logarithmic) strains of the elastic deformation gradient:
+
+* Drucker & Prager (1952), *Q. Appl. Math.* **10**:157-165 -- the yield
+  surface.
+* Klar, Gast, Pradhana, Fu, Schroeder, Jiang & Teran (2016),
+  *"Drucker-Prager elastoplasticity for sand"*, ACM Trans. Graph.
+  **35**(4):103 -- the principal-strain-space return mapping used here,
+  and the same material model the F2 reference tier (Newton
+  ``SolverImplicitMPM``) uses, which ADR-0033 requires so that one
+  calibration carries between the tiers.
+* Bonet & Wood (2008), *Nonlinear Continuum Mechanics for Finite Element
+  Analysis*, section 6.6 -- Hencky (logarithmic) hyperelasticity.
+
+Rate independence is the point.  The constitutive response contributes no
+term that can lose hyperbolicity: the characteristic speeds of the
+resulting system are the elastic wave speeds, which are real and positive
+for any admissible ``(lambda, mu)``, so the problem stays well posed at
+every inertial number and refinement is meaningful.  The price is that
+this model has **no Bagnold profile** -- steady inclined flow of a
+rate-independent plastic solid is plug flow with a basal shear band, not
+the 3/2-power profile -- so Bagnold is not available as a verification
+case for this tier, and :mod:`bunkershot3d.solvers.mpm.verification` uses
+an elastic column and a free-fall case instead.
+
+The compressive cap
+-------------------
+
+A bare Drucker-Prager cone is open in compression: the mean stress can
+grow without bound while staying elastic, so nothing stops a bed being
+compacted past the packing limit of its own grains.  The cap here is not
+a tuning constant -- it is read off the sand's own packing state, which
+already knows the densest reproducible packing:
+
+    J_min = phi / phi_max,    eps_v_cap = ln(J_min) < 0
+
+Below that volumetric strain, further compression is plastic compaction
+rather than elastic storage.  A loose bed (``Dr = 0``) therefore has room
+to compact by ~15%, a firm one (``Dr = 0.875``) by ~2%, which is
+critical-state behaviour arriving directly from
+:class:`bunkershot3d.sand.packing.PackingState` rather than from a second
+set of invented constants.
+
+Units are SI throughout, plane strain is ``d = 2``, and every contract
+check is a ``raise`` rather than an ``assert`` because ``python -O``
+strips assertions.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...sand import Angularity, SandState
+from ...sand.provenance import (
+    PropertyProvenance,
+    ProvenanceBasis,
+    SandProvenance,
+)
+from ..envelope import GRAVITY_M_S2
+from ..exceptions import CalibrationError
+
+__all__ = [
+    "HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA",
+    "HARDIN_RICHART_ROUND_COEFFICIENT_KPA",
+    "PLANE_STRAIN_DIMENSION",
+    "SAND_POISSON_RATIO",
+    "SandContinuum",
+    "drucker_prager_alpha",
+    "hencky_kirchhoff_principal",
+    "principal_stretches",
+    "project_to_yield_surface",
+    "reconstruct",
+    "yield_function",
+]
+
+PLANE_STRAIN_DIMENSION = 2
+"""Spatial dimension of the plane-strain problem, ``d`` in the return map."""
+
+SAND_POISSON_RATIO = 0.30
+"""Drained Poisson's ratio for a granular soil.
+
+A textbook convention for sands (0.25-0.35), not a measurement on bunker
+sand.  It is a weak lever here: the plastic limit state that sets the
+forces is fixed by the friction angle and the cap, while ``nu`` and the
+shear modulus set only the elastic wave speed and therefore the timestep.
+"""
+
+HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA = 3230.0
+"""``A`` in ``G_max = A (2.97 - e)^2 / (1 + e) sqrt(p')``, SI-converted.
+
+Hardin & Richart (1963), *"Elastic wave velocities in granular soils"*,
+J. Soil Mech. Found. Div. ASCE **89**(SM1):33-65, angular-grain form,
+converted from the original 1230 psi coefficient.  USGA guidance
+specifies angular bunker sand, so this is the branch the presets take."""
+
+HARDIN_RICHART_ROUND_COEFFICIENT_KPA = 6908.0
+"""The round-grain branch, ``G_max = A (2.17 - e)^2 / (1 + e) sqrt(p')``."""
+
+_ANGULAR_VOID_OFFSET = 2.97
+_ROUND_VOID_OFFSET = 2.17
+_KPA_PER_PA = 1.0e-3
+_PA_PER_KPA = 1.0e3
+
+_SINGULAR_VALUE_FLOOR = 1.0e-8
+"""Floor on a principal stretch before its logarithm is taken.
+
+A deformation gradient that has been driven to (or through) zero
+determinant has no logarithm.  Flooring rather than raising keeps one
+pathological particle from destroying an otherwise healthy step, and the
+solver reports how many particles were floored so the event is visible.
+"""
+
+_MIN_EARTH_PRESSURE_DEPTH_M = 1.0e-4
+"""Shallowest bed depth the reference confining stress is formed on."""
+
+
+def drucker_prager_alpha(friction_angle_deg: float) -> float:
+    """Return the Drucker-Prager cone slope ``alpha`` for a friction angle.
+
+    ``alpha = sqrt(2/3) * 2 sin(phi) / (3 - sin(phi))`` -- the inner-cone
+    (compressive-meridian) match to Mohr-Coulomb, as used by Klar et al.
+    (2016) eq. (26).  The yield surface is written on the Kirchhoff stress
+    as ``||dev(tau)|| + alpha tr(tau) <= 0``, so ``alpha`` is
+    dimensionless and the same number serves plane strain and 3-D, which
+    is what lets F1 and the F2 reference share one calibration.
+
+    Args:
+        friction_angle_deg: Internal friction angle in degrees, strictly
+            inside ``(0, 90)``.
+
+    Returns:
+        The cone slope.
+
+    Raises:
+        CalibrationError: If the friction angle is not a usable angle.
+    """
+    angle = float(friction_angle_deg)
+    if not math.isfinite(angle) or not 0.0 < angle < 90.0:
+        raise CalibrationError(
+            "friction angle must lie strictly between 0 and 90 deg, got "
+            f"{friction_angle_deg!r} deg"
+        )
+    sin_phi = math.sin(math.radians(angle))
+    return math.sqrt(2.0 / 3.0) * (2.0 * sin_phi) / (3.0 - sin_phi)
+
+
+def hencky_kirchhoff_principal(
+    hencky_strain: NDArray[np.float64],
+    *,
+    shear_modulus_pa: float,
+    lame_lambda_pa: float,
+) -> NDArray[np.float64]:
+    """Principal Kirchhoff stresses of the Hencky elastic model.
+
+    ``tau_i = 2 mu eps_i + lambda tr(eps)``, the principal form of the
+    St Venant-Kirchhoff model written in logarithmic strain (Bonet & Wood
+    2008, section 6.6).  Kirchhoff rather than Cauchy because the return
+    mapping is defined on ``tau``; divide by ``J`` for Cauchy.
+
+    Args:
+        hencky_strain: ``(n, d)`` principal logarithmic strains.
+        shear_modulus_pa: Lame ``mu``.
+        lame_lambda_pa: Lame ``lambda``.
+
+    Returns:
+        ``(n, d)`` principal Kirchhoff stresses in pascals.
+    """
+    trace = hencky_strain.sum(axis=-1, keepdims=True)
+    return 2.0 * shear_modulus_pa * hencky_strain + lame_lambda_pa * trace
+
+
+def yield_function(
+    hencky_strain: NDArray[np.float64],
+    *,
+    shear_modulus_pa: float,
+    lame_lambda_pa: float,
+    alpha: float,
+    tip_volumetric_strain: float,
+) -> NDArray[np.float64]:
+    """Drucker-Prager yield function on the elastic Hencky strain.
+
+    ``y = ||dev(tau)|| + alpha (tr(tau) - tr(tau)_tip)``, expressed
+    directly in strain because ``dev(tau) = 2 mu dev(eps)`` and
+    ``tr(tau) = (2 mu + d lambda) tr(eps)`` for the Hencky model.  Values
+    are pascals; ``y <= 0`` is admissible.
+
+    Exposed because it is the sharpest available verification of the
+    return mapping: after
+    :func:`project_to_yield_surface` every particle must satisfy
+    ``y <= 0``, and every particle that actually yielded must satisfy
+    ``y = 0`` to round-off.
+
+    Args:
+        hencky_strain: ``(n, d)`` principal logarithmic strains.
+        shear_modulus_pa: Lame ``mu``.
+        lame_lambda_pa: Lame ``lambda``.
+        alpha: Cone slope from :func:`drucker_prager_alpha`.
+        tip_volumetric_strain: ``tr(eps)`` at the cone tip, which is
+            positive when the sand carries cohesion and zero when it does
+            not.
+
+    Returns:
+        ``(n,)`` yield-function values in pascals.
+    """
+    dimension = hencky_strain.shape[-1]
+    trace = hencky_strain.sum(axis=-1)
+    deviator = hencky_strain - (trace / dimension)[..., None]
+    deviator_norm = np.sqrt(np.einsum("ij,ij->i", deviator, deviator))
+    bulk_term = 2.0 * shear_modulus_pa + dimension * lame_lambda_pa
+    return 2.0 * shear_modulus_pa * deviator_norm + alpha * bulk_term * (
+        trace - tip_volumetric_strain
+    )
+
+
+def project_to_yield_surface(
+    hencky_strain: NDArray[np.float64],
+    *,
+    shear_modulus_pa: float,
+    lame_lambda_pa: float,
+    alpha: float,
+    tip_volumetric_strain: float,
+    cap_volumetric_strain: float,
+) -> tuple[NDArray[np.float64], NDArray[np.bool_], NDArray[np.bool_]]:
+    """Return-map the elastic Hencky strain onto the capped DP cone.
+
+    Three cases, in the order they are applied:
+
+    1. **Cap.**  ``tr(eps) < eps_cap`` means the bed has been compressed
+       past the packing limit of its own grains; the excess volumetric
+       strain becomes plastic compaction and the trace is clamped.  The
+       deviator is untouched, so this is a purely volumetric projection.
+    2. **Tip.**  ``tr(eps) >= tr(eps)_tip`` is a state the cone cannot
+       carry at all -- isotropic tension beyond the cohesive apex -- and
+       the whole deviatoric strain is released, leaving the particle at
+       the tip.  This is what lets sand separate freely at a free surface
+       instead of behaving like a stretched solid.  Note the condition is
+       on the trace alone: Klar's published form also sends ``||dev|| =
+       0`` to the tip, which would wrongly claim a purely isotropic
+       *compression* -- an admissible state deep in the cone, and the
+       commonest state in a settled bed.
+    3. **Cone.**  Otherwise ``dgamma = ||dev|| + alpha (2 mu + d lambda) /
+       (2 mu) * (tr - tr_tip)``; a non-positive ``dgamma`` is elastic and
+       a positive one is returned along the deviatoric direction.
+
+    Case 3 changes only the deviator, so plastic flow is **volume
+    preserving** -- a non-associated flow rule, deliberately, because the
+    associated rule for a frictional cone predicts unbounded dilation
+    (Klar et al. 2016, section 4.2).  Dilatancy in this tier is carried by
+    the cap and the packing state, not by the flow rule.
+
+    Args:
+        hencky_strain: ``(n, d)`` trial principal logarithmic strains.
+        shear_modulus_pa: Lame ``mu``.
+        lame_lambda_pa: Lame ``lambda``.
+        alpha: Cone slope.
+        tip_volumetric_strain: ``tr(eps)`` at the cone tip, ``>= 0``.
+        cap_volumetric_strain: Most compressive ``tr(eps)`` the packing
+            state can carry elastically, ``< 0``.
+
+    Returns:
+        ``(projected_strain, yielded, capped)`` where ``yielded`` marks
+        particles moved by case 2 or 3 and ``capped`` marks those moved by
+        case 1.
+
+    Raises:
+        CalibrationError: If the strain array is not ``(n, d)`` with
+            ``d >= 1``, or if the cap is not compressive.
+    """
+    if hencky_strain.ndim != 2 or hencky_strain.shape[1] < 1:
+        raise CalibrationError(
+            "hencky_strain must have shape (n, d) with d >= 1, got "
+            f"{hencky_strain.shape!r}"
+        )
+    if not math.isfinite(cap_volumetric_strain) or cap_volumetric_strain >= 0.0:
+        raise CalibrationError(
+            "cap_volumetric_strain must be negative -- the cap is a limit on "
+            f"compaction, not on extension -- got {cap_volumetric_strain!r}"
+        )
+    dimension = hencky_strain.shape[1]
+    strain = np.array(hencky_strain, dtype=np.float64, copy=True)
+
+    trace = strain.sum(axis=1)
+    capped = trace < cap_volumetric_strain
+    if bool(capped.any()):
+        correction = np.where(capped, cap_volumetric_strain - trace, 0.0) / dimension
+        strain = strain + correction[:, None]
+        trace = strain.sum(axis=1)
+
+    deviator = strain - (trace / dimension)[:, None]
+    deviator_norm = np.sqrt(np.einsum("ij,ij->i", deviator, deviator))
+
+    at_tip = trace >= tip_volumetric_strain
+    bulk_term = 2.0 * shear_modulus_pa + dimension * lame_lambda_pa
+    delta_gamma = deviator_norm + alpha * (bulk_term / (2.0 * shear_modulus_pa)) * (
+        trace - tip_volumetric_strain
+    )
+    # A state on the hydrostatic axis has no deviatoric direction to be
+    # projected along.  It needs none: below the tip it is admissible, and
+    # at or above the tip the tip branch above already claims it.
+    on_cone = (~at_tip) & (deviator_norm > 0.0) & (delta_gamma > 0.0)
+
+    projected = strain.copy()
+    if bool(at_tip.any()):
+        projected[at_tip] = tip_volumetric_strain / dimension
+    if bool(on_cone.any()):
+        scale = np.where(deviator_norm > 0.0, delta_gamma / deviator_norm, 0.0)
+        projected = np.where(
+            on_cone[:, None], strain - scale[:, None] * deviator, projected
+        )
+    return projected, at_tip | on_cone, capped
+
+
+@dataclass(frozen=True)
+class SandContinuum:
+    """The continuum material F1 solves, derived from a :class:`SandState`.
+
+    Every constant here is either read from the sand package or derived
+    from something it already carries.  Nothing is a second, parallel set
+    of sand constants -- issue #7999 records that the sand package's own
+    values are borrowed, and duplicating them somewhere else would make
+    that record unfalsifiable.
+
+    Attributes:
+        density_kg_m3: Bulk density including pore water, from
+            :attr:`~bunkershot3d.sand.state.SandState.bulk_density_kg_m3`.
+        shear_modulus_pa: Lame ``mu``.
+        lame_lambda_pa: Lame ``lambda``.
+        alpha: Drucker-Prager cone slope.
+        tip_volumetric_strain: ``tr(eps)`` at the cohesive cone tip.
+        cap_volumetric_strain: Most compressive ``tr(eps)`` the packing
+            state carries elastically.
+        grain_diameter_m: ``d50``, for the validity envelope.
+        friction_angle_deg: Retained for reporting.
+        cohesion_pa: Moisture-derived apparent cohesion.
+        provenance: Where each of the above came from.
+    """
+
+    density_kg_m3: float
+    shear_modulus_pa: float
+    lame_lambda_pa: float
+    alpha: float
+    tip_volumetric_strain: float
+    cap_volumetric_strain: float
+    grain_diameter_m: float
+    friction_angle_deg: float
+    cohesion_pa: float
+    provenance: SandProvenance
+
+    def __post_init__(self) -> None:
+        positive = {
+            "density_kg_m3": self.density_kg_m3,
+            "shear_modulus_pa": self.shear_modulus_pa,
+            "lame_lambda_pa": self.lame_lambda_pa,
+            "alpha": self.alpha,
+            "grain_diameter_m": self.grain_diameter_m,
+        }
+        for name, value in positive.items():
+            if not math.isfinite(value) or value <= 0.0:
+                raise CalibrationError(f"{name} must be positive, got {value!r}")
+        if not math.isfinite(self.cap_volumetric_strain) or (
+            self.cap_volumetric_strain >= 0.0
+        ):
+            raise CalibrationError(
+                "cap_volumetric_strain must be negative, got "
+                f"{self.cap_volumetric_strain!r}"
+            )
+        if not math.isfinite(self.tip_volumetric_strain) or (
+            self.tip_volumetric_strain < 0.0
+        ):
+            raise CalibrationError(
+                "tip_volumetric_strain must be non-negative -- a cohesionless "
+                f"sand has a tip at zero -- got {self.tip_volumetric_strain!r}"
+            )
+
+    # ------------------------------------------------------------- derived
+
+    @property
+    def youngs_modulus_pa(self) -> float:
+        """``E`` implied by the Lame constants."""
+        numerator = self.shear_modulus_pa * (
+            3.0 * self.lame_lambda_pa + 2.0 * self.shear_modulus_pa
+        )
+        return numerator / (self.lame_lambda_pa + self.shear_modulus_pa)
+
+    @property
+    def p_wave_modulus_pa(self) -> float:
+        """``lambda + 2 mu``: the constrained (oedometer) modulus."""
+        return self.lame_lambda_pa + 2.0 * self.shear_modulus_pa
+
+    @property
+    def elastic_wave_speed_m_s(self) -> float:
+        """Dilatational wave speed ``sqrt((lambda + 2 mu) / rho)``.
+
+        This is the speed the CFL condition is formed on: it is the
+        fastest signal the discretisation carries, and it is **computed**
+        from the material rather than pinned, so a stiffer sand shortens
+        the timestep by itself.
+        """
+        return math.sqrt(self.p_wave_modulus_pa / self.density_kg_m3)
+
+    @property
+    def tensile_strength_pa(self) -> float:
+        """Isotropic tensile strength ``c cot(phi)`` at the cone apex."""
+        return self.cohesion_pa / math.tan(math.radians(self.friction_angle_deg))
+
+    def cauchy_from_hencky(
+        self, hencky_strain: NDArray[np.float64]
+    ) -> NDArray[np.float64]:
+        """Principal Cauchy stresses for a principal Hencky strain.
+
+        Args:
+            hencky_strain: ``(n, d)`` principal logarithmic strains.
+
+        Returns:
+            ``(n, d)`` principal Cauchy stresses; ``J = exp(tr(eps))``.
+        """
+        kirchhoff = hencky_kirchhoff_principal(
+            hencky_strain,
+            shear_modulus_pa=self.shear_modulus_pa,
+            lame_lambda_pa=self.lame_lambda_pa,
+        )
+        jacobian = np.exp(hencky_strain.sum(axis=-1))[..., None]
+        return kirchhoff / jacobian
+
+    def project(
+        self, hencky_strain: NDArray[np.float64]
+    ) -> tuple[NDArray[np.float64], NDArray[np.bool_], NDArray[np.bool_]]:
+        """Return-map a trial strain with this material's constants."""
+        return project_to_yield_surface(
+            hencky_strain,
+            shear_modulus_pa=self.shear_modulus_pa,
+            lame_lambda_pa=self.lame_lambda_pa,
+            alpha=self.alpha,
+            tip_volumetric_strain=self.tip_volumetric_strain,
+            cap_volumetric_strain=self.cap_volumetric_strain,
+        )
+
+    def yield_value(self, hencky_strain: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Yield-function values for this material's constants."""
+        return yield_function(
+            hencky_strain,
+            shear_modulus_pa=self.shear_modulus_pa,
+            lame_lambda_pa=self.lame_lambda_pa,
+            alpha=self.alpha,
+            tip_volumetric_strain=self.tip_volumetric_strain,
+        )
+
+    # ------------------------------------------------------------ factory
+
+    @classmethod
+    def from_sand_state(
+        cls,
+        sand: SandState,
+        *,
+        reference_depth_m: float | None = None,
+        poisson_ratio: float = SAND_POISSON_RATIO,
+        gravity_m_s2: float = GRAVITY_M_S2,
+        shear_modulus_pa: float | None = None,
+        dilation_suction_pa: float | None = None,
+    ) -> SandContinuum:
+        """Derive the continuum constants from a sand state.
+
+        The small-strain shear modulus follows Hardin & Richart (1963),
+        which consumes exactly the quantities the sand package already
+        carries -- void ratio, angularity, and a confining stress formed
+        from the bed's own depth and bulk density -- rather than
+        introducing an independent stiffness constant.  The branch is
+        chosen by :class:`~bunkershot3d.sand.packing.Angularity`, so an
+        angular USGA sand and a rounded one do not silently share a
+        modulus.
+
+        The confining stress is the geostatic mean effective stress at
+        mid-bed, ``p' = (1 + 2 K_0)/3 * rho g h/2`` with Jaky's
+        ``K_0 = 1 - sin(phi)``.  It is a *reference* stress for the
+        modulus only: the model is not pressure-dependent at runtime, and
+        stating that plainly matters more than hiding it, because a
+        pressure-dependent modulus would make the elastic wave speed --
+        and therefore the timestep -- a function of the solution.
+
+        Args:
+            sand: The bed being struck.
+            reference_depth_m: Bed depth the confining stress is formed
+                over. Defaults to the sand state's own bed depth.
+            poisson_ratio: Drained Poisson's ratio.
+            gravity_m_s2: Gravitational acceleration.
+            shear_modulus_pa: Override the derived modulus. Supplied by
+                verification cases that need a stated stiffness, and by
+                callers who have measured one.
+            dilation_suction_pa: Forwarded to
+                :meth:`~bunkershot3d.sand.state.SandState.cohesive_strength_pa`.
+                A **saturated** bed has no default here and the sand
+                package raises without it, which is deliberate and is
+                left to propagate: a silent zero and a silent multi-MPa
+                suction are both wrong, and F1 has no better answer than
+                the sand model does.
+
+        Returns:
+            The continuum material.
+
+        Raises:
+            CalibrationError: If the sand state is not a
+                :class:`~bunkershot3d.sand.state.SandState`, or if the
+                Poisson ratio is outside ``(-1, 0.5)``.
+            MoistureRegimeError: If the bed is saturated and no dilation
+                suction was supplied.
+        """
+        if not isinstance(sand, SandState):
+            raise CalibrationError(f"expected a SandState, got {type(sand).__name__}")
+        if not math.isfinite(poisson_ratio) or not -1.0 < poisson_ratio < 0.5:
+            raise CalibrationError(
+                "poisson_ratio must lie strictly inside (-1, 0.5), got "
+                f"{poisson_ratio!r}"
+            )
+        depth_m = sand.bed.depth_m if reference_depth_m is None else reference_depth_m
+        modulus_pa = (
+            _hardin_richart_shear_modulus_pa(
+                sand, depth_m=depth_m, gravity_m_s2=gravity_m_s2
+            )
+            if shear_modulus_pa is None
+            else float(shear_modulus_pa)
+        )
+        if not math.isfinite(modulus_pa) or modulus_pa <= 0.0:
+            raise CalibrationError(
+                f"shear modulus must be positive, got {modulus_pa!r} Pa"
+            )
+        lame_lambda = 2.0 * modulus_pa * poisson_ratio / (1.0 - 2.0 * poisson_ratio)
+
+        alpha = drucker_prager_alpha(sand.friction_angle_deg)
+        cohesion_pa = float(sand.cohesive_strength_pa(dilation_suction_pa))
+        tensile_pa = cohesion_pa / math.tan(sand.friction_angle_rad)
+        bulk_term = 2.0 * modulus_pa + PLANE_STRAIN_DIMENSION * lame_lambda
+        tip = PLANE_STRAIN_DIMENSION * tensile_pa / bulk_term
+
+        packing = sand.packing
+        cap = math.log(packing.solid_fraction / packing.solid_fraction_max)
+        if cap >= 0.0:
+            raise CalibrationError(
+                f"sand '{sand.name}' is already at or past its densest packing "
+                f"(phi = {packing.solid_fraction:.4f}, phi_max = "
+                f"{packing.solid_fraction_max:.4f}), so there is no compressive "
+                "cap to place; the packing state is not physical"
+            )
+        return cls(
+            density_kg_m3=sand.bulk_density_kg_m3,
+            shear_modulus_pa=modulus_pa,
+            lame_lambda_pa=lame_lambda,
+            alpha=alpha,
+            tip_volumetric_strain=tip,
+            cap_volumetric_strain=cap,
+            grain_diameter_m=sand.d50_m,
+            friction_angle_deg=sand.friction_angle_deg,
+            cohesion_pa=cohesion_pa,
+            provenance=_continuum_provenance(sand, derived=shear_modulus_pa is None),
+        )
+
+
+def _hardin_richart_shear_modulus_pa(
+    sand: SandState, *, depth_m: float, gravity_m_s2: float
+) -> float:
+    """Small-strain shear modulus from the void ratio and a confining stress."""
+    depth = max(float(depth_m), _MIN_EARTH_PRESSURE_DEPTH_M)
+    earth_pressure_coefficient = 1.0 - math.sin(sand.friction_angle_rad)
+    vertical_stress_pa = sand.bulk_density_kg_m3 * gravity_m_s2 * depth / 2.0
+    mean_stress_kpa = (
+        (1.0 + 2.0 * earth_pressure_coefficient)
+        / 3.0
+        * vertical_stress_pa
+        * _KPA_PER_PA
+    )
+    void_ratio = sand.void_ratio
+    if sand.angularity.shape_index >= Angularity.SUBANGULAR.shape_index:
+        coefficient = HARDIN_RICHART_ANGULAR_COEFFICIENT_KPA
+        offset = _ANGULAR_VOID_OFFSET
+    else:
+        coefficient = HARDIN_RICHART_ROUND_COEFFICIENT_KPA
+        offset = _ROUND_VOID_OFFSET
+    shape_term = (offset - void_ratio) ** 2 / (1.0 + void_ratio)
+    return coefficient * shape_term * math.sqrt(mean_stress_kpa) * _PA_PER_KPA
+
+
+def _continuum_provenance(sand: SandState, *, derived: bool) -> SandProvenance:
+    """Carry the sand's provenance forward and add the F1-specific entries."""
+    entries = dict(sand.provenance.entries)
+    entries["elastic_shear_modulus_pa"] = (
+        PropertyProvenance(
+            basis=ProvenanceBasis.ESTIMATED,
+            source=(
+                "Hardin & Richart (1963), Elastic wave velocities in granular "
+                "soils, J. Soil Mech. Found. Div. ASCE 89(SM1):33-65"
+            ),
+            note=(
+                "Small-strain modulus from the void ratio, the grain angularity "
+                "and a geostatic reference confining stress. Not measured on "
+                "bunker sand. In a rate-independent plastic model the modulus "
+                "sets the elastic wave speed and hence the timestep; the limit "
+                "state that sets the forces is fixed by the friction angle and "
+                "the compressive cap."
+            ),
+        )
+        if derived
+        else PropertyProvenance(
+            basis=ProvenanceBasis.CONVENTION,
+            source="caller-supplied shear modulus",
+            note="Supplied explicitly rather than derived; not a measurement.",
+        )
+    )
+    entries["poisson_ratio"] = PropertyProvenance(
+        basis=ProvenanceBasis.CONVENTION,
+        source="textbook drained Poisson ratio band for sands, 0.25-0.35",
+        note="A convention, not a measurement on bunker sand.",
+    )
+    entries["yield_surface"] = PropertyProvenance(
+        basis=ProvenanceBasis.ESTIMATED,
+        source=(
+            "Drucker & Prager (1952) Q. Appl. Math. 10:157-165; return mapping "
+            "per Klar et al. (2016) ACM TOG 35(4):103"
+        ),
+        note=(
+            "Cone slope is the inner-cone Mohr-Coulomb match to the sand's own "
+            "friction angle; the cohesive tip comes from the moisture model. "
+            "Rate-independent by choice: the mu(I) rheology is ill-posed at "
+            "both low and high inertial number (Barker et al. 2015, JFM "
+            "779:794-818) and would not converge under the grid refinement "
+            "ADR-0033 requires this tier to report."
+        ),
+    )
+    entries["compressive_cap"] = PropertyProvenance(
+        basis=ProvenanceBasis.ESTIMATED,
+        source="random-close-packing limit of the sand's own PackingState",
+        note=(
+            "eps_v_cap = ln(phi / phi_max). Derived from the packing state "
+            "rather than fitted, so a loose bed compacts further than a firm "
+            "one without a second constant being introduced."
+        ),
+    )
+    return SandProvenance(entries=entries)
+
+
+def principal_stretches(
+    deformation_gradient: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+    """SVD of a stack of deformation gradients, with a stretch floor.
+
+    Args:
+        deformation_gradient: ``(n, d, d)`` elastic deformation gradients.
+
+    Returns:
+        ``(left, stretches, right_transposed)`` with the singular values
+        floored at :data:`_SINGULAR_VALUE_FLOOR` so that their logarithm
+        exists even for an inverted or degenerate particle.
+    """
+    left, stretches, right_transposed = np.linalg.svd(deformation_gradient)
+    return left, np.maximum(stretches, _SINGULAR_VALUE_FLOOR), right_transposed
+
+
+def reconstruct(
+    left: NDArray[np.float64],
+    hencky_strain: NDArray[np.float64],
+    right_transposed: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Rebuild ``F = U exp(eps) V^T`` from a projected principal strain.
+
+    Args:
+        left: ``(n, d, d)`` left singular vectors.
+        hencky_strain: ``(n, d)`` principal logarithmic strains.
+        right_transposed: ``(n, d, d)`` transposed right singular vectors.
+
+    Returns:
+        ``(n, d, d)`` deformation gradients.
+    """
+    return (left * np.exp(hencky_strain)[:, None, :]) @ right_transposed

--- a/src/bunkershot3d/solvers/mpm/envelope.py
+++ b/src/bunkershot3d/solvers/mpm/envelope.py
@@ -1,0 +1,325 @@
+"""The F1 validity envelope and the quantities ADR-0033 refuses outright.
+
+Why F1 does not reuse ``evaluate_envelope``
+-------------------------------------------
+
+:func:`bunkershot3d.solvers.envelope.evaluate_envelope` judges a query
+against **3D-RFT's** limits: a Froude ceiling of 0.4, a micro-inertial
+limit of 0.1, Askari & Kamrin's ``I_G`` on the surface discretisation,
+and the five Zhang & Goldman RFT failure modes attached unconditionally.
+Three of those standing caveats -- no wake model, reduced accuracy at
+sharp corners, steady-state assumption -- are statements about *resistive
+force theory*.  Attaching them to a continuum solve would be a category
+error, and a flattering one: it would describe F1's weaknesses using F0's
+vocabulary and so hide the ones F1 actually has.
+
+The shared machinery that is genuinely tier-independent **is** reused:
+:class:`~bunkershot3d.solvers.envelope.ValidityVerdict`,
+:class:`~bunkershot3d.solvers.envelope.EnvelopeStatus`,
+:class:`~bunkershot3d.solvers.envelope.Caveat`,
+:func:`~bunkershot3d.solvers.envelope.dimensionless_groups` and
+:func:`~bunkershot3d.solvers.envelope.worst_of`.  A caller therefore
+handles an F0 verdict and an F1 verdict identically, which is the point
+of ADR-0032's one-protocol rule.
+
+The status floor
+----------------
+
+**No F1 query can be better than ``BEYOND_VALIDATION``.**  That is not a
+pessimistic default; it is arithmetic.  ``EXTRAPOLATED`` means "outside
+the stated limits but inside the published validation set", and issue
+#8616 found there is no published validation set for any quantity this
+tier produces -- no measured sand velocity field, no measured divot
+section, no measured clubhead deceleration in sand.  A status of
+``WITHIN`` would have to be measured against something that does not
+exist.  The NASA-STD-7009B self-assessment records validation at level 0
+of 4, and this floor is how that number is prevented from quietly rising
+because a new tier was added.
+
+Refinement runs the other way here
+----------------------------------
+
+F0's trap is that refining the surface mesh *raises* ``I_G`` and makes
+the fit less exact.  F1's is the mirror image: refining ``dx`` below a
+few grain diameters means the continuum is being asked to resolve
+structure the size of individual grains, where a continuum stress has no
+meaning.  So this envelope refuses a grid that is **too fine** as well as
+a feature that spans too few grains.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from enum import StrEnum
+
+from ..envelope import (
+    GRAVITY_M_S2,
+    MARGINAL_CONTINUUM_SIZE_RATIO,
+    MAX_VALIDATED_SPEED_M_S,
+    MIN_CONTINUUM_SIZE_RATIO,
+    Caveat,
+    DimensionlessGroups,
+    EnvelopeStatus,
+    ValidityVerdict,
+    dimensionless_groups,
+)
+from ..exceptions import OutOfEnvelopeError, SolverInputError
+
+__all__ = [
+    "F1_STANDING_CAVEATS",
+    "MIN_CELLS_PER_GRAIN",
+    "MIN_CELLS_PER_RESOLVED_FEATURE",
+    "RefusedQuantity",
+    "evaluate_f1_envelope",
+    "require_quotable",
+]
+
+MIN_CELLS_PER_GRAIN = 2.0
+"""Fewest grain diameters a cell may span before the continuum is a fiction.
+
+A cell finer than about two grains is resolving structure the size of
+individual grains with a model that has no grains in it.  Refining past
+this point does not improve the answer; it changes what the answer is
+about."""
+
+MIN_CELLS_PER_RESOLVED_FEATURE = 4.0
+"""Cells across a feature below which that feature is not resolved.
+
+ADR-0033 puts the leading edge deliberately below this, so falling under
+it raises :attr:`~bunkershot3d.solvers.envelope.Caveat.UNDER_RESOLVED_LEADING_EDGE`
+rather than a refusal -- but it is stated on every verdict, because a
+reader looking at a picture of the flow around the edge is entitled to
+know the edge was never resolved."""
+
+F1_STANDING_CAVEATS: tuple[Caveat, ...] = (
+    Caveat.PLANE_STRAIN_NO_OUT_OF_PLANE,
+    Caveat.RATE_INDEPENDENT_PLASTICITY,
+    Caveat.DECLARED_EFFECTIVE_WIDTH,
+    Caveat.BORROWED_COEFFICIENTS,
+    Caveat.NO_MEASURED_COMPARISON,
+)
+"""Caveats that apply to every F1 result without exception.
+
+Four of the five are structural -- they describe what the formulation
+cannot carry -- and the fifth records that the sand constants are
+borrowed, which F1 inherits from the sand package along with the
+constants themselves."""
+
+
+class RefusedQuantity(StrEnum):
+    """Quantities ADR-0033 forbids F1 from reporting at all.
+
+    "Refused" in that ADR means **the API raises**, not "discouraged by
+    documentation".  The distinction is the whole point: a figure outlives
+    its caption, and a number that can be read off an F1 result will be
+    quoted eventually regardless of what the docstring said.
+    """
+
+    CLUB_FORCE = "club_force"
+    """Absolute club force or wrench. F0 owns this; F1 is under-resolved
+    at the leading edge, which is where club force lives."""
+
+    BALL_LAUNCH = "ball_launch"
+    """Ball speed, launch angle or spin. The F0 momentum-transfer path of
+    #8657 remains the only route, and is itself uncalibrated."""
+
+    OUT_OF_PLANE = "out_of_plane"
+    """Any heel-toe or lateral distribution. The quantity does not exist
+    in plane strain, so this is refused rather than approximated."""
+
+
+_REFUSAL_TEXT: Mapping[RefusedQuantity, str] = {
+    RefusedQuantity.CLUB_FORCE: (
+        "F1 may not be quoted for absolute club force. It runs at bulk "
+        "resolution (dx ~ 1-2 mm) and the leading edge, where club force is "
+        "generated, spans only a few cells. F0's per-element decomposition "
+        "owns this quantity. F1's wrench exists only for the shape-and-timing "
+        "cross-check of ADR-0033's B5, and its magnitude additionally depends "
+        "on a declared effective width that is an assumption, not a result."
+    ),
+    RefusedQuantity.BALL_LAUNCH: (
+        "F1 may not be quoted for ball speed, launch angle or spin. Its ball "
+        "exists to show what reaches the ball, and in plane strain it is an "
+        "infinite cylinder rather than a sphere. Ball launch remains on F0's "
+        "momentum-transfer path (#8657)."
+    ),
+    RefusedQuantity.OUT_OF_PLANE: (
+        "F1 may not be quoted for any heel-toe or out-of-plane distribution. "
+        "Plane strain has no third dimension to distribute anything over, so "
+        "there is no approximate answer to give -- only a fabricated one."
+    ),
+}
+
+
+def require_quotable(quantity: RefusedQuantity | str) -> None:
+    """Raise for any quantity ADR-0033 forbids F1 from reporting.
+
+    Args:
+        quantity: The quantity a caller is about to read off an F1 result.
+
+    Raises:
+        OutOfEnvelopeError: Always, for a recognised refused quantity, in
+            the same shape as the existing out-of-envelope refusals.
+        SolverInputError: If the quantity is not one of the refused set --
+            because silently passing an unrecognised name would turn this
+            guard into a no-op the first time somebody misspells one.
+    """
+    try:
+        key = RefusedQuantity(quantity)
+    except ValueError:
+        raise SolverInputError(
+            f"{quantity!r} is not a refused F1 quantity; expected one of "
+            + ", ".join(sorted(item.value for item in RefusedQuantity))
+        ) from None
+    raise OutOfEnvelopeError(
+        f"F1 refuses to report {key.value}:\n  {_REFUSAL_TEXT[key]}",
+        verdict=None,
+    )
+
+
+def evaluate_f1_envelope(
+    *,
+    speed_m_s: float,
+    feature_lengths_m: Mapping[str, float],
+    grain_diameter_m: float,
+    cell_size_m: float,
+    submerged_depth_m: float = 0.0,
+    effective_width_m: float,
+    gravity_m_s2: float = GRAVITY_M_S2,
+) -> ValidityVerdict:
+    """Judge one F1 query at every supplied feature scale.
+
+    Args:
+        speed_m_s: Intrusion speed.
+        feature_lengths_m: Named geometric scales.
+        grain_diameter_m: Median grain diameter.
+        cell_size_m: The grid ``dx``, which plays the role F0's surface
+            discretisation length plays in its own envelope.
+        submerged_depth_m: Deepest submerged point, positive downward.
+        effective_width_m: The declared out-of-plane width, carried onto
+            the verdict's details so a magnitude can never be reproduced
+            without the assumption behind it.
+        gravity_m_s2: Gravitational acceleration.
+
+    Returns:
+        The verdict. Nothing is raised here; refusal is a value.
+
+    Raises:
+        SolverInputError: If no feature scale is supplied, or if the cell
+            size or width is not positive.
+    """
+    if not feature_lengths_m:
+        raise SolverInputError(
+            "at least one feature scale is required; judging the envelope on no "
+            "scale at all is how a solver reports a flattering number"
+        )
+    size = float(cell_size_m)
+    width = float(effective_width_m)
+    if not math.isfinite(size) or size <= 0.0:
+        raise SolverInputError(f"cell_size_m must be positive, got {cell_size_m!r}")
+    if not math.isfinite(width) or width <= 0.0:
+        raise SolverInputError(
+            f"effective_width_m must be positive, got {effective_width_m!r}"
+        )
+
+    ordered = sorted(feature_lengths_m.items(), key=lambda item: item[1])
+    groups = tuple(
+        dimensionless_groups(
+            speed_m_s=speed_m_s,
+            feature_length_m=length,
+            grain_diameter_m=grain_diameter_m,
+            element_size_m=size,
+            name=name,
+            gravity_m_s2=gravity_m_s2,
+        )
+        for name, length in ordered
+    )
+
+    reasons: list[str] = [
+        "no published measurement exists for any quantity this tier produces "
+        "(issue #8616), so its validation level is 0 of 4 and no status better "
+        "than BEYOND_VALIDATION is available to it"
+    ]
+    caveats: list[Caveat] = list(F1_STANDING_CAVEATS)
+    refused = False
+
+    cells_per_grain = size / float(grain_diameter_m)
+    if cells_per_grain < MIN_CELLS_PER_GRAIN:
+        refused = True
+        reasons.append(
+            f"the grid cell spans {cells_per_grain:.3g} grain diameters, under "
+            f"{MIN_CELLS_PER_GRAIN:.0f}: refining a continuum below the grain "
+            "scale does not improve the answer, it changes what the answer is "
+            "about"
+        )
+
+    governing_index = 0
+    for index, group in enumerate(groups):
+        cells = group.scale.length_m / size
+        if cells < MIN_CELLS_PER_RESOLVED_FEATURE:
+            if Caveat.UNDER_RESOLVED_LEADING_EDGE not in caveats:
+                caveats.append(Caveat.UNDER_RESOLVED_LEADING_EDGE)
+            reasons.append(
+                f"the {group.scale.name} scale spans {cells:.3g} cells, under "
+                f"{MIN_CELLS_PER_RESOLVED_FEATURE:.0f}, so its local flow is not "
+                "resolved"
+            )
+        if group.continuum_size_ratio < MARGINAL_CONTINUUM_SIZE_RATIO:
+            if Caveat.MARGINAL_CONTINUUM not in caveats:
+                caveats.append(Caveat.MARGINAL_CONTINUUM)
+            reasons.append(
+                f"the {group.scale.name} scale spans only "
+                f"{group.continuum_size_ratio:.3g} grains"
+            )
+        if group.continuum_size_ratio < MIN_CONTINUUM_SIZE_RATIO:
+            refused = True
+            governing_index = index
+            reasons.append(
+                f"the {group.scale.name} scale spans only "
+                f"{group.continuum_size_ratio:.3g} grains (minimum "
+                f"{MIN_CONTINUUM_SIZE_RATIO:.0f}): there is no continuum there "
+                "to solve"
+            )
+
+    if float(speed_m_s) > MAX_VALIDATED_SPEED_M_S:
+        caveats.append(Caveat.BEYOND_PUBLISHED_SPEED)
+        reasons.append(
+            f"speed {float(speed_m_s):.3g} m/s is "
+            f"{float(speed_m_s) / MAX_VALIDATED_SPEED_M_S:.0f}x the fastest "
+            f"granular intrusion in the published corpus "
+            f"({MAX_VALIDATED_SPEED_M_S} m/s)"
+        )
+    _add_shallow_caveat(groups[governing_index], submerged_depth_m, reasons, caveats)
+
+    return ValidityVerdict(
+        status=EnvelopeStatus.REFUSED if refused else EnvelopeStatus.BEYOND_VALIDATION,
+        groups=groups,
+        caveats=tuple(dict.fromkeys(caveats)),
+        reasons=tuple(dict.fromkeys(reasons)),
+        governing_index=governing_index,
+        clamped_area_fraction=0.0,
+        details={
+            "submerged_depth_m": float(submerged_depth_m),
+            "grain_diameter_m": float(grain_diameter_m),
+            "cell_size_m": size,
+            "effective_width_m": width,
+            "cells_per_grain": cells_per_grain,
+        },
+    )
+
+
+def _add_shallow_caveat(
+    governing: DimensionlessGroups,
+    submerged_depth_m: float,
+    reasons: list[str],
+    caveats: list[Caveat],
+) -> None:
+    """Flag an intrusion too shallow for the bed to develop a stress field."""
+    limit = 2.0 * governing.grain_diameter_m
+    if 0.0 < float(submerged_depth_m) < limit:
+        caveats.append(Caveat.SHALLOW_INTRUSION)
+        reasons.append(
+            f"deepest submerged point is {float(submerged_depth_m) * 1e3:.3g} mm, "
+            f"under {limit * 1e3:.3g} mm (two grain diameters)"
+        )

--- a/src/bunkershot3d/solvers/mpm/grid.py
+++ b/src/bunkershot3d/solvers/mpm/grid.py
@@ -1,0 +1,574 @@
+"""The F1 background grid and its particle-grid transfers.
+
+Transfer scheme: APIC, and why not the other two
+------------------------------------------------
+
+Material-point methods differ mainly in what they carry back and forth
+between particles and the grid, and the classical choices both fail here:
+
+* **PIC** (Harlow 1964) resets each particle's velocity to the
+  interpolated grid velocity, discarding every mode the grid cannot
+  represent.  The loss shows up as strong, resolution-dependent numerical
+  damping.  In this tier that is fatal in a specific way: the shear bands
+  ADR-0033 asks F1 to *show* are exactly the fine-scale velocity
+  structure PIC erases, so a PIC solve would render a smooth picture of a
+  localisation that the model damped away.
+* **FLIP** (Brackbill & Ruppel 1986) carries the grid velocity
+  *increment* instead, which preserves the energy PIC loses but leaves
+  the particle velocity field with null-space noise the grid never sees.
+  In a plastic material the noise feeds the return mapping and shows up
+  as ringing and spurious yielding.
+
+**APIC** (Jiang, Schroeder, Selle, Teran & Stomakhin 2015, *"The affine
+particle-in-cell method"*, ACM Trans. Graph. **34**(4):51) carries a
+per-particle affine velocity field ``C_p`` alongside the velocity.  It is
+as stable as PIC and, unlike either predecessor, conserves **both linear
+and angular momentum** exactly across the transfer.  That last property
+is the reason it is chosen and not merely accepted: the F1 verification
+suite tests angular-momentum conservation of a P2G/G2P round trip to
+round-off, and under PIC or FLIP that test could not pass, so the
+transfer scheme is falsifiable here rather than asserted.
+
+MLS-MPM (Hu et al. 2018) would be a defensible alternative -- it is APIC
+with the stress term folded into the same affine machinery -- but it
+couples the transfer and the force discretisation, and keeping them
+separate is what lets the two be verified independently below.
+
+Basis functions
+---------------
+
+Quadratic B-splines, following Steffen, Kirby & Berzins (2008),
+*"Analysis and reduction of quadrature errors in the material point
+method"*, Int. J. Numer. Meth. Engng **76**:922-948.  They are ``C^1``,
+so a particle crossing a cell boundary sees no gradient discontinuity --
+the cell-crossing noise that afflicts linear-hat MPM simply does not
+arise.  Each particle touches a fixed ``3 x 3`` node stencil.
+
+Two identities of this basis are used as verification anchors, both to
+round-off:
+
+* ``sum_i w_ip = 1`` -- the partition of unity, which makes the P2G mass
+  transfer conserve total mass exactly.
+* ``sum_i grad w_ip = 0`` -- which makes the internal forces sum to zero,
+  so total linear momentum changes only by gravity and the contact
+  impulse and by nothing else.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from ..exceptions import SolverInputError
+
+__all__ = [
+    "NODES_PER_PARTICLE",
+    "STENCIL_WIDTH",
+    "GridInterpolation",
+    "PlaneStrainGrid",
+    "affine_from_grid_velocity",
+    "apic_angular_momentum",
+    "cross_2d",
+    "gather_velocity",
+    "scatter_mass",
+    "scatter_momentum",
+    "scatter_stress_force",
+    "velocity_gradient",
+]
+
+STENCIL_WIDTH = 3
+"""Nodes per axis in a quadratic B-spline stencil."""
+
+NODES_PER_PARTICLE = STENCIL_WIDTH * STENCIL_WIDTH
+"""Nodes one plane-strain particle writes to: ``3 x 3``."""
+
+_DIMENSION = 2
+_APIC_INERTIA_FACTOR = 4.0
+"""``D_p^{-1} dx^2`` for quadratic B-splines: ``D_p = (dx^2 / 4) I``.
+
+Constant because the quadratic B-spline stencil is symmetric about the
+particle, which is precisely why APIC is cheap with this basis (Jiang et
+al. 2015, section 5.2)."""
+
+
+@dataclass(frozen=True, slots=True)
+class GridInterpolation:
+    """One step's particle-to-node stencil, computed once and reused.
+
+    Every transfer in a step -- mass, momentum, force, and both gathers --
+    reads the same weights, so they are formed once.  That is not only a
+    speed decision: recomputing them would let the scatter and the gather
+    drift apart under a future edit, and the conservation identities this
+    solver verifies hold only if they are literally the same numbers.
+
+    Attributes:
+        node_index: ``(n, 9)`` flat node indices, row-major in ``(x, z)``.
+        weight: ``(n, 9)`` B-spline weights, each row summing to 1.
+        weight_gradient: ``(n, 9, 2)`` weight gradients in 1/m, each row
+            summing to the zero vector.
+        offset_m: ``(n, 9, 2)`` node position minus particle position.
+    """
+
+    node_index: NDArray[np.int64]
+    weight: NDArray[np.float64]
+    weight_gradient: NDArray[np.float64]
+    offset_m: NDArray[np.float64]
+
+    @property
+    def n_particles(self) -> int:
+        """Number of particles this stencil was formed for."""
+        return int(self.node_index.shape[0])
+
+
+@dataclass(frozen=True)
+class PlaneStrainGrid:
+    """A uniform Eulerian grid over the in-plane ``(x, z)`` section.
+
+    The plane is the swing plane: ``x`` runs along the club's path and
+    ``z`` is up, matching the world frame the F0 solver and
+    :class:`~bunkershot3d.solvers.protocol.IntrusionState` already use, so
+    a caller never has to remember a second axis convention.  ``y`` --
+    heel to toe -- is the out-of-plane direction that does not exist in
+    this model.
+
+    Attributes:
+        origin_m: ``(2,)`` position of node ``(0, 0)``.
+        cell_size_m: ``dx``, uniform in both axes.
+        node_counts: ``(nx, nz)`` node counts, at least 3 on each axis.
+    """
+
+    origin_m: NDArray[np.float64]
+    cell_size_m: float
+    node_counts: tuple[int, int]
+
+    def __init__(
+        self,
+        origin_m: ArrayLike,
+        cell_size_m: float,
+        node_counts: tuple[int, int],
+    ) -> None:
+        origin = np.array(origin_m, dtype=np.float64, copy=True).reshape(-1)
+        if origin.shape != (_DIMENSION,):
+            raise SolverInputError(
+                f"origin_m must be a 2-vector, got shape {np.shape(origin_m)!r}"
+            )
+        if not np.all(np.isfinite(origin)):
+            raise SolverInputError(f"origin_m must be finite, got {origin!r}")
+        size = float(cell_size_m)
+        if not math.isfinite(size) or size <= 0.0:
+            raise SolverInputError(f"cell_size_m must be positive, got {size!r}")
+        counts = tuple(int(value) for value in node_counts)
+        if len(counts) != _DIMENSION:
+            raise SolverInputError(f"node_counts must be (nx, nz), got {node_counts!r}")
+        if any(value < STENCIL_WIDTH for value in counts):
+            raise SolverInputError(
+                f"each axis needs at least {STENCIL_WIDTH} nodes to carry one "
+                f"quadratic B-spline stencil, got {counts!r}"
+            )
+        origin.flags.writeable = False
+        object.__setattr__(self, "origin_m", origin)
+        object.__setattr__(self, "cell_size_m", size)
+        object.__setattr__(self, "node_counts", counts)
+
+    # -------------------------------------------------------------- shape
+
+    @property
+    def n_nodes(self) -> int:
+        """Total node count."""
+        return self.node_counts[0] * self.node_counts[1]
+
+    @property
+    def cell_volume_m2(self) -> float:
+        """Area of one cell -- the plane-strain analogue of cell volume."""
+        return self.cell_size_m * self.cell_size_m
+
+    @property
+    def extent_m(self) -> NDArray[np.float64]:
+        """``(2,)`` physical span from node 0 to the last node on each axis."""
+        return (np.array(self.node_counts, dtype=np.float64) - 1.0) * self.cell_size_m
+
+    def node_positions_m(self) -> NDArray[np.float64]:
+        """``(n_nodes, 2)`` node positions, in flat index order."""
+        n_x, n_z = self.node_counts
+        index_x = np.arange(n_x, dtype=np.float64)
+        index_z = np.arange(n_z, dtype=np.float64)
+        grid_x, grid_z = np.meshgrid(index_x, index_z, indexing="ij")
+        offsets = np.stack([grid_x.ravel(), grid_z.ravel()], axis=1)
+        return self.origin_m + offsets * self.cell_size_m
+
+    @classmethod
+    def covering(
+        cls,
+        lower_m: ArrayLike,
+        upper_m: ArrayLike,
+        cell_size_m: float,
+        *,
+        pad_cells: int = 3,
+    ) -> PlaneStrainGrid:
+        """Build the smallest grid covering a box, with a stencil margin.
+
+        Args:
+            lower_m: ``(2,)`` lower corner of the region to cover.
+            upper_m: ``(2,)`` upper corner.
+            cell_size_m: ``dx``.
+            pad_cells: Cells of margin added on every side. Two is the
+                minimum a quadratic stencil needs; the default of three
+                leaves a cell of travel before a particle can reach the
+                edge, which is what turns a stray particle into a raised
+                error rather than a silently clipped one.
+
+        Returns:
+            The grid.
+
+        Raises:
+            SolverInputError: If the box is malformed or ``pad_cells`` is
+                below the stencil minimum.
+        """
+        lower = np.array(lower_m, dtype=np.float64).reshape(-1)
+        upper = np.array(upper_m, dtype=np.float64).reshape(-1)
+        if lower.shape != (_DIMENSION,) or upper.shape != (_DIMENSION,):
+            raise SolverInputError("lower_m and upper_m must both be 2-vectors")
+        if not np.all(np.isfinite(lower)) or not np.all(np.isfinite(upper)):
+            raise SolverInputError("the covered box must be finite")
+        if np.any(upper < lower):
+            raise SolverInputError(
+                f"upper_m {upper!r} must not be below lower_m {lower!r}"
+            )
+        if int(pad_cells) < STENCIL_WIDTH - 1:
+            raise SolverInputError(
+                f"pad_cells must be at least {STENCIL_WIDTH - 1} so a particle "
+                f"at the edge still has a full stencil, got {pad_cells!r}"
+            )
+        size = float(cell_size_m)
+        if not math.isfinite(size) or size <= 0.0:
+            raise SolverInputError(f"cell_size_m must be positive, got {size!r}")
+        pad = int(pad_cells)
+        origin = lower - pad * size
+        span_cells = np.ceil((upper - lower) / size).astype(np.int64) + 2 * pad
+        counts = (int(span_cells[0]) + 1, int(span_cells[1]) + 1)
+        return cls(origin, size, counts)
+
+    # ------------------------------------------------------- interpolation
+
+    def interpolate(self, positions_m: NDArray[np.float64]) -> GridInterpolation:
+        """Form the ``3 x 3`` quadratic B-spline stencil for each particle.
+
+        Args:
+            positions_m: ``(n, 2)`` particle positions.
+
+        Returns:
+            The stencil.
+
+        Raises:
+            SolverInputError: If a particle is non-finite or has left the
+                grid's interior. Leaving is raised rather than clamped:
+                a clamped particle is a silent mass sink, and a solver
+                that quietly loses sand is exactly the failure mode
+                ADR-0033 was written about.
+        """
+        positions = np.asarray(positions_m, dtype=np.float64)
+        if positions.ndim != _DIMENSION or positions.shape[1] != _DIMENSION:
+            raise SolverInputError(
+                f"positions_m must have shape (n, 2), got {positions.shape!r}"
+            )
+        if not np.all(np.isfinite(positions)):
+            raise SolverInputError("particle positions contain non-finite values")
+
+        local = (positions - self.origin_m) / self.cell_size_m
+        base = np.floor(local - 0.5).astype(np.int64)
+        counts = np.array(self.node_counts, dtype=np.int64)
+        if np.any(base < 0) or np.any(base + STENCIL_WIDTH > counts):
+            escaped = np.flatnonzero(
+                np.any(base < 0, axis=1) | np.any(base + STENCIL_WIDTH > counts, axis=1)
+            )
+            worst = positions[escaped[0]]
+            raise SolverInputError(
+                f"{escaped.size} particle(s) left the grid interior; the first is "
+                f"at {worst!r} m on a grid spanning "
+                f"{self.origin_m!r} to {self.origin_m + self.extent_m!r} m. "
+                "Enlarge the domain rather than clamping: a clamped particle is "
+                "a silent mass sink."
+            )
+
+        fraction = local - base
+        weights_1d = np.stack(
+            [
+                0.5 * (1.5 - fraction) ** 2,
+                0.75 - (fraction - 1.0) ** 2,
+                0.5 * (fraction - 0.5) ** 2,
+            ],
+            axis=0,
+        )
+        gradients_1d = (
+            np.stack(
+                [
+                    fraction - 1.5,
+                    -2.0 * (fraction - 1.0),
+                    fraction - 0.5,
+                ],
+                axis=0,
+            )
+            / self.cell_size_m
+        )
+
+        weight_x = weights_1d[:, :, 0]
+        weight_z = weights_1d[:, :, 1]
+        gradient_x = gradients_1d[:, :, 0]
+        gradient_z = gradients_1d[:, :, 1]
+        n_particles = positions.shape[0]
+
+        weight = np.einsum("an,bn->nab", weight_x, weight_z).reshape(
+            n_particles, NODES_PER_PARTICLE
+        )
+        weight_gradient = np.stack(
+            [
+                np.einsum("an,bn->nab", gradient_x, weight_z).reshape(
+                    n_particles, NODES_PER_PARTICLE
+                ),
+                np.einsum("an,bn->nab", weight_x, gradient_z).reshape(
+                    n_particles, NODES_PER_PARTICLE
+                ),
+            ],
+            axis=2,
+        )
+
+        stencil = np.arange(STENCIL_WIDTH, dtype=np.int64)
+        index_x = base[:, 0][:, None] + stencil[None, :]
+        index_z = base[:, 1][:, None] + stencil[None, :]
+        node_index = (
+            index_x[:, :, None] * self.node_counts[1] + index_z[:, None, :]
+        ).reshape(n_particles, NODES_PER_PARTICLE)
+
+        node_x = self.origin_m[0] + index_x * self.cell_size_m
+        node_z = self.origin_m[1] + index_z * self.cell_size_m
+        offset_x = np.repeat(node_x - positions[:, 0:1], STENCIL_WIDTH, axis=1)
+        offset_z = np.tile(node_z - positions[:, 1:2], (1, STENCIL_WIDTH))
+        offset = np.stack([offset_x, offset_z], axis=2)
+
+        return GridInterpolation(
+            node_index=node_index,
+            weight=weight,
+            weight_gradient=weight_gradient,
+            offset_m=offset,
+        )
+
+
+def _scatter(
+    grid: PlaneStrainGrid,
+    node_index: NDArray[np.int64],
+    values: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Sum ``values`` onto nodes by flat index."""
+    totals = np.bincount(
+        node_index.ravel(), weights=values.ravel(), minlength=grid.n_nodes
+    )
+    return totals.astype(np.float64, copy=False)
+
+
+def scatter_mass(
+    grid: PlaneStrainGrid,
+    stencil: GridInterpolation,
+    particle_mass_kg: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Transfer particle mass to the nodes.
+
+    Exact to round-off because the B-spline weights are a partition of
+    unity: ``sum_i m_i = sum_p m_p sum_i w_ip = sum_p m_p``.
+
+    Args:
+        grid: The background grid.
+        stencil: This step's interpolation.
+        particle_mass_kg: ``(n,)`` particle masses, per unit width.
+
+    Returns:
+        ``(n_nodes,)`` nodal masses in kg/m.
+    """
+    return _scatter(
+        grid, stencil.node_index, stencil.weight * particle_mass_kg[:, None]
+    )
+
+
+def scatter_momentum(
+    grid: PlaneStrainGrid,
+    stencil: GridInterpolation,
+    particle_mass_kg: NDArray[np.float64],
+    particle_velocity_m_s: NDArray[np.float64],
+    affine_velocity: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Transfer particle momentum to the nodes, APIC-style.
+
+    ``(m v)_i = sum_p w_ip m_p (v_p + C_p (x_i - x_p))``.  The affine term
+    is what makes the transfer conserve angular momentum: the antisymmetric
+    part of ``C_p`` carries the particle's local spin, which PIC discards
+    and FLIP fails to reconstruct.
+
+    Args:
+        grid: The background grid.
+        stencil: This step's interpolation.
+        particle_mass_kg: ``(n,)`` particle masses.
+        particle_velocity_m_s: ``(n, 2)`` particle velocities.
+        affine_velocity: ``(n, 2, 2)`` APIC affine matrices ``C_p``.
+
+    Returns:
+        ``(n_nodes, 2)`` nodal momentum.
+    """
+    affine_term = np.einsum("nij,naj->nai", affine_velocity, stencil.offset_m)
+    carried = particle_velocity_m_s[:, None, :] + affine_term
+    weighted = stencil.weight[:, :, None] * particle_mass_kg[:, None, None] * carried
+    return np.stack(
+        [
+            _scatter(grid, stencil.node_index, weighted[:, :, 0]),
+            _scatter(grid, stencil.node_index, weighted[:, :, 1]),
+        ],
+        axis=1,
+    )
+
+
+def scatter_stress_force(
+    grid: PlaneStrainGrid,
+    stencil: GridInterpolation,
+    particle_volume_m2: NDArray[np.float64],
+    cauchy_stress_pa: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Transfer the internal stress divergence to the nodes.
+
+    ``f_i = -sum_p V_p sigma_p grad w_ip``, the standard MPM internal
+    force in the current configuration.  Because ``sum_i grad w_ip = 0``
+    for a B-spline stencil, ``sum_i f_i = 0`` to round-off for **any**
+    stress field: internal forces cannot move the centre of mass, and the
+    conservation suite tests exactly that.
+
+    Args:
+        grid: The background grid.
+        stencil: This step's interpolation.
+        particle_volume_m2: ``(n,)`` current particle areas.
+        cauchy_stress_pa: ``(n, 2, 2)`` symmetric Cauchy stresses.
+
+    Returns:
+        ``(n_nodes, 2)`` nodal internal forces in N/m.
+    """
+    traction = np.einsum("nkl,nal->nak", cauchy_stress_pa, stencil.weight_gradient)
+    weighted = -particle_volume_m2[:, None, None] * traction
+    return np.stack(
+        [
+            _scatter(grid, stencil.node_index, weighted[:, :, 0]),
+            _scatter(grid, stencil.node_index, weighted[:, :, 1]),
+        ],
+        axis=1,
+    )
+
+
+def gather_velocity(
+    stencil: GridInterpolation, node_velocity_m_s: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Interpolate the nodal velocity back to the particles.
+
+    Args:
+        stencil: This step's interpolation.
+        node_velocity_m_s: ``(n_nodes, 2)`` nodal velocities.
+
+    Returns:
+        ``(n, 2)`` particle velocities.
+    """
+    sampled = node_velocity_m_s[stencil.node_index]
+    return np.einsum("na,nak->nk", stencil.weight, sampled)
+
+
+def affine_from_grid_velocity(
+    grid: PlaneStrainGrid,
+    stencil: GridInterpolation,
+    node_velocity_m_s: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Rebuild the APIC affine matrix ``C_p`` from the grid.
+
+    ``C_p = D_p^{-1} sum_i w_ip v_i (x_i - x_p)^T`` with
+    ``D_p = (dx^2 / 4) I`` for quadratic B-splines.
+
+    Args:
+        grid: The background grid.
+        stencil: This step's interpolation.
+        node_velocity_m_s: ``(n_nodes, 2)`` nodal velocities.
+
+    Returns:
+        ``(n, 2, 2)`` affine velocity matrices.
+    """
+    sampled = node_velocity_m_s[stencil.node_index]
+    weighted = stencil.weight[:, :, None] * sampled
+    moment = np.einsum("nak,nal->nkl", weighted, stencil.offset_m)
+    return moment * (_APIC_INERTIA_FACTOR / (grid.cell_size_m * grid.cell_size_m))
+
+
+def cross_2d(
+    left: NDArray[np.float64], right: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Scalar cross product ``a_x b_z - a_z b_x`` of stacked 2-vectors.
+
+    In plane strain the only surviving component of a cross product is the
+    out-of-plane one, so a torque or an angular momentum is a scalar here.
+
+    Args:
+        left: ``(..., 2)`` left operand.
+        right: ``(..., 2)`` right operand.
+
+    Returns:
+        ``(...)`` the out-of-plane component.
+    """
+    return left[..., 0] * right[..., 1] - left[..., 1] * right[..., 0]
+
+
+def apic_angular_momentum(
+    grid: PlaneStrainGrid,
+    positions_m: NDArray[np.float64],
+    velocity_m_s: NDArray[np.float64],
+    affine_velocity: NDArray[np.float64],
+    mass_kg: NDArray[np.float64],
+) -> float:
+    """Total APIC angular momentum of a particle set, about the origin.
+
+    The conserved quantity is **not** ``sum m (x x v)``.  Carrying the
+    affine matrix means each particle also holds the angular momentum of
+    its own local velocity field, and for quadratic B-splines
+    ``D_p = (dx^2 / 4) I`` gives
+
+        ``L = sum_p m_p [ x_p x v_p + (dx^2 / 4)(C_zx - C_xz) ]``
+
+    which is exactly what a P2G/G2P round trip preserves (Jiang et al.
+    2015, section 5.3).  Omitting the second term is the commonest way to
+    "measure" APIC's angular-momentum conservation and conclude it does
+    not have it.
+
+    Args:
+        grid: The background grid, for ``dx``.
+        positions_m: ``(n, 2)`` particle positions.
+        velocity_m_s: ``(n, 2)`` particle velocities.
+        affine_velocity: ``(n, 2, 2)`` affine matrices ``C_p``.
+        mass_kg: ``(n,)`` particle masses.
+
+    Returns:
+        The total angular momentum in kg m/s (per unit width).
+    """
+    orbital = cross_2d(positions_m, velocity_m_s)
+    spin = (grid.cell_size_m * grid.cell_size_m / _APIC_INERTIA_FACTOR) * (
+        affine_velocity[:, 1, 0] - affine_velocity[:, 0, 1]
+    )
+    return float((mass_kg * (orbital + spin)).sum())
+
+
+def velocity_gradient(
+    stencil: GridInterpolation, node_velocity_m_s: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Particle velocity gradient ``sum_i v_i (grad w_ip)^T``.
+
+    Args:
+        stencil: This step's interpolation.
+        node_velocity_m_s: ``(n_nodes, 2)`` nodal velocities.
+
+    Returns:
+        ``(n, 2, 2)`` velocity gradients in 1/s, index ``[k, l] =
+        dv_k / dx_l``.
+    """
+    sampled = node_velocity_m_s[stencil.node_index]
+    return np.einsum("nak,nal->nkl", sampled, stencil.weight_gradient)

--- a/src/bunkershot3d/solvers/mpm/solver.py
+++ b/src/bunkershot3d/solvers/mpm/solver.py
@@ -1,0 +1,918 @@
+"""The F1 solver: 2-D plane-strain MPM implementing ``GranularSolver``.
+
+One step, in the order it happens
+---------------------------------
+
+1. **P2G.**  Mass and APIC momentum onto the grid.
+2. **Stress.**  Cauchy stress from each particle's elastic deformation
+   gradient through the Hencky law, scattered as an internal force.
+3. **Grid update.**  Symplectic Euler: ``v* = v + dt (f/m + g)``.
+4. **Boundaries.**  Domain walls, then the club's collision projection,
+   which returns the exact momentum ledger that becomes the wrench.
+5. **G2P.**  Velocity, the APIC affine matrix, and the velocity gradient.
+6. **Plasticity.**  ``F <- (I + dt grad v) F``, then the capped
+   Drucker-Prager return map.
+7. **Advection**, then the particle-level pushout backstop.
+
+Why ``solve`` marches instead of evaluating
+-------------------------------------------
+
+:class:`~bunkershot3d.solvers.protocol.IntrusionState` is an
+*instantaneous* query: a pose, a velocity, and a free surface.  F0 can
+answer it directly because its constitutive shortcut is memoryless -- the
+force depends only on the current depth and speed.  A continuum has a
+history, and there is no such thing as "the stress at this pose" without
+one.
+
+F1 therefore supplies the history explicitly and says what it assumed:
+the body is **reversed along its own velocity direction until it is clear
+of the bed, then driven back to the queried pose at constant velocity**.
+That straight-line constant-speed approach is a modelling assumption, it
+is recorded in the result's verdict, and it is what makes an F1 answer
+comparable to an F0 one at all.
+
+What this solver may not be quoted for
+--------------------------------------
+
+ADR-0033 is explicit: F1 runs at bulk resolution (``dx ~ 1-2 mm``) for
+10-100 mm flow features, the ~0.5 mm leading edge is deliberately
+under-resolved, and **absolute club force stays F0's**.  The wrench
+returned here exists so the two tiers can be cross-checked on shape and
+timing; its magnitude additionally depends on ``effective_width_m``,
+which is a declared assumption rather than a result and is therefore a
+**required** constructor argument with no default.
+:mod:`bunkershot3d.solvers.mpm.envelope` carries both facts onto every
+verdict.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+import numpy as np
+from numpy.typing import NDArray
+
+from src.shared.python.core.contracts import ensure
+
+from ..drft import DEFAULT_FEATURE_SCALES_M
+from ..elements import SurfaceElements
+from ..envelope import GRAVITY_M_S2, RefusalPolicy, ValidityVerdict
+from ..exceptions import SolverInputError
+from ..protocol import FidelityTier, IntrusionState, SolverResult, Wrench
+from .body import RigidSection
+from .constitutive import (
+    SandContinuum,
+    hencky_kirchhoff_principal,
+    principal_stretches,
+    reconstruct,
+)
+from .envelope import evaluate_f1_envelope
+from .grid import (
+    PlaneStrainGrid,
+    affine_from_grid_velocity,
+    gather_velocity,
+    scatter_mass,
+    scatter_momentum,
+    scatter_stress_force,
+    velocity_gradient,
+)
+from .state import (
+    DomainWalls,
+    ParticleState,
+    apply_wall_conditions,
+    settled_bed,
+    surface_profile_m,
+)
+
+__all__ = [
+    "DEFAULT_CFL_NUMBER",
+    "MPMRun",
+    "PlaneStrainMPMSolver",
+    "StepDiagnostics",
+    "cfl_time_step_s",
+]
+
+DEFAULT_CFL_NUMBER = 0.4
+"""Courant number on the elastic wave speed.
+
+Symplectic Euler on an explicit MPM is stable to roughly ``C < 1`` for
+the elastic wave alone; 0.4 leaves margin for the plastic correction and
+for the club's own motion, which enters the same condition."""
+
+_DIMENSION = 2
+_MASS_FLOOR_KG = 1e-15
+_MIN_APPROACH_CLEARANCE_CELLS = 2.0
+_SURFACE_BINS = 64
+
+
+def cfl_time_step_s(
+    *,
+    cell_size_m: float,
+    elastic_wave_speed_m_s: float,
+    max_material_speed_m_s: float,
+    cfl_number: float = DEFAULT_CFL_NUMBER,
+) -> float:
+    """Return the CFL-limited timestep, computed rather than pinned.
+
+    ``dt = C dx / (c_p + v_max)`` with ``c_p = sqrt((lambda + 2 mu) / rho)``
+    the dilatational wave speed of the *material* -- so a stiffer sand
+    shortens the step by itself and no constant needs revisiting -- and
+    ``v_max`` the fastest material or body speed in the problem, which is
+    what stops the club from crossing more than a fraction of a cell in
+    one step.
+
+    Args:
+        cell_size_m: Grid ``dx``.
+        elastic_wave_speed_m_s: ``c_p``.
+        max_material_speed_m_s: Fastest particle or body speed.
+        cfl_number: Courant number.
+
+    Returns:
+        The timestep in seconds.
+
+    Raises:
+        SolverInputError: If any input is unusable, or if the resulting
+            step is not positive and finite. This is a ``raise`` and not
+            an ``assert``: ``python -O`` strips assertions, and a CFL
+            condition that evaporates under an optimisation flag is worse
+            than none at all.
+    """
+    size = float(cell_size_m)
+    wave = float(elastic_wave_speed_m_s)
+    speed = float(max_material_speed_m_s)
+    number = float(cfl_number)
+    if not math.isfinite(size) or size <= 0.0:
+        raise SolverInputError(f"cell_size_m must be positive, got {cell_size_m!r}")
+    if not math.isfinite(wave) or wave <= 0.0:
+        raise SolverInputError(
+            f"elastic wave speed must be positive, got {elastic_wave_speed_m_s!r}"
+        )
+    if not math.isfinite(speed) or speed < 0.0:
+        raise SolverInputError(
+            f"max material speed must be finite and non-negative, got "
+            f"{max_material_speed_m_s!r}"
+        )
+    if not math.isfinite(number) or not 0.0 < number <= 1.0:
+        raise SolverInputError(f"cfl_number must lie in (0, 1], got {cfl_number!r}")
+    step = number * size / (wave + speed)
+    if not math.isfinite(step) or step <= 0.0:
+        raise SolverInputError(
+            f"the CFL condition produced an unusable timestep {step!r} s"
+        )
+    return step
+
+
+@dataclass(frozen=True, slots=True)
+class StepDiagnostics:
+    """What one step did, kept so the run is inspectable rather than opaque.
+
+    Attributes:
+        time_s: Simulation time at the end of the step.
+        contact_force_n_per_m: ``(2,)`` total in-plane force on the body,
+            per unit out-of-plane width.
+        stress_force_n_per_m: ``(2,)`` the stress-and-weight part of that
+            force. See :meth:`MPMRun.force_split` for what the split
+            means and, just as importantly, what it does not.
+        contact_torque_n: Torque on the body about ``+y``, per unit width.
+        n_contacts: Grid nodes the club projected.
+        n_swept: Of those, nodes reached only by the swept test.
+        n_pushed_out: Particles the backstop had to reposition.
+        n_yielded: Particles the return map moved.
+        n_capped: Particles that hit the compressive cap.
+        kinetic_energy_j_per_m: Translational kinetic energy.
+        elastic_energy_j_per_m: Stored Hencky strain energy.
+        gravitational_energy_j_per_m: Potential energy above the floor.
+        linear_momentum_kg_m_s: ``(2,)`` total particle momentum.
+        total_mass_kg_per_m: Total particle mass. Invariant.
+    """
+
+    time_s: float
+    contact_force_n_per_m: NDArray[np.float64]
+    stress_force_n_per_m: NDArray[np.float64]
+    contact_torque_n: float
+    n_contacts: int
+    n_swept: int
+    n_pushed_out: int
+    n_yielded: int
+    n_capped: int
+    kinetic_energy_j_per_m: float
+    elastic_energy_j_per_m: float
+    gravitational_energy_j_per_m: float
+    linear_momentum_kg_m_s: NDArray[np.float64]
+    total_mass_kg_per_m: float
+
+
+@dataclass(frozen=True)
+class MPMRun:
+    """The whole trace of one F1 march, and what can be read off it.
+
+    Attributes:
+        steps: One :class:`StepDiagnostics` per step, in order.
+        time_step_s: The CFL step the march used.
+        particles: Final particle state.
+        grid: The background grid.
+        section: Final club pose.
+        free_surface_height_m: The undisturbed surface the run started
+            from.
+        bed_x_bounds_m: Horizontal extent of the bed.
+    """
+
+    steps: tuple[StepDiagnostics, ...]
+    time_step_s: float
+    particles: ParticleState
+    grid: PlaneStrainGrid
+    section: RigidSection
+    free_surface_height_m: float
+    bed_x_bounds_m: tuple[float, float]
+
+    def __post_init__(self) -> None:
+        if not self.steps:
+            raise SolverInputError(
+                "an F1 run with no steps has nothing to report; a zero-step run "
+                "would return a zero wrench that reads as a result"
+            )
+
+    @property
+    def n_steps(self) -> int:
+        """Number of steps marched."""
+        return len(self.steps)
+
+    @property
+    def duration_s(self) -> float:
+        """Simulation time spanned."""
+        return self.steps[-1].time_s
+
+    def contact_force_history_n_per_m(self) -> NDArray[np.float64]:
+        """``(n_steps, 2)`` in-plane force on the body over the run."""
+        return np.array([step.contact_force_n_per_m for step in self.steps])
+
+    def time_history_s(self) -> NDArray[np.float64]:
+        """``(n_steps,)`` step end times."""
+        return np.array([step.time_s for step in self.steps])
+
+    def peak_force_time_s(self) -> float:
+        """When the force magnitude peaked.
+
+        ADR-0033 marks the timing of peak load quotable with tier while
+        the magnitude is not, so it is reported separately rather than
+        inferred by a caller from a history it has to scan itself.
+        """
+        magnitude = np.linalg.norm(self.contact_force_history_n_per_m(), axis=1)
+        return float(self.steps[int(np.argmax(magnitude))].time_s)
+
+    def averaged_force_n_per_m(self, window_s: float) -> NDArray[np.float64]:
+        """Mean in-plane force over the final ``window_s`` of the run.
+
+        Explicit MPM contact is step-noisy -- a node enters or leaves the
+        projected set discretely -- so a single step's force is not the
+        quantity anybody means.  The window is an argument rather than a
+        constant so that a caller cannot be given an average whose length
+        it did not choose.
+
+        Args:
+            window_s: Length of the trailing window.
+
+        Returns:
+            ``(2,)`` mean force per unit width.
+
+        Raises:
+            SolverInputError: If the window is not positive.
+        """
+        if not math.isfinite(window_s) or window_s <= 0.0:
+            raise SolverInputError(f"window_s must be positive, got {window_s!r}")
+        times = self.time_history_s()
+        selected = times >= (times[-1] - window_s)
+        return self.contact_force_history_n_per_m()[selected].mean(axis=0)
+
+    def averaged_stress_force_n_per_m(self, window_s: float) -> NDArray[np.float64]:
+        """Mean stress-and-weight part of the force over the same window."""
+        if not math.isfinite(window_s) or window_s <= 0.0:
+            raise SolverInputError(f"window_s must be positive, got {window_s!r}")
+        times = self.time_history_s()
+        selected = times >= (times[-1] - window_s)
+        history = np.array([step.stress_force_n_per_m for step in self.steps])
+        return history[selected].mean(axis=0)
+
+    def force_split(
+        self, window_s: float
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Split the reaction into its stress-borne and momentum-flux parts.
+
+        The two add to the total exactly, by construction:
+
+        * the **stress** part is ``sum_i (f_i^internal + m_i g)`` over the
+          projected nodes -- what the sand's own stress and weight were
+          already delivering there;
+        * the **momentum-flux** part is the remainder of the contact
+          impulse, which is the momentum needed to bring that sand up to
+          the club's velocity.
+
+        This is *not* F0's ``alpha |z~|`` versus ``lambda rho v_n^2``
+        decomposition and must not be read as one.  It is the analogous
+        physical partition -- quasi-static resistance against ram
+        pressure -- computed from an exact momentum ledger rather than
+        from a fitted form, which is what makes the two tiers'
+        depth/inertia crossovers comparable at all.
+
+        Args:
+            window_s: Length of the trailing averaging window.
+
+        Returns:
+            ``(stress_part, momentum_flux_part)``, both ``(2,)``.
+        """
+        total = self.averaged_force_n_per_m(window_s)
+        stress = self.averaged_stress_force_n_per_m(window_s)
+        return stress, total - stress
+
+    def divot_depth_m(self, *, n_bins: int = _SURFACE_BINS) -> float:
+        """Deepest depression of the free surface below its original level.
+
+        Read off the particles, because in MPM the free surface *is*
+        wherever the particles stop.  Bins the sand has left entirely are
+        skipped rather than treated as infinitely deep.
+
+        Args:
+            n_bins: Horizontal bins across the bed.
+
+        Returns:
+            Depth in metres, non-negative.
+        """
+        _, heights = surface_profile_m(
+            self.particles, x_bounds_m=self.bed_x_bounds_m, n_bins=n_bins
+        )
+        populated = heights[np.isfinite(heights)]
+        if populated.size == 0:
+            return 0.0
+        return max(float(self.free_surface_height_m - populated.min()), 0.0)
+
+    def max_pushed_out(self) -> int:
+        """Worst single step's pushout count, the anti-tunnelling telltale."""
+        return max(step.n_pushed_out for step in self.steps)
+
+
+@dataclass(frozen=True)
+class PlaneStrainMPMSolver:
+    """The F1 tier: 2-D plane-strain MPM, swappable with the F0 solver.
+
+    Attributes:
+        material: The continuum, derived from a
+            :class:`~bunkershot3d.sand.state.SandState`.
+        cell_size_m: Grid ``dx``. ADR-0033 specifies bulk resolution,
+            1-2 mm; finer does not make the tier quotable for club force,
+            it only makes it slower.
+        effective_width_m: The out-of-plane width a per-unit-width
+            plane-strain load is multiplied by to become a force. **A
+            modelling assumption, not a result**, which is why it has no
+            default: ADR-0033 requires it to be recorded before any
+            magnitude comparison against F0.
+        bed_depth_m: Depth of sand below the free surface.
+        run_in_lengths: Bed length ahead of and behind the body, in
+            multiples of the body's own horizontal extent.
+        particles_per_cell_axis: MPM quadrature density.
+        cfl_number: Courant number for the timestep.
+        gravity_m_s2: Gravitational acceleration.
+        contact_friction: Club-on-sand Coulomb friction.
+        walls: Domain wall conditions.
+        refusal_policy: What happens on a refused verdict.
+        feature_scales_m: Scales the envelope is judged at.
+        max_steps: Hard cap on the march.
+        averaging_window_s: Trailing window the reported wrench is
+            averaged over.
+    """
+
+    material: SandContinuum
+    cell_size_m: float
+    effective_width_m: float
+    bed_depth_m: float = 0.10
+    run_in_lengths: float = 1.5
+    particles_per_cell_axis: int = 2
+    cfl_number: float = DEFAULT_CFL_NUMBER
+    gravity_m_s2: float = GRAVITY_M_S2
+    contact_friction: float = 0.3
+    walls: DomainWalls = field(default_factory=DomainWalls)
+    refusal_policy: RefusalPolicy = RefusalPolicy.STRICT
+    feature_scales_m: Mapping[str, float] = field(
+        default_factory=lambda: dict(DEFAULT_FEATURE_SCALES_M)
+    )
+    max_steps: int = 20000
+    averaging_window_s: float = 2.0e-4
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.material, SandContinuum):
+            raise SolverInputError(
+                f"material must be a SandContinuum, got {type(self.material).__name__}"
+            )
+        positive = {
+            "cell_size_m": self.cell_size_m,
+            "effective_width_m": self.effective_width_m,
+            "bed_depth_m": self.bed_depth_m,
+            "gravity_m_s2": self.gravity_m_s2,
+            "averaging_window_s": self.averaging_window_s,
+        }
+        for name, value in positive.items():
+            if not math.isfinite(value) or value <= 0.0:
+                raise SolverInputError(f"{name} must be positive, got {value!r}")
+        if self.run_in_lengths < 0.0 or not math.isfinite(self.run_in_lengths):
+            raise SolverInputError(
+                f"run_in_lengths must be non-negative, got {self.run_in_lengths!r}"
+            )
+        if int(self.max_steps) < 1:
+            raise SolverInputError(
+                f"max_steps must be positive, got {self.max_steps!r}"
+            )
+        if not self.feature_scales_m:
+            raise SolverInputError("at least one feature scale is required")
+        object.__setattr__(self, "feature_scales_m", dict(self.feature_scales_m))
+
+    # ------------------------------------------------------------ protocol
+
+    @property
+    def fidelity_tier(self) -> FidelityTier:
+        """Always :attr:`~bunkershot3d.solvers.protocol.FidelityTier.F1`."""
+        return FidelityTier.F1
+
+    def envelope(self, state: IntrusionState) -> ValidityVerdict:
+        """Judge a query without marching a single step.
+
+        Args:
+            state: The intrusion query.
+
+        Returns:
+            The F1 verdict. Refusal is a value here and becomes an
+            exception only in :meth:`solve`, under the refusal policy.
+        """
+        self._require_state(state)
+        velocities = state.element_velocities_m_s()
+        speeds = np.sqrt(np.einsum("ij,ij->i", velocities, velocities))
+        depths = -state.element_depths_m()
+        submerged = depths > 0.0
+        return self._verdict(
+            speed_m_s=float(speeds.max()) if speeds.size else 0.0,
+            submerged_depth_m=(
+                float(depths[submerged].max()) if bool(submerged.any()) else 0.0
+            ),
+        )
+
+    def solve(self, state: IntrusionState) -> SolverResult:
+        """March the sand up to the queried pose and report the wrench.
+
+        Args:
+            state: The intrusion query.
+
+        Returns:
+            The wrench about ``state.reference_point_m``, the F1 tier, and
+            the validity verdict -- always all three.
+
+        Raises:
+            OutOfEnvelopeError: If the verdict refuses and the policy is
+                strict.
+            SolverInputError: If the query is malformed, or if the query
+                has no in-plane motion for the approach to be built from.
+        """
+        self._require_state(state)
+        verdict = self.envelope(state)
+        verdict.require_usable(self.refusal_policy)
+        run = self.run(state)
+        return self._result(state, run, verdict)
+
+    # --------------------------------------------------------------- march
+
+    def run(self, state: IntrusionState) -> MPMRun:
+        """Build the bed and the approach, then march to the queried pose.
+
+        Exposed separately from :meth:`solve` because the verification
+        suite needs the whole trace -- conservation residuals, the energy
+        history, the free surface -- and not only the resultant.
+
+        Args:
+            state: The intrusion query.
+
+        Returns:
+            The run.
+        """
+        self._require_state(state)
+        section, approach_distance_m = self._approach(state)
+        grid, particles, bounds = self._build_bed(state, section, approach_distance_m)
+        step_s = self.time_step_s(state)
+        n_steps = self._approach_steps(state, approach_distance_m, step_s)
+        return self.march(
+            particles,
+            section,
+            grid,
+            n_steps=n_steps,
+            time_step_s=step_s,
+            free_surface_height_m=state.free_surface_height_m,
+            bed_x_bounds_m=bounds,
+        )
+
+    def time_step_s(self, state: IntrusionState) -> float:
+        """The CFL step for this query, computed and checked at runtime."""
+        velocities = state.element_velocities_m_s()
+        speeds = np.sqrt(np.einsum("ij,ij->i", velocities, velocities))
+        return cfl_time_step_s(
+            cell_size_m=self.cell_size_m,
+            elastic_wave_speed_m_s=self.material.elastic_wave_speed_m_s,
+            max_material_speed_m_s=float(speeds.max()) if speeds.size else 0.0,
+            cfl_number=self.cfl_number,
+        )
+
+    def march(
+        self,
+        particles: ParticleState,
+        section: RigidSection,
+        grid: PlaneStrainGrid,
+        *,
+        n_steps: int,
+        time_step_s: float,
+        free_surface_height_m: float,
+        bed_x_bounds_m: tuple[float, float],
+        damping_per_step: float = 0.0,
+    ) -> MPMRun:
+        """Integrate ``n_steps`` of the scheme and return the trace.
+
+        Args:
+            particles: The bed, advanced in place.
+            section: The club at its starting pose.
+            grid: The background grid.
+            n_steps: How many steps to take.
+            time_step_s: The step, normally from :meth:`time_step_s`.
+            free_surface_height_m: The undisturbed surface, for the divot.
+            bed_x_bounds_m: Horizontal extent of the bed.
+            damping_per_step: Fraction of the nodal velocity removed each
+                step. Zero for a shot; the verification suite uses it to
+                relax a column to static equilibrium, which is the only
+                honest way to compare against a *static* analytic answer.
+
+        Returns:
+            The run.
+
+        Raises:
+            SolverInputError: If the step count exceeds ``max_steps``, or
+                if the body would cross more than one cell in a step --
+                the runtime assertion of the CFL condition, which is a
+                ``raise`` so that ``python -O`` cannot remove it.
+        """
+        steps = int(n_steps)
+        if steps < 1:
+            raise SolverInputError(f"n_steps must be positive, got {n_steps!r}")
+        if steps > int(self.max_steps):
+            raise SolverInputError(
+                f"the requested march is {steps} steps, over the {self.max_steps} "
+                "cap; raise max_steps deliberately rather than letting a run grow "
+                "without bound"
+            )
+        if not math.isfinite(damping_per_step) or not 0.0 <= damping_per_step < 1.0:
+            raise SolverInputError(
+                f"damping_per_step must lie in [0, 1), got {damping_per_step!r}"
+            )
+        self._require_courant(section, time_step_s)
+
+        datum_m = float(free_surface_height_m) - self.bed_depth_m
+        node_positions = grid.node_positions_m()
+        diagnostics: list[StepDiagnostics] = []
+        moving = section
+        elapsed = 0.0
+        for _ in range(steps):
+            elapsed += time_step_s
+            report = self._advance(
+                particles,
+                moving,
+                grid,
+                node_positions,
+                time_step_s=time_step_s,
+                elapsed_s=elapsed,
+                datum_m=datum_m,
+                damping_per_step=damping_per_step,
+            )
+            diagnostics.append(report)
+            moving = moving.advanced(time_step_s)
+
+        return MPMRun(
+            steps=tuple(diagnostics),
+            time_step_s=float(time_step_s),
+            particles=particles,
+            grid=grid,
+            section=moving,
+            free_surface_height_m=float(free_surface_height_m),
+            bed_x_bounds_m=bed_x_bounds_m,
+        )
+
+    # ------------------------------------------------------------ one step
+
+    def _advance(
+        self,
+        particles: ParticleState,
+        section: RigidSection,
+        grid: PlaneStrainGrid,
+        node_positions: NDArray[np.float64],
+        *,
+        time_step_s: float,
+        elapsed_s: float,
+        datum_m: float,
+        damping_per_step: float,
+    ) -> StepDiagnostics:
+        """One full MPM step, mutating ``particles`` in place."""
+        stencil = grid.interpolate(particles.position_m)
+        nodal_mass = scatter_mass(grid, stencil, particles.mass_kg)
+        nodal_momentum = scatter_momentum(
+            grid,
+            stencil,
+            particles.mass_kg,
+            particles.velocity_m_s,
+            particles.affine,
+        )
+        live = nodal_mass > _MASS_FLOOR_KG
+        node_velocity = np.zeros_like(nodal_momentum)
+        node_velocity[live] = nodal_momentum[live] / nodal_mass[live, None]
+
+        stress, elastic_energy = self._cauchy_stress(particles)
+        internal_force = scatter_stress_force(
+            grid, stencil, self._current_volume(particles), stress
+        )
+        weight = np.zeros_like(internal_force)
+        weight[:, 1] = -nodal_mass * self.gravity_m_s2
+        applied_force = internal_force + weight
+
+        updated = node_velocity.copy()
+        updated[live] += time_step_s * applied_force[live] / nodal_mass[live, None]
+        if damping_per_step > 0.0:
+            updated *= 1.0 - damping_per_step
+        apply_wall_conditions(grid, updated, self.walls)
+        updated, impulse = section.project_grid_velocity(
+            node_positions,
+            updated,
+            nodal_mass,
+            time_step_s=time_step_s,
+            stress_force_n=applied_force,
+        )
+
+        particles.velocity_m_s = gather_velocity(stencil, updated)
+        particles.affine = affine_from_grid_velocity(grid, stencil, updated)
+        gradient = velocity_gradient(stencil, updated)
+        identity = np.eye(_DIMENSION)
+        trial = (identity + time_step_s * gradient) @ particles.deformation_gradient
+
+        left, stretches, right = principal_stretches(trial)
+        projected, yielded, capped = self.material.project(np.log(stretches))
+        particles.deformation_gradient = reconstruct(left, projected, right)
+
+        particles.position_m = (
+            particles.position_m + time_step_s * particles.velocity_m_s
+        )
+        particles.position_m, particles.velocity_m_s, pushed = section.push_out(
+            particles.position_m, particles.velocity_m_s
+        )
+
+        return StepDiagnostics(
+            time_s=float(elapsed_s),
+            contact_force_n_per_m=impulse.force_on_body_n(time_step_s),
+            stress_force_n_per_m=-impulse.stress_force_n,
+            contact_torque_n=impulse.torque_on_body_n_m(
+                time_step_s, section.reference_point_m
+            ),
+            n_contacts=impulse.n_contacts,
+            n_swept=impulse.n_swept,
+            n_pushed_out=int(pushed),
+            n_yielded=int(yielded.sum()),
+            n_capped=int(capped.sum()),
+            kinetic_energy_j_per_m=particles.kinetic_energy_j(),
+            elastic_energy_j_per_m=float(elastic_energy),
+            gravitational_energy_j_per_m=particles.gravitational_energy_j(
+                self.gravity_m_s2, datum_m
+            ),
+            linear_momentum_kg_m_s=particles.linear_momentum_kg_m_s(),
+            total_mass_kg_per_m=particles.total_mass_kg,
+        )
+
+    def _cauchy_stress(
+        self, particles: ParticleState
+    ) -> tuple[NDArray[np.float64], float]:
+        """Cauchy stress and stored energy from the elastic deformation.
+
+        For an isotropic model the Kirchhoff stress is coaxial with the
+        *left* stretch, so ``tau = U diag(tau_i) U^T`` and
+        ``sigma = tau / J``.  The stored energy is the Hencky strain
+        energy ``mu ||eps||^2 + (lambda / 2) tr(eps)^2``, which the
+        conservation suite needs to close the energy budget.
+        """
+        left, stretches, _ = principal_stretches(particles.deformation_gradient)
+        strain = np.log(stretches)
+        kirchhoff = hencky_kirchhoff_principal(
+            strain,
+            shear_modulus_pa=self.material.shear_modulus_pa,
+            lame_lambda_pa=self.material.lame_lambda_pa,
+        )
+        jacobian = stretches.prod(axis=1)
+        principal = kirchhoff / jacobian[:, None]
+        stress = np.einsum("nik,nk,njk->nij", left, principal, left)
+
+        trace = strain.sum(axis=1)
+        density = (
+            self.material.shear_modulus_pa * np.einsum("ij,ij->i", strain, strain)
+            + 0.5 * self.material.lame_lambda_pa * trace**2
+        )
+        energy = float((particles.initial_volume_m2 * density).sum())
+        return stress, energy
+
+    @staticmethod
+    def _current_volume(particles: ParticleState) -> NDArray[np.float64]:
+        """``V = J V_0``, the deformed particle area."""
+        jacobian = np.linalg.det(particles.deformation_gradient)
+        return particles.initial_volume_m2 * jacobian
+
+    # ------------------------------------------------------------- set-up
+
+    def _require_state(self, state: IntrusionState) -> None:
+        """Precondition: ``state`` is a usable intrusion query."""
+        if not isinstance(state, IntrusionState):
+            raise SolverInputError(
+                f"expected an IntrusionState, got {type(state).__name__}"
+            )
+        if not isinstance(state.elements, SurfaceElements):
+            raise SolverInputError(
+                "intrusion state must carry a SurfaceElements structure of arrays"
+            )
+        if len(state.elements) == 0:
+            raise SolverInputError("the intruder has no surface elements")
+
+    def _require_courant(self, section: RigidSection, time_step_s: float) -> None:
+        """Runtime assertion of the CFL condition, as a ``raise``."""
+        travel = section.max_speed_m_s * float(time_step_s)
+        if travel > self.cell_size_m:
+            raise SolverInputError(
+                f"the club would cross {travel * 1e3:.4g} mm in one step on a "
+                f"{self.cell_size_m * 1e3:.4g} mm grid, so sand could pass through "
+                "it. Lower cfl_number or refine the grid; this is checked with a "
+                "raise rather than an assert because python -O strips assertions."
+            )
+
+    def section_from_state(self, state: IntrusionState) -> RigidSection:
+        """Project the 3-D body onto the swing plane as a convex section.
+
+        The element centroids are dropped onto ``(x, z)`` and hulled.
+        Heel-to-toe structure is discarded here, visibly, because plane
+        strain has nowhere to put it.
+
+        Args:
+            state: The intrusion query.
+
+        Returns:
+            The section, carrying the body's in-plane velocity.
+        """
+        centroids = state.elements.centroids_m
+        points = np.stack([centroids[:, 0], centroids[:, 2]], axis=1)
+        velocity = np.array(
+            [state.velocity_m_s[0], state.velocity_m_s[2]], dtype=np.float64
+        )
+        reference = np.array(
+            [state.reference_point_m[0], state.reference_point_m[2]], dtype=np.float64
+        )
+        return RigidSection.from_points(
+            points,
+            velocity_m_s=velocity,
+            angular_velocity_rad_s=float(state.angular_velocity_rad_s[1]),
+            reference_point_m=reference,
+            friction=self.contact_friction,
+        )
+
+    def _approach(self, state: IntrusionState) -> tuple[RigidSection, float]:
+        """Reverse the body along its velocity until it is clear of the bed.
+
+        Returns:
+            ``(starting_section, approach_distance_m)``.
+
+        Raises:
+            SolverInputError: If the body has no in-plane speed, so there
+                is no approach direction to reverse along. F1 has no
+                answer for a static intruder and says so rather than
+                inventing a history.
+        """
+        section = self.section_from_state(state)
+        speed = section.speed_m_s
+        if speed <= 0.0:
+            raise SolverInputError(
+                "the query has no in-plane velocity, so F1 has no approach "
+                "direction to build the deformation history from. A continuum "
+                "force depends on how the body got there; there is no "
+                "instantaneous answer to return."
+            )
+        direction = section.velocity_m_s / speed
+        lower, upper = section.bounds_m()
+        clearance = _MIN_APPROACH_CLEARANCE_CELLS * self.cell_size_m
+        if direction[1] < 0.0:
+            # Descending: back off until the lowest point clears the surface.
+            distance = (state.free_surface_height_m + clearance - lower[1]) / (
+                -direction[1]
+            )
+        else:
+            # Level or rising: there is no height to back off to, so run in
+            # horizontally from beyond the body's own length.
+            span = float(upper[0] - lower[0])
+            distance = (span + clearance) / max(abs(direction[0]), 1e-9)
+        distance = max(float(distance), clearance)
+        return section.translated(-distance * direction), distance
+
+    def _approach_steps(
+        self, state: IntrusionState, approach_distance_m: float, time_step_s: float
+    ) -> int:
+        """How many steps the approach takes at the queried speed."""
+        section = self.section_from_state(state)
+        steps = int(math.ceil(approach_distance_m / (section.speed_m_s * time_step_s)))
+        return max(steps, 1)
+
+    def _build_bed(
+        self,
+        state: IntrusionState,
+        starting_section: RigidSection,
+        approach_distance_m: float,
+    ) -> tuple[PlaneStrainGrid, ParticleState, tuple[float, float]]:
+        """Build a grid and a settled bed wide enough for the whole approach."""
+        final = self.section_from_state(state)
+        lower_start, upper_start = starting_section.bounds_m()
+        lower_end, upper_end = final.bounds_m()
+        span = float(max(upper_end[0] - lower_end[0], self.cell_size_m))
+        margin = self.run_in_lengths * span
+        bed_lower = float(min(lower_start[0], lower_end[0])) - margin
+        bed_upper = float(max(upper_start[0], upper_end[0])) + margin
+        surface = state.free_surface_height_m
+        floor = surface - self.bed_depth_m
+
+        grid = PlaneStrainGrid.covering(
+            (bed_lower, min(floor, float(min(lower_start[1], lower_end[1])))),
+            (bed_upper, max(surface, float(max(upper_start[1], upper_end[1])))),
+            self.cell_size_m,
+        )
+        particles = settled_bed(
+            self.material,
+            x_bounds_m=(bed_lower, bed_upper),
+            free_surface_height_m=surface,
+            depth_m=self.bed_depth_m,
+            cell_size_m=self.cell_size_m,
+            particles_per_cell_axis=self.particles_per_cell_axis,
+            gravity_m_s2=self.gravity_m_s2,
+        )
+        _ = approach_distance_m
+        return grid, particles, (bed_lower, bed_upper)
+
+    # -------------------------------------------------------------- result
+
+    def _verdict(
+        self, *, speed_m_s: float, submerged_depth_m: float
+    ) -> ValidityVerdict:
+        """Assemble the F1 validity verdict for one query."""
+        return evaluate_f1_envelope(
+            speed_m_s=speed_m_s,
+            feature_lengths_m=self.feature_scales_m,
+            grain_diameter_m=self.material.grain_diameter_m,
+            cell_size_m=self.cell_size_m,
+            submerged_depth_m=submerged_depth_m,
+            effective_width_m=self.effective_width_m,
+            gravity_m_s2=self.gravity_m_s2,
+        )
+
+    def _result(
+        self, state: IntrusionState, run: MPMRun, verdict: ValidityVerdict
+    ) -> SolverResult:
+        """Turn a march into the protocol's :class:`SolverResult`."""
+        window = min(self.averaging_window_s, run.duration_s)
+        stress_part, flux_part = run.force_split(window)
+        total = stress_part + flux_part
+        width = self.effective_width_m
+
+        force = np.array([total[0] * width, 0.0, total[1] * width])
+        torque_y = float(
+            np.mean(
+                [step.contact_torque_n for step in run.steps[-_torque_window(run) :]]
+            )
+        )
+        torque = np.array([0.0, torque_y * width, 0.0])
+        wrench = Wrench(force, torque, state.reference_point_m)
+        ensure(
+            bool(np.isfinite(wrench.force_n).all()),
+            "F1 produced a non-finite resultant force",
+            value=wrench.force_n,
+        )
+
+        contacts = [step.n_contacts for step in run.steps]
+        depths = -state.element_depths_m()
+        return SolverResult(
+            wrench=wrench,
+            fidelity_tier=self.fidelity_tier,
+            verdict=verdict,
+            depth_force_n=np.array(
+                [stress_part[0] * width, 0.0, stress_part[1] * width]
+            ),
+            inertial_force_n=np.array(
+                [flux_part[0] * width, 0.0, flux_part[1] * width]
+            ),
+            n_active_elements=int(contacts[-1]),
+            active_area_m2=float(contacts[-1]) * self.cell_size_m * width,
+            max_depth_m=max(float(depths.max()) if depths.size else 0.0, 0.0),
+        )
+
+
+def _torque_window(run: MPMRun) -> int:
+    """Steps in the trailing averaging window, at least one."""
+    return max(1, min(run.n_steps, len(run.steps) // 10 or 1))

--- a/src/bunkershot3d/solvers/mpm/solver.py
+++ b/src/bunkershot3d/solvers/mpm/solver.py
@@ -61,7 +61,7 @@ from ..elements import SurfaceElements
 from ..envelope import GRAVITY_M_S2, RefusalPolicy, ValidityVerdict
 from ..exceptions import SolverInputError
 from ..protocol import FidelityTier, IntrusionState, SolverResult, Wrench
-from .body import RigidSection
+from .body import ContactImpulse, RigidSection
 from .constitutive import (
     SandContinuum,
     hencky_kirchhoff_principal,
@@ -105,6 +105,19 @@ _DIMENSION = 2
 _MASS_FLOOR_KG = 1e-15
 _MIN_APPROACH_CLEARANCE_CELLS = 2.0
 _SURFACE_BINS = 64
+
+_NO_CONTACT = ContactImpulse(
+    node_index=np.zeros(0, dtype=np.int64),
+    impulse_n_s=np.zeros((0, _DIMENSION)),
+    position_m=np.zeros((0, _DIMENSION)),
+    stress_force_n=np.zeros(_DIMENSION),
+    n_swept=0,
+)
+"""The ledger of a step with no intruder at all.
+
+A bed marched without a club is a *closed* system, which is the only
+configuration whose momentum budget is an identity rather than a balance
+against a boundary -- so it is what the conservation cases run on."""
 
 
 def cfl_time_step_s(
@@ -213,7 +226,10 @@ class MPMRun:
         time_step_s: The CFL step the march used.
         particles: Final particle state.
         grid: The background grid.
-        section: Final club pose.
+        section: Final club pose, or ``None`` for a bed marched with no
+            intruder at all -- which is what the conservation cases need,
+            since a closed system is the only one whose momentum budget
+            is an identity rather than a balance against a boundary.
         free_surface_height_m: The undisturbed surface the run started
             from.
         bed_x_bounds_m: Horizontal extent of the bed.
@@ -223,7 +239,7 @@ class MPMRun:
     time_step_s: float
     particles: ParticleState
     grid: PlaneStrainGrid
-    section: RigidSection
+    section: RigidSection | None
     free_surface_height_m: float
     bed_x_bounds_m: tuple[float, float]
 
@@ -521,7 +537,7 @@ class PlaneStrainMPMSolver:
     def march(
         self,
         particles: ParticleState,
-        section: RigidSection,
+        section: RigidSection | None,
         grid: PlaneStrainGrid,
         *,
         n_steps: int,
@@ -587,7 +603,8 @@ class PlaneStrainMPMSolver:
                 damping_per_step=damping_per_step,
             )
             diagnostics.append(report)
-            moving = moving.advanced(time_step_s)
+            if moving is not None:
+                moving = moving.advanced(time_step_s)
 
         return MPMRun(
             steps=tuple(diagnostics),
@@ -604,7 +621,7 @@ class PlaneStrainMPMSolver:
     def _advance(
         self,
         particles: ParticleState,
-        section: RigidSection,
+        section: RigidSection | None,
         grid: PlaneStrainGrid,
         node_positions: NDArray[np.float64],
         *,
@@ -640,13 +657,15 @@ class PlaneStrainMPMSolver:
         if damping_per_step > 0.0:
             updated *= 1.0 - damping_per_step
         apply_wall_conditions(grid, updated, self.walls)
-        updated, impulse = section.project_grid_velocity(
-            node_positions,
-            updated,
-            nodal_mass,
-            time_step_s=time_step_s,
-            stress_force_n=applied_force,
-        )
+        impulse = _NO_CONTACT
+        if section is not None:
+            updated, impulse = section.project_grid_velocity(
+                node_positions,
+                updated,
+                nodal_mass,
+                time_step_s=time_step_s,
+                stress_force_n=applied_force,
+            )
 
         particles.velocity_m_s = gather_velocity(stencil, updated)
         particles.affine = affine_from_grid_velocity(grid, stencil, updated)
@@ -661,17 +680,20 @@ class PlaneStrainMPMSolver:
         particles.position_m = (
             particles.position_m + time_step_s * particles.velocity_m_s
         )
-        particles.position_m, particles.velocity_m_s, pushed = section.push_out(
-            particles.position_m, particles.velocity_m_s
-        )
+        pushed = 0
+        if section is not None:
+            particles.position_m, particles.velocity_m_s, pushed = section.push_out(
+                particles.position_m, particles.velocity_m_s
+            )
 
+        reference = (
+            np.zeros(_DIMENSION) if section is None else section.reference_point_m
+        )
         return StepDiagnostics(
             time_s=float(elapsed_s),
             contact_force_n_per_m=impulse.force_on_body_n(time_step_s),
             stress_force_n_per_m=-impulse.stress_force_n,
-            contact_torque_n=impulse.torque_on_body_n_m(
-                time_step_s, section.reference_point_m
-            ),
+            contact_torque_n=impulse.torque_on_body_n_m(time_step_s, reference),
             n_contacts=impulse.n_contacts,
             n_swept=impulse.n_swept,
             n_pushed_out=int(pushed),
@@ -737,8 +759,12 @@ class PlaneStrainMPMSolver:
         if len(state.elements) == 0:
             raise SolverInputError("the intruder has no surface elements")
 
-    def _require_courant(self, section: RigidSection, time_step_s: float) -> None:
+    def _require_courant(
+        self, section: RigidSection | None, time_step_s: float
+    ) -> None:
         """Runtime assertion of the CFL condition, as a ``raise``."""
+        if section is None:
+            return
         travel = section.max_speed_m_s * float(time_step_s)
         if travel > self.cell_size_m:
             raise SolverInputError(

--- a/src/bunkershot3d/solvers/mpm/state.py
+++ b/src/bunkershot3d/solvers/mpm/state.py
@@ -1,0 +1,382 @@
+"""Particle state, bed initialisation and the domain walls.
+
+The bed starts in its **geostatic** elastic state rather than unstressed.
+An unstressed bed dropped under gravity rings for several elastic transit
+times before it settles, and that ringing would be indistinguishable from
+the club's own signal in a 2 ms engagement window.  Initialising at the
+1-D consolidation solution
+
+    ``sigma_zz = -rho g d``,  ``eps_xx = 0``,  ``eps_zz = sigma_zz / (lambda + 2 mu)``
+
+removes the transient by construction, up to the discretisation error of
+the stress divergence.
+
+This is *not* the same statement as "the analytic verification case is
+satisfied by construction".  The verification case in
+:mod:`bunkershot3d.solvers.mpm.verification` starts from an **unstressed**
+column and relaxes it, and then asks whether the solver found this state
+on its own.  Seeding it here and finding it there are different claims,
+and only the second one is evidence.
+
+Admissibility of the seed is checked rather than assumed: a sand with a
+low enough friction angle would yield under its own weight at ``K_0``
+confinement, and seeding an inadmissible state would leave the first step
+doing a large plastic correction that looks like club load.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..envelope import GRAVITY_M_S2
+from ..exceptions import SolverInputError
+from .constitutive import SandContinuum
+from .grid import PlaneStrainGrid
+
+__all__ = [
+    "DomainWalls",
+    "ParticleState",
+    "WallCondition",
+    "apply_wall_conditions",
+    "settled_bed",
+    "surface_profile_m",
+]
+
+_DIMENSION = 2
+
+
+class WallCondition(StrEnum):
+    """What a domain wall does to the nodal velocity beside it."""
+
+    STICKY = "sticky"
+    """Both components zeroed. The bed floor."""
+
+    SLIP = "slip"
+    """Only the wall-normal component zeroed, in both directions.
+
+    The lateral condition of a 1-D consolidation column: it enforces
+    ``eps_xx = 0``, which is exactly the confinement the geostatic seed
+    assumes."""
+
+    SEPARATE = "separate"
+    """The wall-normal component zeroed only when it points outward.
+
+    Material may leave but not enter. The condition a free lateral
+    boundary wants."""
+
+    FREE = "free"
+    """Nothing is done. The open top of the domain."""
+
+
+@dataclass(frozen=True, slots=True)
+class DomainWalls:
+    """The four walls of the plane-strain domain.
+
+    Attributes:
+        lower_x: Condition on the ``-x`` face.
+        upper_x: Condition on the ``+x`` face.
+        lower_z: Condition on the ``-z`` face, the bed floor.
+        upper_z: Condition on the ``+z`` face, normally open.
+        thickness_cells: How many node layers each wall acts over. Two,
+            by default, because a quadratic stencil is three nodes wide
+            and a one-node wall lets a particle's stencil reach past it.
+    """
+
+    lower_x: WallCondition = WallCondition.SLIP
+    upper_x: WallCondition = WallCondition.SLIP
+    lower_z: WallCondition = WallCondition.STICKY
+    upper_z: WallCondition = WallCondition.FREE
+    thickness_cells: int = 2
+
+    def __post_init__(self) -> None:
+        if int(self.thickness_cells) < 1:
+            raise SolverInputError(
+                f"thickness_cells must be at least 1, got {self.thickness_cells!r}"
+            )
+
+
+def apply_wall_conditions(
+    grid: PlaneStrainGrid,
+    node_velocity_m_s: NDArray[np.float64],
+    walls: DomainWalls,
+) -> NDArray[np.float64]:
+    """Impose the wall conditions on a nodal velocity field, in place.
+
+    Args:
+        grid: The background grid.
+        node_velocity_m_s: ``(n_nodes, 2)`` nodal velocities, mutated.
+        walls: The four conditions.
+
+    Returns:
+        The same array, for chaining.
+    """
+    count_x, count_z = grid.node_counts
+    band = int(walls.thickness_cells)
+    velocity = node_velocity_m_s.reshape(count_x, count_z, _DIMENSION)
+
+    def _impose(
+        view: NDArray[np.float64], condition: WallCondition, axis: int, outward: float
+    ) -> None:
+        if condition is WallCondition.FREE:
+            return
+        if condition is WallCondition.STICKY:
+            view[...] = 0.0
+            return
+        component = view[..., axis]
+        if condition is WallCondition.SLIP:
+            component[...] = 0.0
+            return
+        # SEPARATE: stop only what is heading out of the domain.
+        component[...] = np.where(component * outward > 0.0, 0.0, component)
+
+    _impose(velocity[:band, :, :], walls.lower_x, 0, -1.0)
+    _impose(velocity[count_x - band :, :, :], walls.upper_x, 0, +1.0)
+    _impose(velocity[:, :band, :], walls.lower_z, 1, -1.0)
+    _impose(velocity[:, count_z - band :, :], walls.upper_z, 1, +1.0)
+    return node_velocity_m_s
+
+
+@dataclass
+class ParticleState:
+    """The Lagrangian carriers of mass, momentum and deformation.
+
+    Deliberately mutable: a step advances every array in place and the
+    solver holds one instance for a whole run.  Everything is per unit
+    out-of-plane width, so masses are kg/m and volumes m^2.
+
+    Attributes:
+        position_m: ``(n, 2)`` positions.
+        velocity_m_s: ``(n, 2)`` velocities.
+        affine: ``(n, 2, 2)`` APIC affine velocity matrices ``C_p``.
+        deformation_gradient: ``(n, 2, 2)`` **elastic** deformation
+            gradients; the plastic part is discarded by the return map.
+        mass_kg: ``(n,)`` particle masses per unit width.
+        initial_volume_m2: ``(n,)`` reference areas.
+    """
+
+    position_m: NDArray[np.float64]
+    velocity_m_s: NDArray[np.float64]
+    affine: NDArray[np.float64]
+    deformation_gradient: NDArray[np.float64]
+    mass_kg: NDArray[np.float64]
+    initial_volume_m2: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        count = self.position_m.shape[0]
+        shapes = {
+            "position_m": (count, _DIMENSION),
+            "velocity_m_s": (count, _DIMENSION),
+            "affine": (count, _DIMENSION, _DIMENSION),
+            "deformation_gradient": (count, _DIMENSION, _DIMENSION),
+            "mass_kg": (count,),
+            "initial_volume_m2": (count,),
+        }
+        for name, expected in shapes.items():
+            actual = getattr(self, name).shape
+            if actual != expected:
+                raise SolverInputError(
+                    f"{name} must have shape {expected}, got {actual}"
+                )
+        if count == 0:
+            raise SolverInputError(
+                "a bed with no particles cannot be solved; an empty domain would "
+                "return an identically zero wrench that reads as a result"
+            )
+        if np.any(self.mass_kg <= 0.0):
+            raise SolverInputError("every particle must carry positive mass")
+
+    @property
+    def n_particles(self) -> int:
+        """Number of particles."""
+        return int(self.position_m.shape[0])
+
+    @property
+    def total_mass_kg(self) -> float:
+        """Total bed mass per unit width. Invariant for the whole run."""
+        return float(self.mass_kg.sum())
+
+    def linear_momentum_kg_m_s(self) -> NDArray[np.float64]:
+        """``(2,)`` total linear momentum per unit width."""
+        return (self.mass_kg[:, None] * self.velocity_m_s).sum(axis=0)
+
+    def kinetic_energy_j(self) -> float:
+        """Translational kinetic energy per unit width.
+
+        The APIC affine field carries kinetic energy too; it is excluded
+        here and the exclusion is stated, because the energy residual it
+        feeds is a truncation-class quantity whose *order* is the test,
+        and a term that is itself O(dx^2) would blur that order.
+        """
+        speed_squared = np.einsum("ij,ij->i", self.velocity_m_s, self.velocity_m_s)
+        return 0.5 * float((self.mass_kg * speed_squared).sum())
+
+    def gravitational_energy_j(self, gravity_m_s2: float, datum_m: float) -> float:
+        """Gravitational potential energy per unit width above ``datum_m``."""
+        return float(
+            (self.mass_kg * gravity_m_s2 * (self.position_m[:, 1] - datum_m)).sum()
+        )
+
+    def copy(self) -> ParticleState:
+        """A deep copy, so a run can be restarted from a saved state."""
+        return ParticleState(
+            position_m=self.position_m.copy(),
+            velocity_m_s=self.velocity_m_s.copy(),
+            affine=self.affine.copy(),
+            deformation_gradient=self.deformation_gradient.copy(),
+            mass_kg=self.mass_kg.copy(),
+            initial_volume_m2=self.initial_volume_m2.copy(),
+        )
+
+
+def settled_bed(
+    material: SandContinuum,
+    *,
+    x_bounds_m: tuple[float, float],
+    free_surface_height_m: float,
+    depth_m: float,
+    cell_size_m: float,
+    particles_per_cell_axis: int = 2,
+    gravity_m_s2: float = GRAVITY_M_S2,
+    geostatic: bool = True,
+) -> ParticleState:
+    """Fill a rectangular bed with particles in geostatic equilibrium.
+
+    Particles are placed on a regular sub-cell lattice, which is the
+    standard MPM quadrature: ``particles_per_cell_axis ** 2`` per cell,
+    each carrying ``dx^2 / ppc`` of reference area.  Two per axis (four
+    per cell) is the usual choice and is enough for the quadratic basis.
+
+    Args:
+        material: The continuum, for density and stiffness.
+        x_bounds_m: ``(lower, upper)`` horizontal extent of the bed.
+        free_surface_height_m: World ``z`` of the undisturbed surface.
+        depth_m: Bed depth below that surface.
+        cell_size_m: Grid ``dx``; the particle lattice is derived from it.
+        particles_per_cell_axis: Particles per cell per axis.
+        gravity_m_s2: Gravitational acceleration.
+        geostatic: Seed the 1-D consolidation stress. Setting this False
+            gives an unstressed bed, which is what the analytic
+            verification case needs so that finding the geostatic state
+            is a result rather than an input.
+
+    Returns:
+        The bed.
+
+    Raises:
+        SolverInputError: If the bed is degenerate, or if the geostatic
+            seed would be outside the yield surface -- which would make
+            the first step a large plastic correction indistinguishable
+            from club load.
+    """
+    lower_x, upper_x = (float(value) for value in x_bounds_m)
+    depth = float(depth_m)
+    size = float(cell_size_m)
+    per_axis = int(particles_per_cell_axis)
+    if not math.isfinite(lower_x) or not math.isfinite(upper_x) or upper_x <= lower_x:
+        raise SolverInputError(
+            f"x_bounds_m must be an increasing finite pair, got {x_bounds_m!r}"
+        )
+    if not math.isfinite(depth) or depth <= 0.0:
+        raise SolverInputError(f"depth_m must be positive, got {depth_m!r}")
+    if not math.isfinite(size) or size <= 0.0:
+        raise SolverInputError(f"cell_size_m must be positive, got {cell_size_m!r}")
+    if per_axis < 1:
+        raise SolverInputError(
+            f"particles_per_cell_axis must be at least 1, got "
+            f"{particles_per_cell_axis!r}"
+        )
+
+    spacing = size / per_axis
+    count_x = max(int(round((upper_x - lower_x) / spacing)), 1)
+    count_z = max(int(round(depth / spacing)), 1)
+    offsets_x = (np.arange(count_x) + 0.5) * spacing + lower_x
+    offsets_z = (np.arange(count_z) + 0.5) * spacing + (
+        float(free_surface_height_m) - depth
+    )
+    mesh_x, mesh_z = np.meshgrid(offsets_x, offsets_z, indexing="ij")
+    position = np.stack([mesh_x.ravel(), mesh_z.ravel()], axis=1)
+
+    volume = np.full(position.shape[0], spacing * spacing)
+    mass = material.density_kg_m3 * volume
+
+    gradient = np.tile(np.eye(_DIMENSION), (position.shape[0], 1, 1))
+    if geostatic:
+        below = np.maximum(float(free_surface_height_m) - position[:, 1], 0.0)
+        vertical_stress = -material.density_kg_m3 * gravity_m_s2 * below
+        vertical_strain = vertical_stress / material.p_wave_modulus_pa
+        _require_admissible_seed(material, vertical_strain)
+        gradient[:, 1, 1] = np.exp(vertical_strain)
+
+    return ParticleState(
+        position_m=position,
+        velocity_m_s=np.zeros_like(position),
+        affine=np.zeros((position.shape[0], _DIMENSION, _DIMENSION)),
+        deformation_gradient=gradient,
+        mass_kg=mass,
+        initial_volume_m2=volume,
+    )
+
+
+def _require_admissible_seed(
+    material: SandContinuum, vertical_strain: NDArray[np.float64]
+) -> None:
+    """Refuse a geostatic seed that is already yielding."""
+    strain = np.stack([np.zeros_like(vertical_strain), vertical_strain], axis=1)
+    worst = float(material.yield_value(strain).max())
+    if worst > 0.0:
+        raise SolverInputError(
+            f"the geostatic seed is outside the yield surface (y = {worst:.4g} Pa) "
+            f"for a friction angle of {material.friction_angle_deg:.3g} deg: this "
+            "bed cannot stand up under its own weight at K_0 confinement, so "
+            "seeding it would make the first step a large plastic correction that "
+            "is indistinguishable from club load"
+        )
+
+
+def surface_profile_m(
+    particles: ParticleState,
+    *,
+    x_bounds_m: tuple[float, float],
+    n_bins: int,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Free-surface height per horizontal bin, from the topmost particle.
+
+    The free surface in MPM is wherever the particles stop, so it is read
+    off the particles rather than tracked.  Bins with no particle are
+    reported as ``nan`` rather than interpolated, because an emptied bin
+    is a real feature -- it is the divot -- and filling it in would erase
+    the quantity being measured.
+
+    Args:
+        particles: The bed.
+        x_bounds_m: Horizontal range to profile.
+        n_bins: Number of bins across that range.
+
+    Returns:
+        ``(bin_centres, surface_height)``, both ``(n_bins,)``.
+
+    Raises:
+        SolverInputError: If ``n_bins`` is not positive.
+    """
+    if int(n_bins) < 1:
+        raise SolverInputError(f"n_bins must be positive, got {n_bins!r}")
+    lower, upper = (float(value) for value in x_bounds_m)
+    if upper <= lower:
+        raise SolverInputError(
+            f"x_bounds_m must be an increasing pair, got {x_bounds_m!r}"
+        )
+    edges = np.linspace(lower, upper, int(n_bins) + 1)
+    centres = 0.5 * (edges[:-1] + edges[1:])
+    index = np.digitize(particles.position_m[:, 0], edges) - 1
+    # -inf while reducing, because np.maximum against nan propagates the nan
+    # and would swallow every bin that does hold a particle.
+    heights = np.full(int(n_bins), -np.inf)
+    inside = (index >= 0) & (index < int(n_bins))
+    if bool(inside.any()):
+        np.maximum.at(heights, index[inside], particles.position_m[inside, 1])
+    return centres, np.where(np.isfinite(heights), heights, np.nan)

--- a/src/bunkershot3d/solvers/mpm/verification.py
+++ b/src/bunkershot3d/solvers/mpm/verification.py
@@ -1,0 +1,755 @@
+"""Code verification for the F1 tier, through the existing V&V machinery.
+
+ADR-0033 requires F1 to "produce a GCI study rather than a
+single-resolution result", and the NASA-STD-7009B self-assessment in
+:mod:`bunkershot3d.vandv.credibility` records **validation at level 0 of
+4**.  A new solver that cannot demonstrate its own correctness makes that
+score worse, not better, so this module exists before any picture does.
+
+Nothing here uses experimental data.  It is *code verification* -- is the
+maths right -- and it reuses
+:mod:`bunkershot3d.vandv.conservation`,
+:mod:`bunkershot3d.vandv.convergence` and :mod:`bunkershot3d.vandv.gci`
+rather than growing a second Richardson extrapolation beside the Celik
+implementation that is already there.
+
+The four checks, and why each is the one it is
+----------------------------------------------
+
+**Free fall.**  A closed bed under gravity with no intruder and no walls.
+Mass is conserved exactly (particles never change mass, and the B-spline
+partition of unity makes the P2G sum exact), and total momentum after
+``n`` steps is exactly ``M g n dt`` because the internal forces sum to
+zero for *any* stress field.  Both are identities of the scheme, so both
+are round-off class.
+
+**Elastic column.**  An unstressed column relaxed under its own weight to
+static equilibrium, against the closed-form 1-D consolidation answer
+``<sigma_zz> = -rho g H / 2``.  This is a real test rather than a
+restatement of the initialisation: the solver's own bed seeding uses the
+geostatic state, but this case **starts unstressed and has to find it**.
+The equilibrium state is verified to be elastic, so the analytic elastic
+answer is the exact solution of the elastoplastic model here, not an
+approximation to it.
+
+**Why not Bagnold.**  The obvious granular analytic case is the Bagnold
+profile of steady inclined flow, and it is unavailable to this tier *by
+construction*: it is a consequence of the ``mu(I)`` rate dependence, and
+F1's constitutive model is deliberately rate-independent (see
+:mod:`bunkershot3d.solvers.mpm.constitutive` for why).  A
+rate-independent plastic solid on an incline gives plug flow over a basal
+shear band, not a 3/2 power law.  Using Bagnold anyway would be testing a
+rheology this solver does not have.
+
+**Energy.**  Truncation class, not round-off: symplectic Euler conserves
+energy only to ``O(dt)``, and the *order of the decay* is the test.  A
+truncation residual can always be made small by shrinking ``dt``, which
+says nothing, so :mod:`bunkershot3d.vandv.conservation` refuses to let it
+be judged by a fixed tolerance and this module obeys that.
+
+**F0 cross-check.**  ADR-0033 is explicit that this is a consistency
+check between two uncalibrated models and **not** a validation: agreement
+raises neither tier's validation level above 0, because neither is being
+compared to a measurement.  What it can do is falsify, so the comparison
+is reported as numbers -- including the ratio and where it comes from --
+rather than reduced to a pass.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...vandv.conservation import ConservationClass, ConservationResidual
+from ...vandv.convergence import ObservedOrder, observed_order_from_errors
+from ...vandv.gci import GCIResult, GridSolution, grid_convergence_index
+from ..drft import DRFTSolver
+from ..envelope import GRAVITY_M_S2, RefusalPolicy
+from ..exceptions import SolverInputError
+from ..protocol import IntrusionState, SolverResult
+from .constitutive import SandContinuum, principal_stretches
+from .grid import PlaneStrainGrid
+from .solver import MPMRun, PlaneStrainMPMSolver
+from .state import DomainWalls, ParticleState, WallCondition, settled_bed
+
+__all__ = [
+    "ColumnEquilibrium",
+    "F0CrossCheck",
+    "column_grid_convergence",
+    "cross_check_against_f0",
+    "elastic_column_equilibrium",
+    "energy_residuals",
+    "free_fall_residuals",
+    "mean_vertical_stress_pa",
+]
+
+_OPEN_DOMAIN = DomainWalls(
+    lower_x=WallCondition.FREE,
+    upper_x=WallCondition.FREE,
+    lower_z=WallCondition.FREE,
+    upper_z=WallCondition.FREE,
+)
+"""No walls at all: the closed-system configuration the momentum identity
+is an identity in."""
+
+_COLUMN_DOMAIN = DomainWalls(
+    lower_x=WallCondition.SLIP,
+    upper_x=WallCondition.SLIP,
+    lower_z=WallCondition.STICKY,
+    upper_z=WallCondition.FREE,
+)
+"""The 1-D consolidation column: laterally confined, fixed base, free top."""
+
+
+def _free_solver(
+    material: SandContinuum,
+    cell_size_m: float,
+    *,
+    walls: DomainWalls,
+    gravity_m_s2: float,
+    max_steps: int,
+) -> PlaneStrainMPMSolver:
+    """A solver configured for a verification case rather than a shot."""
+    return PlaneStrainMPMSolver(
+        material=material,
+        cell_size_m=cell_size_m,
+        effective_width_m=1.0,
+        bed_depth_m=1.0,
+        walls=walls,
+        gravity_m_s2=gravity_m_s2,
+        refusal_policy=RefusalPolicy.REPORT,
+        max_steps=max_steps,
+    )
+
+
+def _particles(
+    material: SandContinuum,
+    *,
+    cell_size_m: float,
+    width_m: float,
+    height_m: float,
+    particles_per_cell_axis: int = 2,
+    geostatic: bool = False,
+) -> ParticleState:
+    """A rectangular block of particles occupying ``[0, W] x [0, H]``."""
+    return settled_bed(
+        material,
+        x_bounds_m=(0.0, width_m),
+        free_surface_height_m=height_m,
+        depth_m=height_m,
+        cell_size_m=cell_size_m,
+        particles_per_cell_axis=particles_per_cell_axis,
+        geostatic=geostatic,
+    )
+
+
+def _open_grid(
+    *, cell_size_m: float, width_m: float, height_m: float
+) -> PlaneStrainGrid:
+    """A grid with room on every side, for a case that has no walls at all."""
+    return PlaneStrainGrid.covering(
+        (0.0, 0.0), (width_m, height_m), cell_size_m, pad_cells=4
+    )
+
+
+def _column_grid(
+    *, cell_size_m: float, width_m: float, height_m: float
+) -> PlaneStrainGrid:
+    """A grid whose wall bands land **on** the column's own boundaries.
+
+    This is the whole of the boundary condition and it is easy to get
+    silently wrong.  :class:`~bunkershot3d.solvers.mpm.state.DomainWalls`
+    acts over the outermost two node layers of the grid, so a grid padded
+    generously on every side puts the "fixed base" two cells *below* the
+    column and the "confining" side walls two cells *outside* it.  The
+    column then stands in free space and simply falls -- with an entirely
+    plausible-looking run and a mean stress of zero.
+
+    One cell of padding on the left, the right and the bottom puts the
+    inner wall layer exactly on ``x = 0``, ``x = W`` and ``z = 0``, which
+    are the 1-D consolidation conditions the analytic answer assumes.
+    """
+    size = float(cell_size_m)
+    count_x = int(math.ceil(width_m / size)) + 3
+    count_z = int(math.ceil(height_m / size)) + 4
+    return PlaneStrainGrid((-size, -size), size, (count_x, count_z))
+
+
+# --------------------------------------------------------------- free fall
+
+
+def free_fall_residuals(
+    material: SandContinuum,
+    *,
+    cell_size_m: float = 0.004,
+    width_m: float = 0.024,
+    height_m: float = 0.024,
+    n_steps: int = 40,
+    gravity_m_s2: float = GRAVITY_M_S2,
+) -> tuple[ConservationResidual, ...]:
+    """Mass and momentum residuals of a closed bed in free fall.
+
+    An unstressed block with no intruder and no walls.  Nothing can
+    generate stress -- ``F`` stays the identity because the grid velocity
+    field is uniform -- so the only force is gravity and both residuals
+    are exact identities of the scheme:
+
+    * ``sum_p m_p`` never changes, and P2G sums it exactly by the
+      partition of unity;
+    * ``sum_p m_p v_p`` after ``n`` steps is exactly ``M g n dt``, because
+      ``sum_i grad w_ip = 0`` makes the internal forces sum to zero for
+      any stress field whatsoever.
+
+    Both are therefore **round-off class**, and neither carries a step
+    size: :class:`~bunkershot3d.vandv.conservation.ConservationResidual`
+    refuses a step size on a round-off residual precisely so nobody fits
+    an order to floating-point noise.
+
+    Args:
+        material: The continuum.
+        cell_size_m: Grid ``dx``.
+        width_m: Block width.
+        height_m: Block height.
+        n_steps: Steps to fall.
+        gravity_m_s2: Gravitational acceleration.
+
+    Returns:
+        ``(mass_residual, vertical_momentum_residual)``.
+    """
+    particles = _particles(
+        material,
+        cell_size_m=cell_size_m,
+        width_m=width_m,
+        height_m=height_m,
+    )
+    grid = _open_grid(cell_size_m=cell_size_m, width_m=width_m, height_m=height_m)
+    solver = _free_solver(
+        material,
+        cell_size_m,
+        walls=_OPEN_DOMAIN,
+        gravity_m_s2=gravity_m_s2,
+        max_steps=max(n_steps, 1),
+    )
+    initial_mass = particles.total_mass_kg
+    step_s = 0.4 * cell_size_m / material.elastic_wave_speed_m_s
+    run = solver.march(
+        particles,
+        None,
+        grid,
+        n_steps=n_steps,
+        time_step_s=step_s,
+        free_surface_height_m=height_m,
+        bed_x_bounds_m=(0.0, width_m),
+    )
+
+    final = run.steps[-1]
+    expected_momentum = -initial_mass * gravity_m_s2 * n_steps * step_s
+    return (
+        ConservationResidual(
+            name="F1 free fall: total particle mass",
+            conservation_class=ConservationClass.ROUND_OFF,
+            residual=abs(final.total_mass_kg_per_m - initial_mass),
+            scale=initial_mass,
+        ),
+        ConservationResidual(
+            name="F1 free fall: vertical linear momentum",
+            conservation_class=ConservationClass.ROUND_OFF,
+            residual=abs(float(final.linear_momentum_kg_m_s[1]) - expected_momentum),
+            scale=abs(expected_momentum),
+        ),
+    )
+
+
+# ------------------------------------------------------------------ energy
+
+
+def energy_residuals(
+    material: SandContinuum,
+    *,
+    courant_numbers: Sequence[float] = (0.4, 0.2, 0.1),
+    cell_size_m: float = 0.004,
+    width_m: float = 0.024,
+    height_m: float = 0.024,
+    duration_s: float = 4.0e-4,
+    gravity_m_s2: float = GRAVITY_M_S2,
+) -> tuple[ConservationResidual, ...]:
+    """Energy residuals of a closed bed in free fall, one per timestep.
+
+    What this covers, and what it deliberately does not
+    ---------------------------------------------------
+
+    It measures the **time integrator's** energy behaviour.  Symplectic
+    Euler applied to ``v <- v + g dt``, ``x <- x + v dt`` loses exactly
+    ``M g^2 dt^2 / 2`` of ``KE + m g z`` per step, so over a fixed window
+    ``T`` the drift is ``M g^2 dt T / 2`` -- first order in ``dt``, with a
+    closed form, and with no plasticity anywhere because the grid
+    velocity field is uniform and ``F`` stays the identity.
+
+    It does **not** cover the elastic energy exchange, and the reason is
+    a real property of the material rather than an oversight.  The
+    obvious case -- a pre-compressed block released to oscillate -- does
+    not work for cohesionless sand: the block rebounds past its rest
+    state into tension, the Drucker-Prager return map correctly
+    annihilates the deviatoric strain at the cone tip, and the resulting
+    energy loss is *physical plastic dissipation*, not truncation error.
+    Measured on a first attempt at this case: 129 of 144 particles
+    yielding per step.  Fitting an order to that would be fitting an
+    order to the plasticity.  The elastic pathway is covered instead by a
+    static check --
+    :attr:`ColumnEquilibrium.analytic_elastic_energy_j_per_m` -- which
+    needs no conservation argument.
+
+    Args:
+        material: The continuum.
+        courant_numbers: Courant numbers to run, giving the step series.
+        cell_size_m: Grid ``dx``.
+        width_m: Block width.
+        height_m: Block height.
+        duration_s: Physical time each run covers, held fixed so the runs
+            compare the same event at different steps.
+        gravity_m_s2: Gravitational acceleration.
+
+    Returns:
+        One truncation-class residual per Courant number, each carrying
+        its step size because the order of the decay *is* its test.
+
+    Raises:
+        SolverInputError: If any particle yields, which would make the
+            residual physical dissipation rather than truncation error.
+    """
+    residuals: list[ConservationResidual] = []
+    for number in courant_numbers:
+        particles = _particles(
+            material,
+            cell_size_m=cell_size_m,
+            width_m=width_m,
+            height_m=height_m,
+        )
+        grid = _open_grid(cell_size_m=cell_size_m, width_m=width_m, height_m=height_m)
+        step_s = float(number) * cell_size_m / material.elastic_wave_speed_m_s
+        n_steps = max(int(round(duration_s / step_s)), 2)
+        solver = _free_solver(
+            material,
+            cell_size_m,
+            walls=_OPEN_DOMAIN,
+            gravity_m_s2=gravity_m_s2,
+            max_steps=n_steps,
+        )
+        run = solver.march(
+            particles,
+            None,
+            grid,
+            n_steps=n_steps,
+            time_step_s=step_s,
+            free_surface_height_m=height_m,
+            bed_x_bounds_m=(0.0, width_m),
+        )
+        yielded = sum(step.n_yielded for step in run.steps)
+        if yielded:
+            raise SolverInputError(
+                f"{yielded} particle(s) yielded during the free-fall energy "
+                "case. A uniformly falling block cannot deform, so this means "
+                "the transfer is not reproducing a uniform velocity field and "
+                "the residual would no longer be truncation error"
+            )
+        total = np.array(
+            [
+                step.kinetic_energy_j_per_m
+                + step.elastic_energy_j_per_m
+                + step.gravitational_energy_j_per_m
+                for step in run.steps
+            ]
+        )
+        scale = float(np.abs(total).max())
+        residuals.append(
+            ConservationResidual(
+                name=f"F1 free fall: total energy at C={number:g}",
+                conservation_class=ConservationClass.TRUNCATION,
+                residual=float(np.abs(total - total[0]).max()),
+                scale=scale if scale > 0.0 else 1.0,
+                step_size_s=step_s,
+            )
+        )
+    return tuple(residuals)
+
+
+# ---------------------------------------------------------- elastic column
+
+
+def mean_vertical_stress_pa(material: SandContinuum, particles: ParticleState) -> float:
+    """Volume-weighted mean vertical Cauchy stress over a particle set."""
+    left, stretches, _ = principal_stretches(particles.deformation_gradient)
+    strain = np.log(stretches)
+    trace = strain.sum(axis=1)
+    kirchhoff = (
+        2.0 * material.shear_modulus_pa * strain
+        + material.lame_lambda_pa * trace[:, None]
+    )
+    jacobian = stretches.prod(axis=1)
+    principal = kirchhoff / jacobian[:, None]
+    vertical = np.einsum("nk,nk,nk->n", left[:, 1, :], principal, left[:, 1, :])
+    volume = particles.initial_volume_m2 * jacobian
+    return float((vertical * volume).sum() / volume.sum())
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnEquilibrium:
+    """One relaxed elastic column, against its closed-form answer.
+
+    Attributes:
+        cell_size_m: The grid the column was solved on.
+        mean_vertical_stress_pa: Solved volume-weighted ``<sigma_zz>``.
+        analytic_mean_vertical_stress_pa: ``-rho g H / 2``.
+        residual_kinetic_energy_j_per_m: What was left moving at the end.
+        initial_kinetic_scale_j_per_m: The largest kinetic energy the
+            relaxation passed through, so the residual has something to be
+            judged against.
+        n_yielded: Particles the return map moved on the final step. Must
+            be zero for the elastic answer to be the exact one.
+        n_steps: Steps taken.
+        n_particles: Particles in the column.
+    """
+
+    cell_size_m: float
+    mean_vertical_stress_pa: float
+    analytic_mean_vertical_stress_pa: float
+    elastic_energy_j_per_m: float
+    analytic_elastic_energy_j_per_m: float
+    residual_kinetic_energy_j_per_m: float
+    initial_kinetic_scale_j_per_m: float
+    n_yielded: int
+    n_steps: int
+    n_particles: int
+
+    @property
+    def elastic_energy_relative_error(self) -> float:
+        """Error in the stored strain energy against ``W (rho g)^2 H^3 / (6 M)``.
+
+        The elastic pathway's check.  It is static, so it needs no
+        conservation argument -- which matters because the conservative
+        elastic case a cohesionless sand would need does not exist (see
+        :func:`energy_residuals`).
+        """
+        return abs(
+            self.elastic_energy_j_per_m - self.analytic_elastic_energy_j_per_m
+        ) / abs(self.analytic_elastic_energy_j_per_m)
+
+    @property
+    def absolute_error_pa(self) -> float:
+        """Absolute error against the analytic answer."""
+        return abs(self.mean_vertical_stress_pa - self.analytic_mean_vertical_stress_pa)
+
+    @property
+    def relative_error(self) -> float:
+        """Error as a fraction of the analytic answer."""
+        return self.absolute_error_pa / abs(self.analytic_mean_vertical_stress_pa)
+
+    @property
+    def relaxed_fraction(self) -> float:
+        """How far the kinetic energy fell from its peak. Near zero is settled."""
+        if self.initial_kinetic_scale_j_per_m <= 0.0:
+            return 0.0
+        return self.residual_kinetic_energy_j_per_m / self.initial_kinetic_scale_j_per_m
+
+    def summary(self) -> str:
+        """A line fit for a verification report."""
+        return (
+            f"dx={self.cell_size_m * 1e3:.4g} mm, {self.n_particles} particles: "
+            f"<sigma_zz> = {self.mean_vertical_stress_pa:.6g} Pa against "
+            f"{self.analytic_mean_vertical_stress_pa:.6g} Pa analytic "
+            f"({self.relative_error:.3%}), relaxed to "
+            f"{self.relaxed_fraction:.2e} of peak KE"
+        )
+
+
+def elastic_column_equilibrium(
+    material: SandContinuum,
+    *,
+    cell_size_m: float,
+    width_m: float = 0.024,
+    height_m: float = 0.048,
+    gravity_m_s2: float = GRAVITY_M_S2,
+    damping_per_step: float = 0.02,
+    n_steps: int | None = None,
+) -> ColumnEquilibrium:
+    """Relax an unstressed column under its own weight and compare.
+
+    Laterally confined by slip walls and fixed at the base, so the exact
+    solution is the 1-D consolidation state
+    ``sigma_zz(z) = -rho g (H - z)``, whose volume average is
+    ``-rho g H / 2``.  That state is inside the Drucker-Prager cone for
+    any sand this package can build -- the ``K_0`` stress ratio
+    ``nu / (1 - nu)`` puts it well below the yield surface -- so the
+    *elastic* answer is the exact solution of the elastoplastic model and
+    not an approximation to it.  ``n_yielded`` is reported so that claim
+    is checked rather than assumed.
+
+    Args:
+        material: The continuum.
+        cell_size_m: Grid ``dx``.
+        width_m: Column width.
+        height_m: Column height.
+        gravity_m_s2: Gravitational acceleration.
+        damping_per_step: Nodal velocity damping. Relaxation to a
+            *static* answer needs it; it vanishes as the velocity does,
+            so it cannot move the equilibrium it is converging to.
+        n_steps: Steps to relax. Defaults to enough elastic transits of
+            the column for the damping to have acted.
+
+    Returns:
+        The relaxed column.
+    """
+    particles = _particles(
+        material,
+        cell_size_m=cell_size_m,
+        width_m=width_m,
+        height_m=height_m,
+    )
+    grid = _column_grid(cell_size_m=cell_size_m, width_m=width_m, height_m=height_m)
+    step_s = 0.4 * cell_size_m / material.elastic_wave_speed_m_s
+    transit_s = height_m / material.elastic_wave_speed_m_s
+    steps = (
+        int(math.ceil(24.0 * transit_s / step_s)) if n_steps is None else int(n_steps)
+    )
+    solver = _free_solver(
+        material,
+        cell_size_m,
+        walls=_COLUMN_DOMAIN,
+        gravity_m_s2=gravity_m_s2,
+        max_steps=steps,
+    )
+    run = solver.march(
+        particles,
+        None,
+        grid,
+        n_steps=steps,
+        time_step_s=step_s,
+        free_surface_height_m=height_m,
+        bed_x_bounds_m=(0.0, width_m),
+        damping_per_step=damping_per_step,
+    )
+    peak_kinetic = max(step.kinetic_energy_j_per_m for step in run.steps)
+    unit_weight = material.density_kg_m3 * gravity_m_s2
+    return ColumnEquilibrium(
+        cell_size_m=float(cell_size_m),
+        mean_vertical_stress_pa=mean_vertical_stress_pa(material, particles),
+        analytic_mean_vertical_stress_pa=-unit_weight * height_m / 2.0,
+        elastic_energy_j_per_m=run.steps[-1].elastic_energy_j_per_m,
+        # U = W int_0^H sigma_zz^2 / (2 M) dz = W (rho g)^2 H^3 / (6 M)
+        analytic_elastic_energy_j_per_m=(
+            width_m * unit_weight**2 * height_m**3 / (6.0 * material.p_wave_modulus_pa)
+        ),
+        residual_kinetic_energy_j_per_m=run.steps[-1].kinetic_energy_j_per_m,
+        initial_kinetic_scale_j_per_m=peak_kinetic,
+        n_yielded=run.steps[-1].n_yielded,
+        n_steps=run.n_steps,
+        n_particles=particles.n_particles,
+    )
+
+
+def column_grid_convergence(
+    material: SandContinuum,
+    *,
+    cell_sizes_m: Sequence[float] = (0.006, 0.004, 0.003),
+    width_m: float = 0.024,
+    height_m: float = 0.048,
+    gravity_m_s2: float = GRAVITY_M_S2,
+) -> tuple[tuple[ColumnEquilibrium, ...], ObservedOrder, GCIResult]:
+    """Refine the elastic column and report the order and the GCI.
+
+    The default cell sizes divide the column height exactly at two
+    particles per cell per axis, which matters: a size that leaves a
+    partial particle layer changes the *discrete* column's height by a
+    rounding rather than by the discretisation, and a rounding artefact
+    is not a smooth function of ``dx``, so the observed order would be
+    measuring the ``round`` call.
+
+    Args:
+        material: The continuum.
+        cell_sizes_m: Grid sizes, coarsest first. Three at least, since
+            Celik's apparent order needs three levels.
+        width_m: Column width.
+        height_m: Column height.
+        gravity_m_s2: Gravitational acceleration.
+
+    Returns:
+        ``(levels, observed_order, gci)``.
+
+    Raises:
+        SolverInputError: If fewer than three sizes are supplied.
+    """
+    sizes = [float(size) for size in cell_sizes_m]
+    if len(sizes) < 3:
+        raise SolverInputError(
+            f"a GCI study needs at least three grids, got {len(sizes)}"
+        )
+    levels = tuple(
+        elastic_column_equilibrium(
+            material,
+            cell_size_m=size,
+            width_m=width_m,
+            height_m=height_m,
+            gravity_m_s2=gravity_m_s2,
+        )
+        for size in sizes
+    )
+    order = observed_order_from_errors(
+        [level.cell_size_m for level in levels],
+        [level.absolute_error_pa for level in levels],
+    )
+    gci = grid_convergence_index(
+        [
+            GridSolution(
+                cell_size_m=level.cell_size_m,
+                value=level.mean_vertical_stress_pa,
+                label=f"dx={level.cell_size_m * 1e3:.3g} mm",
+            )
+            for level in levels
+        ],
+        quantity="F1 elastic column mean vertical stress",
+    )
+    return levels, order, gci
+
+
+# ----------------------------------------------------------- F0 comparison
+
+
+@dataclass(frozen=True, slots=True)
+class F0CrossCheck:
+    """F1 and F0 on the quantities both produce, and where they diverge.
+
+    ADR-0033 states plainly what this is: **a consistency check between
+    two uncalibrated models, not a validation.**  Agreement raises
+    neither tier's NASA-STD-7009B validation level above 0, because
+    neither is being compared to a measurement.  Disagreement beyond a
+    declared band, on the other hand, means at least one of them is
+    wrong, and that is worth knowing.
+
+    Attributes:
+        speed_m_s: Intrusion speed the pair was run at.
+        f0_force_n: ``(3,)`` F0 resultant force.
+        f1_force_n: ``(3,)`` F1 resultant force, at the declared width.
+        f0_depth_force_n: F0's depth-linear part.
+        f0_inertial_force_n: F0's dynamic part.
+        f1_stress_force_n: F1's stress-and-weight part.
+        f1_flux_force_n: F1's momentum-flux part.
+        f0_max_depth_m: Deepest submerged point per F0.
+        f1_max_depth_m: The same per F1.
+        f1_divot_depth_m: F1's free-surface depression, which F0 cannot
+            produce at all.
+        effective_width_m: The declared width F1's magnitude rests on.
+    """
+
+    speed_m_s: float
+    f0_force_n: NDArray[np.float64]
+    f1_force_n: NDArray[np.float64]
+    f0_depth_force_n: NDArray[np.float64]
+    f0_inertial_force_n: NDArray[np.float64]
+    f1_stress_force_n: NDArray[np.float64]
+    f1_flux_force_n: NDArray[np.float64]
+    f0_max_depth_m: float
+    f1_max_depth_m: float
+    f1_divot_depth_m: float
+    effective_width_m: float
+
+    @property
+    def magnitude_ratio(self) -> float:
+        """``|F1| / |F0|``. Meaningful only alongside the declared width."""
+        f0 = float(np.linalg.norm(self.f0_force_n))
+        if f0 <= 0.0:
+            return math.inf
+        return float(np.linalg.norm(self.f1_force_n)) / f0
+
+    @property
+    def direction_agreement(self) -> float:
+        """Cosine between the two resultant force directions.
+
+        The most transferable part of the comparison: it does not depend
+        on the effective width at all, so it is the one number here that
+        is not conditional on a modelling assumption.
+        """
+        f0_norm = float(np.linalg.norm(self.f0_force_n))
+        f1_norm = float(np.linalg.norm(self.f1_force_n))
+        if f0_norm <= 0.0 or f1_norm <= 0.0:
+            return 0.0
+        return float(self.f0_force_n @ self.f1_force_n) / (f0_norm * f1_norm)
+
+    @property
+    def f0_inertial_fraction(self) -> float:
+        """Share of F0's force carried by its dynamic term."""
+        depth = float(np.linalg.norm(self.f0_depth_force_n))
+        inertial = float(np.linalg.norm(self.f0_inertial_force_n))
+        return inertial / (depth + inertial) if depth + inertial > 0.0 else 0.0
+
+    @property
+    def f1_flux_fraction(self) -> float:
+        """Share of F1's reaction carried by momentum flux."""
+        stress = float(np.linalg.norm(self.f1_stress_force_n))
+        flux = float(np.linalg.norm(self.f1_flux_force_n))
+        return flux / (stress + flux) if stress + flux > 0.0 else 0.0
+
+    def summary(self) -> str:
+        """A paragraph fit for a verification report."""
+        return (
+            f"v={self.speed_m_s:.4g} m/s, width={self.effective_width_m * 1e3:.4g} mm: "
+            f"|F0|={float(np.linalg.norm(self.f0_force_n)):.4g} N, "
+            f"|F1|={float(np.linalg.norm(self.f1_force_n)):.4g} N, "
+            f"ratio={self.magnitude_ratio:.3g}, "
+            f"direction cos={self.direction_agreement:.4f}; "
+            f"inertial share F0={self.f0_inertial_fraction:.3f} vs flux share "
+            f"F1={self.f1_flux_fraction:.3f}; depth F0={self.f0_max_depth_m * 1e3:.3g} "
+            f"mm vs F1={self.f1_max_depth_m * 1e3:.3g} mm; F1 divot "
+            f"{self.f1_divot_depth_m * 1e3:.3g} mm (F0 produces none)"
+        )
+
+
+def cross_check_against_f0(
+    state: IntrusionState,
+    f0_solver: DRFTSolver,
+    f1_solver: PlaneStrainMPMSolver,
+) -> F0CrossCheck:
+    """Run both tiers on one query and report where they diverge.
+
+    Args:
+        state: The intrusion query, given to both tiers unchanged.
+        f0_solver: The F0 solver. Its refusal policy should be permissive,
+            since a bunker shot is far outside its stated envelope and a
+            strict policy would refuse before producing anything to
+            compare.
+        f1_solver: The F1 solver.
+
+    Returns:
+        The comparison.
+    """
+    f0_result: SolverResult = f0_solver.solve(state)
+    run = f1_solver.run(state)
+    window = min(f1_solver.averaging_window_s, run.duration_s)
+    stress_part, flux_part = run.force_split(window)
+    width = f1_solver.effective_width_m
+    total = (stress_part + flux_part) * width
+    depths = -state.element_depths_m()
+
+    return F0CrossCheck(
+        speed_m_s=state.speed_m_s,
+        f0_force_n=np.asarray(f0_result.wrench.force_n, dtype=np.float64),
+        f1_force_n=np.array([total[0], 0.0, total[1]]),
+        f0_depth_force_n=np.asarray(f0_result.depth_force_n, dtype=np.float64),
+        f0_inertial_force_n=np.asarray(f0_result.inertial_force_n, dtype=np.float64),
+        f1_stress_force_n=np.array(
+            [stress_part[0] * width, 0.0, stress_part[1] * width]
+        ),
+        f1_flux_force_n=np.array([flux_part[0] * width, 0.0, flux_part[1] * width]),
+        f0_max_depth_m=f0_result.max_depth_m,
+        f1_max_depth_m=max(float(depths.max()) if depths.size else 0.0, 0.0),
+        f1_divot_depth_m=run.divot_depth_m(),
+        effective_width_m=width,
+    )
+
+
+def _unused(run: MPMRun) -> None:  # pragma: no cover - typing anchor
+    """Keep :class:`MPMRun` imported for annotations under ``from __future__``."""
+    del run

--- a/tests/bunkershot3d/solvers/mpm/__init__.py
+++ b/tests/bunkershot3d/solvers/mpm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the F1 plane-strain MPM solver (ADR-0033)."""

--- a/tests/bunkershot3d/solvers/mpm/test_body.py
+++ b/tests/bunkershot3d/solvers/mpm/test_body.py
@@ -1,0 +1,317 @@
+"""The rigid intruder: its distance field, its motion and its contact.
+
+The two things that must not be got wrong here are the **sign of the
+torque** -- plane strain leaves exactly one component alive and it is
+easy to invert -- and **tunnelling**, which at 25 m/s is the difference
+between a solver and a random number generator.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from bunkershot3d.solvers.exceptions import SolverInputError
+from bunkershot3d.solvers.mpm.body import (
+    RigidSection,
+    convex_hull_2d,
+    plane_torque_about_y,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def unit_square(**kwargs: object) -> RigidSection:
+    """A 1 m square centred on the origin, counter-clockwise."""
+    vertices = np.array([[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]])
+    return RigidSection(vertices, **kwargs)  # type: ignore[arg-type]
+
+
+class TestConvexHull:
+    """Monotone chain, implemented rather than imported."""
+
+    def test_recovers_a_square_from_a_cloud(self) -> None:
+        rng = np.random.default_rng(31)
+        interior = rng.uniform(-0.4, 0.4, size=(200, 2))
+        corners = np.array([[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]])
+        hull = convex_hull_2d(np.vstack([interior, corners]))
+        assert hull.shape == (4, 2)
+        np.testing.assert_allclose(np.sort(hull, axis=0), np.sort(corners, axis=0))
+
+    def test_winding_is_counter_clockwise(self) -> None:
+        hull = convex_hull_2d(np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]))
+        following = np.roll(hull, -1, axis=0)
+        area = 0.5 * float(
+            (hull[:, 0] * following[:, 1] - following[:, 0] * hull[:, 1]).sum()
+        )
+        assert area > 0.0
+
+    def test_collinear_points_are_refused(self) -> None:
+        line = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+        with pytest.raises(SolverInputError, match="collinear"):
+            convex_hull_2d(line)
+
+    def test_too_few_points_are_refused(self) -> None:
+        with pytest.raises(SolverInputError, match="at least 3 distinct"):
+            convex_hull_2d(np.array([[0.0, 0.0], [1.0, 0.0]]))
+
+
+class TestSignedDistance:
+    """Negative inside, and the normal is the real gradient direction."""
+
+    def test_centre_is_deepest(self) -> None:
+        distance, _ = unit_square().signed_distance(np.array([[0.0, 0.0]]))
+        assert distance[0] == pytest.approx(-0.5)
+
+    def test_face_distance_is_exact(self) -> None:
+        section = unit_square()
+        distance, normal = section.signed_distance(np.array([[0.0, 1.25]]))
+        assert distance[0] == pytest.approx(0.75)
+        np.testing.assert_allclose(normal[0], [0.0, 1.0], atol=1e-14)
+
+    def test_corner_distance_is_the_true_distance(self) -> None:
+        """A max-of-half-planes surrogate would report 0.5 here, not 0.707."""
+        section = unit_square()
+        distance, normal = section.signed_distance(np.array([[1.0, 1.0]]))
+        assert distance[0] == pytest.approx(math.sqrt(0.5), rel=1e-12)
+        np.testing.assert_allclose(
+            normal[0], [math.sqrt(0.5), math.sqrt(0.5)], atol=1e-12
+        )
+
+    def test_normal_is_outward_everywhere_outside(self) -> None:
+        rng = np.random.default_rng(37)
+        section = unit_square()
+        points = rng.uniform(-2.0, 2.0, size=(500, 2))
+        distance, normal = section.signed_distance(points)
+        outside = distance > 1e-9
+        stepped = points[outside] + 1e-6 * normal[outside]
+        stepped_distance, _ = section.signed_distance(stepped)
+        assert np.all(stepped_distance > distance[outside])
+
+    def test_contains_agrees_with_the_sign(self) -> None:
+        rng = np.random.default_rng(41)
+        section = unit_square()
+        points = rng.uniform(-1.0, 1.0, size=(300, 2))
+        distance, _ = section.signed_distance(points)
+        np.testing.assert_array_equal(section.contains(points), distance < 0.0)
+
+    def test_clockwise_input_is_rewound(self) -> None:
+        clockwise = np.array([[-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]])
+        section = RigidSection(clockwise)
+        assert section.area_m2 == pytest.approx(1.0)
+        distance, _ = section.signed_distance(np.array([[0.0, 0.0]]))
+        assert distance[0] < 0.0
+
+
+class TestMotion:
+    """Rigid motion, and the sign of everything that rotates."""
+
+    def test_translation_advances_by_velocity(self) -> None:
+        section = unit_square(velocity_m_s=(2.0, -1.0))
+        moved = section.advanced(0.5)
+        np.testing.assert_allclose(
+            moved.vertices_m, section.vertices_m + np.array([1.0, -0.5])
+        )
+
+    def test_rotation_matches_the_velocity_field(self) -> None:
+        """The advanced pose and ``velocity_at`` must be the same rotation."""
+        spin = 12.0
+        section = unit_square(angular_velocity_rad_s=spin, reference_point_m=(0.0, 0.0))
+        step = 1e-7
+        moved = section.advanced(step)
+        numeric = (moved.vertices_m - section.vertices_m) / step
+        analytic = section.velocity_at(section.vertices_m)
+        np.testing.assert_allclose(numeric, analytic, rtol=1e-6, atol=1e-6)
+
+    def test_velocity_from_spin_is_the_y_axis_convention(self) -> None:
+        section = unit_square(angular_velocity_rad_s=1.0, reference_point_m=(0.0, 0.0))
+        velocity = section.velocity_at(np.array([[1.0, 0.0]]))
+        # omega y_hat x (1, 0, 0) = (0, 0, -1): straight down in z.
+        np.testing.assert_allclose(velocity[0], [0.0, -1.0], atol=1e-14)
+
+    def test_max_speed_includes_the_spin(self) -> None:
+        section = unit_square(
+            velocity_m_s=(1.0, 0.0),
+            angular_velocity_rad_s=100.0,
+            reference_point_m=(0.0, 0.0),
+        )
+        assert section.max_speed_m_s > section.speed_m_s
+
+
+class TestTorqueSign:
+    """One component survives plane strain and its sign is load-bearing."""
+
+    def test_matches_the_three_dimensional_cross_product(self) -> None:
+        lever = np.array([[0.03, -0.01], [0.0, 0.05]])
+        force = np.array([[10.0, 4.0], [-2.0, 7.0]])
+        lever_3d = np.stack([lever[:, 0], np.zeros(2), lever[:, 1]], axis=1)
+        force_3d = np.stack([force[:, 0], np.zeros(2), force[:, 1]], axis=1)
+        expected = float(np.cross(lever_3d, force_3d)[:, 1].sum())
+        assert plane_torque_about_y(lever, force) == pytest.approx(expected, rel=1e-14)
+
+
+class TestContactProjection:
+    """The momentum ledger is the whole of F1's contact wrench."""
+
+    def _nodes(self) -> tuple[np.ndarray, np.ndarray]:
+        """One node just inside the top face, one well clear of the body."""
+        positions = np.array([[0.0, 0.45], [0.0, 2.0]])
+        mass = np.array([1.0, 1.0])
+        return positions, mass
+
+    def test_a_separating_node_is_left_alone(self) -> None:
+        """Sand may leave the club freely: this is what opens the divot."""
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=0.0)
+        positions, mass = self._nodes()
+        velocity = np.array([[0.0, 5.0], [0.0, 0.0]])
+        updated, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        np.testing.assert_allclose(updated[0], velocity[0])
+        np.testing.assert_allclose(impulse.impulse_n_s[0], [0.0, 0.0], atol=1e-15)
+
+    def test_an_approaching_node_loses_its_normal_velocity(self) -> None:
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=0.0)
+        positions, mass = self._nodes()
+        velocity = np.array([[0.0, -5.0], [0.0, 0.0]])
+        updated, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        assert float(updated[0, 1]) == pytest.approx(0.0, abs=1e-14)
+        np.testing.assert_allclose(impulse.impulse_n_s[0], [0.0, 5.0], atol=1e-13)
+
+    def test_sticking_removes_the_whole_relative_velocity(self) -> None:
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=10.0)
+        positions = np.array([[0.0, 0.45]])
+        mass = np.array([2.0])
+        velocity = np.array([[3.0, -1.0]])
+        updated, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        np.testing.assert_allclose(updated[0], [0.0, 0.0], atol=1e-14)
+        np.testing.assert_allclose(impulse.impulse_n_s[0], [-6.0, 2.0], atol=1e-13)
+
+    def test_a_frictionless_slide_keeps_the_tangential_velocity(self) -> None:
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=0.0)
+        positions = np.array([[0.0, 0.45]])
+        mass = np.array([2.0])
+        velocity = np.array([[3.0, -1.0]])
+        updated, _ = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        np.testing.assert_allclose(updated[0], [3.0, 0.0], atol=1e-14)
+
+    def test_the_ledger_reports_the_reaction_on_the_body(self) -> None:
+        """Newton's third law, arithmetically."""
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=10.0)
+        positions = np.array([[0.0, 0.45]])
+        mass = np.array([2.0])
+        velocity = np.array([[0.0, -4.0]])
+        step = 2e-4
+        _, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=step
+        )
+        force = impulse.force_on_body_n(step)
+        # The sand carried -8 kg m/s downward and was stopped, so the club
+        # took 8 kg m/s downward over the step.
+        np.testing.assert_allclose(force, [0.0, -8.0 / step], rtol=1e-13)
+
+    def test_a_moving_body_is_matched_not_stopped(self) -> None:
+        """Sand under a descending sole is carried down with it."""
+        section = unit_square(velocity_m_s=(0.0, -6.0), friction=10.0)
+        positions = np.array([[0.0, -0.45]])
+        mass = np.array([1.0])
+        velocity = np.array([[0.0, 0.0]])
+        updated, _ = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        np.testing.assert_allclose(updated[0], [0.0, -6.0], atol=1e-14)
+
+    def test_partial_friction_reduces_but_does_not_stop_the_slide(self) -> None:
+        """The Coulomb cone bounds the tangential velocity; it never sets it."""
+        section = unit_square(velocity_m_s=(0.0, 0.0), friction=0.25)
+        positions = np.array([[0.0, 0.45]])
+        mass = np.array([1.0])
+        velocity = np.array([[4.0, -2.0]])
+        updated, _ = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        # |v_t| = 4, mu |v_n| = 0.5, so 3.5 survives.
+        np.testing.assert_allclose(updated[0], [3.5, 0.0], atol=1e-13)
+
+    def test_massless_nodes_are_skipped(self) -> None:
+        section = unit_square(friction=1.0)
+        positions = np.array([[0.0, 0.0]])
+        mass = np.array([0.0])
+        velocity = np.array([[0.0, -5.0]])
+        _, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1e-4
+        )
+        assert impulse.n_contacts == 0
+        np.testing.assert_allclose(impulse.force_on_body_n(1e-4), [0.0, 0.0])
+
+    def test_a_non_positive_step_is_refused(self) -> None:
+        section = unit_square()
+        with pytest.raises(SolverInputError, match="time_step_s"):
+            section.project_grid_velocity(
+                np.zeros((1, 2)), np.zeros((1, 2)), np.ones(1), time_step_s=0.0
+            )
+
+
+class TestSweptContact:
+    """A node the club is about to reach is stopped before it arrives."""
+
+    def test_a_node_ahead_of_the_body_is_collided(self) -> None:
+        section = unit_square(velocity_m_s=(20.0, 0.0), friction=0.0)
+        # 1 mm ahead of the leading face, which travels 2 mm this step.
+        positions = np.array([[0.501, 0.0]])
+        mass = np.array([1.0])
+        velocity = np.array([[0.0, 0.0]])
+        updated, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1.0e-4
+        )
+        assert impulse.n_contacts == 1
+        assert impulse.n_swept == 1
+        assert float(updated[0, 0]) == pytest.approx(20.0)
+
+    def test_a_node_the_body_will_not_reach_is_untouched(self) -> None:
+        section = unit_square(velocity_m_s=(20.0, 0.0), friction=0.0)
+        positions = np.array([[0.60, 0.0]])
+        mass = np.array([1.0])
+        velocity = np.zeros((1, 2))
+        _, impulse = section.project_grid_velocity(
+            positions, velocity, mass, time_step_s=1.0e-4
+        )
+        assert impulse.n_contacts == 0
+
+
+class TestPushOut:
+    """The backstop, and the reason it is reported rather than hidden."""
+
+    def test_an_embedded_particle_is_placed_on_the_surface(self) -> None:
+        section = unit_square()
+        positions = np.array([[0.0, 0.2], [2.0, 2.0]])
+        velocity = np.array([[0.0, -1.0], [0.0, 0.0]])
+        moved, updated, count = section.push_out(positions, velocity)
+        assert count == 1
+        distance, _ = section.signed_distance(moved)
+        assert float(distance[0]) == pytest.approx(0.0, abs=1e-14)
+        np.testing.assert_allclose(moved[1], positions[1])
+
+    def test_inward_velocity_is_removed_and_sliding_is_not(self) -> None:
+        section = unit_square()
+        positions = np.array([[0.0, 0.45]])
+        velocity = np.array([[3.0, -2.0]])
+        _, updated, _ = section.push_out(positions, velocity)
+        np.testing.assert_allclose(updated[0], [3.0, 0.0], atol=1e-14)
+
+    def test_nothing_inside_means_nothing_moves(self) -> None:
+        section = unit_square()
+        positions = np.array([[2.0, 2.0]])
+        velocity = np.array([[1.0, 1.0]])
+        moved, updated, count = section.push_out(positions, velocity)
+        assert count == 0
+        assert moved is positions
+        assert updated is velocity

--- a/tests/bunkershot3d/solvers/mpm/test_constitutive.py
+++ b/tests/bunkershot3d/solvers/mpm/test_constitutive.py
@@ -180,19 +180,61 @@ class TestHenckyStress:
 
 
 class TestSvdRoundTrip:
-    """The decomposition the return mapping runs inside."""
+    """The closed-form 2x2 decomposition the return mapping runs inside.
+
+    Only three properties are relied on downstream, so those are what get
+    tested -- not whether the factors happen to agree with LAPACK's, which
+    they need not and do not.
+    """
+
+    @staticmethod
+    def _sample(seed: int, scale: float = 0.05) -> np.ndarray:
+        rng = np.random.default_rng(seed)
+        return np.eye(2) + rng.normal(scale=scale, size=(512, 2, 2))
 
     def test_reconstruction_is_exact(self) -> None:
-        rng = np.random.default_rng(11)
-        gradient = np.eye(2) + rng.normal(scale=0.05, size=(64, 2, 2))
+        gradient = self._sample(11)
         left, stretches, right_transposed = principal_stretches(gradient)
         rebuilt = reconstruct(left, np.log(stretches), right_transposed)
         np.testing.assert_allclose(rebuilt, gradient, rtol=0.0, atol=1e-13)
+
+    def test_reconstruction_survives_an_inverted_particle(self) -> None:
+        """det(F) < 0 puts the second singular value below zero if unhandled."""
+        gradient = self._sample(13, scale=1.5)
+        assert float(np.linalg.det(gradient).min()) < 0.0
+        left, stretches, right_transposed = principal_stretches(gradient)
+        assert float(stretches.min()) >= 0.0
+        rebuilt = reconstruct(left, np.log(stretches), right_transposed)
+        np.testing.assert_allclose(rebuilt, gradient, rtol=0.0, atol=1e-12)
+
+    def test_singular_values_match_lapack(self) -> None:
+        gradient = self._sample(17, scale=0.8)
+        _, stretches, _ = principal_stretches(gradient)
+        expected = np.linalg.svd(gradient, compute_uv=False)
+        np.testing.assert_allclose(stretches, expected, rtol=1e-12, atol=1e-14)
+
+    def test_left_factor_is_orthogonal(self) -> None:
+        """The Kirchhoff stress is coaxial with it, so it must be a rotation."""
+        gradient = self._sample(19, scale=0.6)
+        left, _, right_transposed = principal_stretches(gradient)
+        identity = np.broadcast_to(np.eye(2), left.shape)
+        np.testing.assert_allclose(
+            left @ np.transpose(left, (0, 2, 1)), identity, atol=1e-13
+        )
+        np.testing.assert_allclose(
+            right_transposed @ np.transpose(right_transposed, (0, 2, 1)),
+            identity,
+            atol=1e-13,
+        )
 
     def test_a_degenerate_gradient_still_has_a_logarithm(self) -> None:
         gradient = np.zeros((1, 2, 2))
         _, stretches, _ = principal_stretches(gradient)
         assert np.all(np.isfinite(np.log(stretches)))
+
+    def test_a_malformed_gradient_is_refused(self) -> None:
+        with pytest.raises(CalibrationError, match=r"shape \(n, 2, 2\)"):
+            principal_stretches(np.zeros((4, 3, 3)))
 
 
 class TestSandContinuum:

--- a/tests/bunkershot3d/solvers/mpm/test_constitutive.py
+++ b/tests/bunkershot3d/solvers/mpm/test_constitutive.py
@@ -1,0 +1,305 @@
+"""The F1 constitutive model: capped Drucker-Prager on Hencky strains.
+
+The sharpest available check on a return mapping is the yield function
+itself: after projection **every** state must be admissible, and every
+state that was actually projected must sit exactly on the surface.  That
+is an identity of the scheme, so it is tested to round-off rather than to
+a tolerance chosen to make it pass.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from bunkershot3d.sand import Angularity, playing_condition, usga_reference_sand
+from bunkershot3d.sand.exceptions import MoistureRegimeError
+from bunkershot3d.sand.presets import PlayingCondition
+from bunkershot3d.solvers.exceptions import CalibrationError
+from bunkershot3d.solvers.mpm.constitutive import (
+    PLANE_STRAIN_DIMENSION,
+    SandContinuum,
+    drucker_prager_alpha,
+    hencky_kirchhoff_principal,
+    principal_stretches,
+    project_to_yield_surface,
+    reconstruct,
+    yield_function,
+)
+
+pytestmark = pytest.mark.unit
+
+_MU_PA = 9.0e6
+_LAMBDA_PA = 13.5e6
+_ALPHA = 0.374
+_CAP = -0.02
+
+
+def _project(strain: np.ndarray, *, tip: float = 0.0, cap: float = _CAP):
+    return project_to_yield_surface(
+        strain,
+        shear_modulus_pa=_MU_PA,
+        lame_lambda_pa=_LAMBDA_PA,
+        alpha=_ALPHA,
+        tip_volumetric_strain=tip,
+        cap_volumetric_strain=cap,
+    )
+
+
+def _yield(strain: np.ndarray, *, tip: float = 0.0) -> np.ndarray:
+    return yield_function(
+        strain,
+        shear_modulus_pa=_MU_PA,
+        lame_lambda_pa=_LAMBDA_PA,
+        alpha=_ALPHA,
+        tip_volumetric_strain=tip,
+    )
+
+
+class TestConeSlope:
+    """``alpha`` is the inner-cone Mohr-Coulomb match."""
+
+    def test_reproduces_klar_formula(self) -> None:
+        sin_phi = math.sin(math.radians(34.0))
+        expected = math.sqrt(2.0 / 3.0) * 2.0 * sin_phi / (3.0 - sin_phi)
+        assert drucker_prager_alpha(34.0) == pytest.approx(expected, rel=1e-14)
+
+    def test_grows_with_friction_angle(self) -> None:
+        assert drucker_prager_alpha(25.0) < drucker_prager_alpha(40.0)
+
+    @pytest.mark.parametrize("angle", [0.0, 90.0, -5.0, float("nan")])
+    def test_refuses_an_unusable_angle(self, angle: float) -> None:
+        with pytest.raises(CalibrationError):
+            drucker_prager_alpha(angle)
+
+
+class TestReturnMapping:
+    """The projected state is admissible, and the projection is exact."""
+
+    def test_admissible_states_are_untouched(self) -> None:
+        # Isotropic compression well inside the cone and inside the cap.
+        strain = np.array([[-0.001, -0.001], [-0.002, -0.0019]])
+        projected, yielded, capped = _project(strain)
+        assert not yielded.any()
+        assert not capped.any()
+        np.testing.assert_array_equal(projected, strain)
+
+    def test_every_projected_state_is_admissible(self) -> None:
+        rng = np.random.default_rng(20260816)
+        strain = rng.normal(scale=0.05, size=(4000, PLANE_STRAIN_DIMENSION))
+        projected, _, _ = _project(strain)
+        # Scale the round-off budget by the stress scale the yield function
+        # is measured in, since y has units of pascals.
+        stress_scale = (2.0 * _MU_PA + PLANE_STRAIN_DIMENSION * _LAMBDA_PA) * float(
+            np.abs(strain).max()
+        )
+        assert float(_yield(projected).max()) <= 1e-9 * stress_scale
+
+    def test_yielded_states_land_exactly_on_the_surface(self) -> None:
+        rng = np.random.default_rng(7)
+        # Pure shear well outside the cone: guaranteed case-III projections.
+        deviator = rng.normal(scale=0.05, size=(500,))
+        strain = np.stack([deviator - 0.002, -deviator - 0.002], axis=1)
+        projected, yielded, _ = _project(strain)
+        assert yielded.any()
+        cone = yielded & (projected.sum(axis=1) < 0.0)
+        residual = np.abs(_yield(projected)[cone])
+        stress_scale = 2.0 * _MU_PA * float(np.abs(deviator).max())
+        assert float(residual.max()) <= 1e-12 * stress_scale
+
+    def test_cone_projection_preserves_volume(self) -> None:
+        """Non-associated flow: case III changes the deviator only."""
+        strain = np.array([[0.03, -0.034], [0.05, -0.06]])
+        projected, yielded, capped = _project(strain)
+        assert yielded.all()
+        assert not capped.any()
+        np.testing.assert_allclose(
+            projected.sum(axis=1), strain.sum(axis=1), rtol=0.0, atol=1e-15
+        )
+
+    def test_tension_is_released_to_the_tip(self) -> None:
+        """Sand cannot be stretched: a tensile trial state goes to the tip."""
+        strain = np.array([[0.02, 0.01]])
+        projected, yielded, _ = _project(strain)
+        assert yielded.all()
+        np.testing.assert_allclose(projected, np.zeros_like(strain), atol=1e-16)
+
+    def test_cohesive_tip_carries_isotropic_tension(self) -> None:
+        bulk = 2.0 * _MU_PA + PLANE_STRAIN_DIMENSION * _LAMBDA_PA
+        tensile_pa = 2000.0
+        tip = PLANE_STRAIN_DIMENSION * tensile_pa / bulk
+        strain = np.array([[0.25 * tip, 0.25 * tip]])
+        projected, yielded, _ = _project(strain, tip=tip)
+        # Half-way to the tip is admissible for a cohesive sand and is not
+        # for a cohesionless one.
+        assert not yielded.any()
+        assert _project(strain, tip=0.0)[1].all()
+        np.testing.assert_allclose(projected, strain)
+
+    def test_compressive_cap_clamps_only_the_volumetric_part(self) -> None:
+        strain = np.array([[-0.05, -0.05]])  # tr = -0.10, cap = -0.02
+        projected, _, capped = _project(strain)
+        assert capped.all()
+        assert projected.sum(axis=1) == pytest.approx(_CAP, rel=1e-14)
+
+    def test_cap_leaves_the_deviator_alone(self) -> None:
+        strain = np.array([[-0.05 + 0.001, -0.05 - 0.001]])
+        projected, _, capped = _project(strain)
+        assert capped.all()
+        trial_dev = strain - strain.mean(axis=1, keepdims=True)
+        projected_dev = projected - projected.mean(axis=1, keepdims=True)
+        np.testing.assert_allclose(projected_dev, trial_dev, atol=1e-16)
+
+    def test_a_non_compressive_cap_is_refused(self) -> None:
+        with pytest.raises(CalibrationError, match="must be negative"):
+            _project(np.zeros((1, 2)), cap=0.0)
+
+    def test_a_malformed_strain_array_is_refused(self) -> None:
+        with pytest.raises(CalibrationError, match=r"shape \(n, d\)"):
+            _project(np.zeros(4))
+
+
+class TestHenckyStress:
+    """The elastic law and its Cauchy conversion."""
+
+    def test_zero_strain_is_stress_free(self) -> None:
+        stress = hencky_kirchhoff_principal(
+            np.zeros((3, 2)), shear_modulus_pa=_MU_PA, lame_lambda_pa=_LAMBDA_PA
+        )
+        np.testing.assert_array_equal(stress, np.zeros((3, 2)))
+
+    def test_uniaxial_strain_gives_the_constrained_modulus(self) -> None:
+        strain = np.array([[0.0, -1e-4]])
+        stress = hencky_kirchhoff_principal(
+            strain, shear_modulus_pa=_MU_PA, lame_lambda_pa=_LAMBDA_PA
+        )
+        assert stress[0, 1] == pytest.approx(-1e-4 * (_LAMBDA_PA + 2.0 * _MU_PA))
+        assert stress[0, 0] == pytest.approx(-1e-4 * _LAMBDA_PA)
+
+
+class TestSvdRoundTrip:
+    """The decomposition the return mapping runs inside."""
+
+    def test_reconstruction_is_exact(self) -> None:
+        rng = np.random.default_rng(11)
+        gradient = np.eye(2) + rng.normal(scale=0.05, size=(64, 2, 2))
+        left, stretches, right_transposed = principal_stretches(gradient)
+        rebuilt = reconstruct(left, np.log(stretches), right_transposed)
+        np.testing.assert_allclose(rebuilt, gradient, rtol=0.0, atol=1e-13)
+
+    def test_a_degenerate_gradient_still_has_a_logarithm(self) -> None:
+        gradient = np.zeros((1, 2, 2))
+        _, stretches, _ = principal_stretches(gradient)
+        assert np.all(np.isfinite(np.log(stretches)))
+
+
+class TestSandContinuum:
+    """Material constants come from the sand package, never from a second set."""
+
+    def test_derives_from_a_preset(self) -> None:
+        sand = playing_condition(PlayingCondition.FIRM)
+        material = SandContinuum.from_sand_state(sand)
+        assert material.density_kg_m3 == pytest.approx(sand.bulk_density_kg_m3)
+        assert material.grain_diameter_m == pytest.approx(sand.d50_m)
+        assert material.friction_angle_deg == pytest.approx(sand.friction_angle_deg)
+        assert material.alpha == pytest.approx(
+            drucker_prager_alpha(sand.friction_angle_deg)
+        )
+
+    def test_wave_speed_is_computed_not_pinned(self) -> None:
+        sand = playing_condition(PlayingCondition.FIRM)
+        soft = SandContinuum.from_sand_state(sand, shear_modulus_pa=1.0e6)
+        stiff = SandContinuum.from_sand_state(sand, shear_modulus_pa=4.0e6)
+        assert stiff.elastic_wave_speed_m_s == pytest.approx(
+            2.0 * soft.elastic_wave_speed_m_s, rel=1e-12
+        )
+        assert soft.elastic_wave_speed_m_s == pytest.approx(
+            math.sqrt(soft.p_wave_modulus_pa / soft.density_kg_m3)
+        )
+
+    def test_cap_tightens_as_the_bed_gets_denser(self) -> None:
+        """Critical state, arriving from the packing machinery itself."""
+        loose = SandContinuum.from_sand_state(
+            usga_reference_sand("loose", 1.6, 0.05), shear_modulus_pa=9.0e6
+        )
+        dense = SandContinuum.from_sand_state(
+            usga_reference_sand("dense", 2.8, 0.05), shear_modulus_pa=9.0e6
+        )
+        assert loose.cap_volumetric_strain < dense.cap_volumetric_strain < 0.0
+
+    def test_a_damp_sand_carries_a_cohesive_tip(self) -> None:
+        dry = SandContinuum.from_sand_state(
+            usga_reference_sand("dry", 2.0, 0.0005), shear_modulus_pa=9.0e6
+        )
+        damp = SandContinuum.from_sand_state(
+            usga_reference_sand("damp", 2.0, 0.050), shear_modulus_pa=9.0e6
+        )
+        assert damp.tip_volumetric_strain > dry.tip_volumetric_strain >= 0.0
+        assert damp.tensile_strength_pa == pytest.approx(
+            damp.cohesion_pa / math.tan(math.radians(damp.friction_angle_deg))
+        )
+
+    def test_a_saturated_bed_refuses_to_guess_its_suction(self) -> None:
+        """The sand model has no default here, and F1 has no better one."""
+        wet = playing_condition(PlayingCondition.WET)
+        with pytest.raises(MoistureRegimeError, match="dilation_suction_pa"):
+            SandContinuum.from_sand_state(wet, shear_modulus_pa=9.0e6)
+        stated = SandContinuum.from_sand_state(
+            wet, shear_modulus_pa=9.0e6, dilation_suction_pa=0.0
+        )
+        assert stated.tip_volumetric_strain >= 0.0
+
+    def test_angularity_selects_the_modulus_branch(self) -> None:
+        angular = SandContinuum.from_sand_state(
+            usga_reference_sand("a", 2.0, 0.05, angularity=Angularity.ANGULAR)
+        )
+        rounded = SandContinuum.from_sand_state(
+            usga_reference_sand("r", 2.0, 0.05, angularity=Angularity.ROUNDED)
+        )
+        assert angular.shear_modulus_pa != pytest.approx(rounded.shear_modulus_pa)
+
+    def test_provenance_records_every_f1_specific_constant(self) -> None:
+        material = SandContinuum.from_sand_state(
+            playing_condition(PlayingCondition.FIRM)
+        )
+        for key in (
+            "elastic_shear_modulus_pa",
+            "poisson_ratio",
+            "yield_surface",
+            "compressive_cap",
+        ):
+            assert key in material.provenance.entries
+        # The sand's own provenance survives the derivation.
+        assert "friction_angle_deg" in material.provenance.entries
+
+    def test_nothing_is_measured_on_bunker_sand(self) -> None:
+        material = SandContinuum.from_sand_state(
+            playing_condition(PlayingCondition.FIRM)
+        )
+        assert material.provenance.measured_properties() == ()
+
+    def test_refuses_a_non_sand_state(self) -> None:
+        with pytest.raises(CalibrationError, match="expected a SandState"):
+            SandContinuum.from_sand_state(object())  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("nu", [0.5, 0.6, -1.0])
+    def test_refuses_an_unusable_poisson_ratio(self, nu: float) -> None:
+        with pytest.raises(CalibrationError, match="poisson_ratio"):
+            SandContinuum.from_sand_state(
+                playing_condition(PlayingCondition.FIRM), poisson_ratio=nu
+            )
+
+    def test_cauchy_divides_by_the_jacobian(self) -> None:
+        material = SandContinuum.from_sand_state(
+            playing_condition(PlayingCondition.FIRM), shear_modulus_pa=9.0e6
+        )
+        strain = np.array([[-0.01, -0.005]])
+        kirchhoff = hencky_kirchhoff_principal(
+            strain,
+            shear_modulus_pa=material.shear_modulus_pa,
+            lame_lambda_pa=material.lame_lambda_pa,
+        )
+        cauchy = material.cauchy_from_hencky(strain)
+        np.testing.assert_allclose(cauchy * math.exp(-0.015), kirchhoff, rtol=1e-13)

--- a/tests/bunkershot3d/solvers/mpm/test_grid.py
+++ b/tests/bunkershot3d/solvers/mpm/test_grid.py
@@ -276,9 +276,13 @@ class TestApicRoundTrip:
 class TestCrossProduct:
     """Plane strain leaves one component of a cross product alive."""
 
-    def test_matches_numpy(self) -> None:
+    def test_matches_the_embedded_three_dimensional_cross(self) -> None:
+        """NumPy 2 deprecated the 2-D cross, so the check embeds in 3-D."""
         rng = np.random.default_rng(29)
         left = rng.normal(size=(50, 2))
         right = rng.normal(size=(50, 2))
-        expected = np.cross(left, right)
+        zeros = np.zeros(50)
+        left_3d = np.stack([left[:, 0], left[:, 1], zeros], axis=1)
+        right_3d = np.stack([right[:, 0], right[:, 1], zeros], axis=1)
+        expected = np.cross(left_3d, right_3d)[:, 2]
         np.testing.assert_allclose(cross_2d(left, right), expected, atol=1e-15)

--- a/tests/bunkershot3d/solvers/mpm/test_grid.py
+++ b/tests/bunkershot3d/solvers/mpm/test_grid.py
@@ -1,0 +1,284 @@
+"""The F1 grid, its B-spline basis and the APIC transfers.
+
+Everything here is an **identity of the scheme**, not an approximation,
+so every tolerance is a round-off tolerance and none of them was widened
+to make a test pass.  Three identities carry the conservation guarantees
+the solver later relies on:
+
+* ``sum_i w_ip = 1``          -> P2G conserves mass exactly
+* ``sum_i grad w_ip = 0``     -> internal forces sum to zero exactly
+* the APIC round trip         -> linear *and* angular momentum survive
+
+The last one is the load-bearing justification for choosing APIC over PIC
+or FLIP, so it is tested directly rather than cited.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bunkershot3d.solvers.exceptions import SolverInputError
+from bunkershot3d.solvers.mpm.grid import (
+    NODES_PER_PARTICLE,
+    PlaneStrainGrid,
+    affine_from_grid_velocity,
+    apic_angular_momentum,
+    cross_2d,
+    gather_velocity,
+    scatter_mass,
+    scatter_momentum,
+    scatter_stress_force,
+    velocity_gradient,
+)
+
+pytestmark = pytest.mark.unit
+
+_ROUND_OFF = 1e-12
+
+
+@pytest.fixture
+def grid() -> PlaneStrainGrid:
+    return PlaneStrainGrid(
+        origin_m=(-0.02, -0.03), cell_size_m=0.002, node_counts=(24, 30)
+    )
+
+
+@pytest.fixture
+def particles(grid: PlaneStrainGrid) -> np.ndarray:
+    rng = np.random.default_rng(20260816)
+    lower = grid.origin_m + 2.0 * grid.cell_size_m
+    upper = grid.origin_m + grid.extent_m - 2.0 * grid.cell_size_m
+    return lower + rng.random((300, 2)) * (upper - lower)
+
+
+class TestGridConstruction:
+    """A grid that cannot carry a stencil is refused, not silently used."""
+
+    def test_node_positions_are_uniform(self, grid: PlaneStrainGrid) -> None:
+        positions = grid.node_positions_m()
+        assert positions.shape == (grid.n_nodes, 2)
+        np.testing.assert_allclose(positions[0], grid.origin_m)
+        np.testing.assert_allclose(
+            positions[-1], grid.origin_m + grid.extent_m, atol=1e-15
+        )
+
+    def test_refuses_a_grid_too_small_for_a_stencil(self) -> None:
+        with pytest.raises(SolverInputError, match="at least 3 nodes"):
+            PlaneStrainGrid((0.0, 0.0), 0.01, (2, 8))
+
+    @pytest.mark.parametrize("size", [0.0, -0.01, float("inf")])
+    def test_refuses_an_unusable_cell_size(self, size: float) -> None:
+        with pytest.raises(SolverInputError, match="cell_size_m"):
+            PlaneStrainGrid((0.0, 0.0), size, (8, 8))
+
+    def test_covering_leaves_a_stencil_margin(self) -> None:
+        covering = PlaneStrainGrid.covering((0.0, 0.0), (0.05, 0.03), 0.005)
+        assert np.all(covering.origin_m <= -0.005)
+        upper = covering.origin_m + covering.extent_m
+        assert upper[0] >= 0.05 and upper[1] >= 0.03
+
+    def test_covering_refuses_too_thin_a_margin(self) -> None:
+        with pytest.raises(SolverInputError, match="pad_cells"):
+            PlaneStrainGrid.covering((0.0, 0.0), (0.05, 0.03), 0.005, pad_cells=1)
+
+
+class TestBasisIdentities:
+    """The two sums the conservation proofs stand on."""
+
+    def test_weights_are_a_partition_of_unity(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        stencil = grid.interpolate(particles)
+        assert stencil.weight.shape == (particles.shape[0], NODES_PER_PARTICLE)
+        np.testing.assert_allclose(
+            stencil.weight.sum(axis=1), 1.0, rtol=0.0, atol=_ROUND_OFF
+        )
+
+    def test_weights_are_non_negative(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        stencil = grid.interpolate(particles)
+        assert float(stencil.weight.min()) >= 0.0
+
+    def test_weight_gradients_sum_to_zero(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        stencil = grid.interpolate(particles)
+        residual = np.abs(stencil.weight_gradient.sum(axis=1)).max()
+        assert residual <= _ROUND_OFF / grid.cell_size_m
+
+    def test_basis_reproduces_a_linear_field(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        """``sum_i w_ip x_i = x_p``: the reason APIC's affine term vanishes."""
+        stencil = grid.interpolate(particles)
+        nodes = grid.node_positions_m()[stencil.node_index]
+        interpolated = np.einsum("na,nak->nk", stencil.weight, nodes)
+        np.testing.assert_allclose(interpolated, particles, rtol=0.0, atol=1e-14)
+
+    def test_gradient_matches_a_finite_difference(self, grid: PlaneStrainGrid) -> None:
+        point = np.array([[0.0031, -0.0042]])
+        step = 1e-7
+        analytic = grid.interpolate(point).weight_gradient[0]
+        for axis in (0, 1):
+            shift = np.zeros((1, 2))
+            shift[0, axis] = step
+            forward = grid.interpolate(point + shift).weight
+            backward = grid.interpolate(point - shift).weight
+            numeric = (forward - backward)[0] / (2.0 * step)
+            np.testing.assert_allclose(
+                analytic[:, axis], numeric, rtol=1e-6, atol=1e-6 / grid.cell_size_m
+            )
+
+    def test_a_particle_off_the_grid_raises(self, grid: PlaneStrainGrid) -> None:
+        outside = grid.origin_m + grid.extent_m + grid.cell_size_m
+        with pytest.raises(SolverInputError, match="left the grid interior"):
+            grid.interpolate(outside[None, :])
+
+    def test_a_non_finite_particle_raises(self, grid: PlaneStrainGrid) -> None:
+        with pytest.raises(SolverInputError, match="non-finite"):
+            grid.interpolate(np.array([[np.nan, 0.0]]))
+
+
+class TestTransfers:
+    """P2G and G2P, and what each of them conserves."""
+
+    def test_mass_transfer_is_exact(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        mass = np.full(particles.shape[0], 3.7e-4)
+        stencil = grid.interpolate(particles)
+        nodal = scatter_mass(grid, stencil, mass)
+        assert nodal.shape == (grid.n_nodes,)
+        assert abs(nodal.sum() - mass.sum()) <= _ROUND_OFF * mass.sum()
+
+    def test_linear_momentum_transfer_is_exact(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        rng = np.random.default_rng(3)
+        count = particles.shape[0]
+        mass = rng.uniform(1e-4, 5e-4, size=count)
+        velocity = rng.normal(scale=2.0, size=(count, 2))
+        affine = rng.normal(scale=50.0, size=(count, 2, 2))
+        stencil = grid.interpolate(particles)
+        nodal = scatter_momentum(grid, stencil, mass, velocity, affine)
+        expected = (mass[:, None] * velocity).sum(axis=0)
+        scale = float(np.abs(expected).max())
+        np.testing.assert_allclose(
+            nodal.sum(axis=0), expected, rtol=0.0, atol=_ROUND_OFF * scale
+        )
+
+    def test_internal_forces_sum_to_zero(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        """Any stress field at all: this is a basis identity, not physics."""
+        rng = np.random.default_rng(5)
+        count = particles.shape[0]
+        volume = rng.uniform(1e-7, 2e-7, size=count)
+        stress = rng.normal(scale=1e5, size=(count, 2, 2))
+        stress = 0.5 * (stress + np.transpose(stress, (0, 2, 1)))
+        stencil = grid.interpolate(particles)
+        force = scatter_stress_force(grid, stencil, volume, stress)
+        scale = float(np.abs(force).max())
+        np.testing.assert_allclose(force.sum(axis=0), 0.0, rtol=0.0, atol=1e-10 * scale)
+
+    def test_gather_reproduces_a_uniform_velocity(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        node_velocity = np.tile(np.array([1.5, -0.25]), (grid.n_nodes, 1))
+        stencil = grid.interpolate(particles)
+        gathered = gather_velocity(stencil, node_velocity)
+        expected = np.broadcast_to(np.array([1.5, -0.25]), gathered.shape)
+        np.testing.assert_allclose(gathered, expected, rtol=0.0, atol=1e-14)
+
+    def test_velocity_gradient_of_a_uniform_field_is_zero(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        node_velocity = np.tile(np.array([1.5, -0.25]), (grid.n_nodes, 1))
+        stencil = grid.interpolate(particles)
+        gradient = velocity_gradient(stencil, node_velocity)
+        assert float(np.abs(gradient).max()) <= 1e-9
+
+    def test_velocity_gradient_recovers_a_linear_field(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        target = np.array([[2.0, -0.5], [0.75, 1.25]])
+        nodes = grid.node_positions_m()
+        node_velocity = nodes @ target.T
+        stencil = grid.interpolate(particles)
+        gradient = velocity_gradient(stencil, node_velocity)
+        np.testing.assert_allclose(
+            gradient, np.broadcast_to(target, gradient.shape), rtol=1e-9, atol=1e-9
+        )
+
+
+class TestApicRoundTrip:
+    """Why APIC and not PIC or FLIP: both momenta survive the round trip."""
+
+    def _round_trip(self, grid: PlaneStrainGrid, particles: np.ndarray, seed: int):
+        rng = np.random.default_rng(seed)
+        count = particles.shape[0]
+        mass = rng.uniform(1e-4, 5e-4, size=count)
+        velocity = rng.normal(scale=2.0, size=(count, 2))
+        affine = rng.normal(scale=80.0, size=(count, 2, 2))
+        stencil = grid.interpolate(particles)
+        nodal_mass = scatter_mass(grid, stencil, mass)
+        nodal_momentum = scatter_momentum(grid, stencil, mass, velocity, affine)
+        live = nodal_mass > 0.0
+        node_velocity = np.zeros_like(nodal_momentum)
+        node_velocity[live] = nodal_momentum[live] / nodal_mass[live, None]
+        new_velocity = gather_velocity(stencil, node_velocity)
+        new_affine = affine_from_grid_velocity(grid, stencil, node_velocity)
+        return mass, velocity, affine, new_velocity, new_affine
+
+    def test_linear_momentum_survives(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        mass, velocity, _, new_velocity, _ = self._round_trip(grid, particles, 17)
+        before = (mass[:, None] * velocity).sum(axis=0)
+        after = (mass[:, None] * new_velocity).sum(axis=0)
+        scale = float(np.abs(before).max())
+        np.testing.assert_allclose(after, before, rtol=0.0, atol=_ROUND_OFF * scale)
+
+    def test_angular_momentum_survives(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        mass, velocity, affine, new_velocity, new_affine = self._round_trip(
+            grid, particles, 19
+        )
+        before = apic_angular_momentum(grid, particles, velocity, affine, mass)
+        after = apic_angular_momentum(grid, particles, new_velocity, new_affine, mass)
+        scale = abs(before) + float(
+            (mass * np.abs(cross_2d(particles, velocity))).sum()
+        )
+        assert abs(after - before) <= _ROUND_OFF * scale
+
+    def test_pic_would_lose_the_angular_momentum_apic_keeps(
+        self, grid: PlaneStrainGrid, particles: np.ndarray
+    ) -> None:
+        """The scheme choice is falsifiable, not a matter of taste.
+
+        Dropping the affine term is exactly PIC.  If discarding it made no
+        difference, APIC would be pointless machinery and this test would
+        be the one to say so.
+        """
+        mass, velocity, affine, new_velocity, new_affine = self._round_trip(
+            grid, particles, 23
+        )
+        zero_affine = np.zeros_like(new_affine)
+        before = apic_angular_momentum(grid, particles, velocity, affine, mass)
+        apic = apic_angular_momentum(grid, particles, new_velocity, new_affine, mass)
+        pic = apic_angular_momentum(grid, particles, new_velocity, zero_affine, mass)
+        assert abs(apic - before) < abs(pic - before)
+
+
+class TestCrossProduct:
+    """Plane strain leaves one component of a cross product alive."""
+
+    def test_matches_numpy(self) -> None:
+        rng = np.random.default_rng(29)
+        left = rng.normal(size=(50, 2))
+        right = rng.normal(size=(50, 2))
+        expected = np.cross(left, right)
+        np.testing.assert_allclose(cross_2d(left, right), expected, atol=1e-15)

--- a/tests/bunkershot3d/solvers/mpm/test_solver.py
+++ b/tests/bunkershot3d/solvers/mpm/test_solver.py
@@ -1,0 +1,456 @@
+"""The F1 solver as a ``GranularSolver``: contract, CFL, envelope, refusals.
+
+ADR-0032's whole point is that every tier implements one protocol, so the
+first thing tested here is that F0 and F1 are genuinely interchangeable --
+not that they agree, which they do not and need not, but that a caller
+written against the protocol can hold either one.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from bunkershot3d.sand import playing_condition
+from bunkershot3d.sand.presets import PlayingCondition
+from bunkershot3d.solvers import (
+    DRFTSolver,
+    EnvelopeStatus,
+    FidelityTier,
+    GranularSolver,
+    IntrusionState,
+    MaterialResponse,
+    OutOfEnvelopeError,
+    RefusalPolicy,
+    SolverResult,
+    SurfaceElements,
+)
+from bunkershot3d.solvers.envelope import Caveat
+from bunkershot3d.solvers.exceptions import SolverInputError
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.envelope import (
+    RefusedQuantity,
+    evaluate_f1_envelope,
+    require_quotable,
+)
+from bunkershot3d.solvers.mpm.solver import (
+    DEFAULT_CFL_NUMBER,
+    PlaneStrainMPMSolver,
+    cfl_time_step_s,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def material() -> SandContinuum:
+    return SandContinuum.from_sand_state(playing_condition(PlayingCondition.FIRM))
+
+
+def sole_state(
+    speed_m_s: float = 12.0,
+    attack_deg: float = 20.0,
+    free_surface_height_m: float = 0.0,
+) -> IntrusionState:
+    """A 40 x 16 mm sole section entering at a stated attack angle."""
+    corners = np.array(
+        [
+            [-0.020, 0.0, -0.008],
+            [0.020, 0.0, -0.008],
+            [0.020, 0.0, 0.008],
+            [-0.020, 0.0, 0.008],
+            [0.024, 0.0, -0.004],
+        ]
+    )
+    normals = np.tile([0.0, 0.0, -1.0], (corners.shape[0], 1))
+    areas = np.full(corners.shape[0], 4.0e-4)
+    angle = math.radians(attack_deg)
+    return IntrusionState(
+        SurfaceElements(corners, normals, areas),
+        (speed_m_s * math.cos(angle), 0.0, -speed_m_s * math.sin(angle)),
+        free_surface_height_m=free_surface_height_m,
+    )
+
+
+@pytest.fixture(scope="module")
+def solver(material: SandContinuum) -> PlaneStrainMPMSolver:
+    return PlaneStrainMPMSolver(
+        material=material,
+        cell_size_m=0.004,
+        effective_width_m=0.030,
+        bed_depth_m=0.06,
+        refusal_policy=RefusalPolicy.REPORT,
+        max_steps=4000,
+    )
+
+
+class TestProtocolConformance:
+    """F1 is swappable with F0 because they implement the same protocol."""
+
+    def test_it_is_a_granular_solver(self, solver: PlaneStrainMPMSolver) -> None:
+        assert isinstance(solver, GranularSolver)
+
+    def test_its_tier_is_f1(self, solver: PlaneStrainMPMSolver) -> None:
+        assert solver.fidelity_tier is FidelityTier.F1
+
+    def test_a_caller_can_hold_either_tier(
+        self, solver: PlaneStrainMPMSolver, material: SandContinuum
+    ) -> None:
+        sand = playing_condition(PlayingCondition.FIRM)
+        f0 = DRFTSolver(
+            material=MaterialResponse.from_sand_state(sand),
+            refusal_policy=RefusalPolicy.REPORT,
+        )
+        tiers: list[GranularSolver] = [f0, solver]
+        assert {tier.fidelity_tier for tier in tiers} == {
+            FidelityTier.F0,
+            FidelityTier.F1,
+        }
+        for tier in tiers:
+            assert isinstance(tier.envelope(sole_state()).status, EnvelopeStatus)
+
+    @pytest.mark.slow
+    def test_solve_returns_a_verdict_carrying_result(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        result = solver.solve(sole_state())
+        assert isinstance(result, SolverResult)
+        assert result.fidelity_tier is FidelityTier.F1
+        assert result.verdict.status is EnvelopeStatus.BEYOND_VALIDATION
+
+    @pytest.mark.slow
+    def test_the_two_force_parts_add_to_the_resultant(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """The split is an exact partition of the contact impulse."""
+        result = solver.solve(sole_state())
+        np.testing.assert_allclose(
+            result.depth_force_n + result.inertial_force_n,
+            result.wrench.force_n,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+    @pytest.mark.slow
+    def test_the_force_opposes_the_motion(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        state = sole_state()
+        result = solver.solve(state)
+        assert float(result.wrench.force_n @ state.velocity_m_s) < 0.0
+
+    @pytest.mark.slow
+    def test_plane_strain_leaves_no_out_of_plane_force(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        result = solver.solve(sole_state())
+        assert float(result.wrench.force_n[1]) == 0.0
+        assert float(result.wrench.torque_n_m[0]) == 0.0
+        assert float(result.wrench.torque_n_m[2]) == 0.0
+
+
+class TestConstruction:
+    """The one argument that has no default, and why."""
+
+    def test_effective_width_is_required(self, material: SandContinuum) -> None:
+        with pytest.raises(TypeError):
+            PlaneStrainMPMSolver(material=material, cell_size_m=0.004)  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize("width", [0.0, -0.01, float("nan")])
+    def test_an_unusable_width_is_refused(
+        self, material: SandContinuum, width: float
+    ) -> None:
+        with pytest.raises(SolverInputError, match="effective_width_m"):
+            PlaneStrainMPMSolver(
+                material=material, cell_size_m=0.004, effective_width_m=width
+            )
+
+    def test_a_non_continuum_material_is_refused(self) -> None:
+        with pytest.raises(SolverInputError, match="SandContinuum"):
+            PlaneStrainMPMSolver(
+                material=object(),  # type: ignore[arg-type]
+                cell_size_m=0.004,
+                effective_width_m=0.03,
+            )
+
+
+class TestTimeStep:
+    """Computed from the elastic wave speed, and checked with a raise."""
+
+    def test_it_uses_the_material_wave_speed(
+        self, material: SandContinuum, solver: PlaneStrainMPMSolver
+    ) -> None:
+        state = sole_state()
+        expected = (
+            DEFAULT_CFL_NUMBER
+            * solver.cell_size_m
+            / (material.elastic_wave_speed_m_s + state.speed_m_s)
+        )
+        assert solver.time_step_s(state) == pytest.approx(expected, rel=1e-12)
+
+    def test_a_stiffer_sand_shortens_the_step_by_itself(
+        self, material: SandContinuum
+    ) -> None:
+        soft = cfl_time_step_s(
+            cell_size_m=0.004,
+            elastic_wave_speed_m_s=100.0,
+            max_material_speed_m_s=0.0,
+        )
+        stiff = cfl_time_step_s(
+            cell_size_m=0.004,
+            elastic_wave_speed_m_s=400.0,
+            max_material_speed_m_s=0.0,
+        )
+        assert stiff == pytest.approx(soft / 4.0, rel=1e-12)
+
+    def test_the_body_speed_enters_the_condition(self) -> None:
+        """This is what stops the club crossing a cell in one step."""
+        still = cfl_time_step_s(
+            cell_size_m=0.004,
+            elastic_wave_speed_m_s=138.0,
+            max_material_speed_m_s=0.0,
+        )
+        fast = cfl_time_step_s(
+            cell_size_m=0.004,
+            elastic_wave_speed_m_s=138.0,
+            max_material_speed_m_s=25.0,
+        )
+        assert fast < still
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"cell_size_m": 0.0}, "cell_size_m"),
+            ({"elastic_wave_speed_m_s": 0.0}, "wave speed"),
+            ({"max_material_speed_m_s": -1.0}, "max material speed"),
+            ({"cfl_number": 0.0}, "cfl_number"),
+            ({"cfl_number": 1.5}, "cfl_number"),
+        ],
+    )
+    def test_unusable_inputs_raise(self, kwargs: dict, match: str) -> None:
+        base = {
+            "cell_size_m": 0.004,
+            "elastic_wave_speed_m_s": 138.0,
+            "max_material_speed_m_s": 10.0,
+        }
+        with pytest.raises(SolverInputError, match=match):
+            cfl_time_step_s(**{**base, **kwargs})
+
+    def test_a_tunnelling_step_is_refused_at_runtime(
+        self, material: SandContinuum
+    ) -> None:
+        """A raise, not an assert, so ``python -O`` cannot remove it."""
+        from bunkershot3d.solvers.mpm.body import RigidSection
+
+        solver = PlaneStrainMPMSolver(
+            material=material, cell_size_m=0.001, effective_width_m=0.03
+        )
+        section = RigidSection(
+            np.array([[0.0, 0.0], [0.01, 0.0], [0.01, 0.01]]),
+            velocity_m_s=(25.0, 0.0),
+        )
+        with pytest.raises(SolverInputError, match="in one step"):
+            solver._require_courant(section, 1.0e-3)
+
+
+class TestApproachHistory:
+    """A continuum has no instantaneous answer, and says so."""
+
+    def test_a_static_query_is_refused(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        state = IntrusionState(
+            sole_state().elements, (0.0, 0.0, 0.0), free_surface_height_m=0.0
+        )
+        with pytest.raises(SolverInputError, match="no approach direction"):
+            solver.run(state)
+
+    def test_a_bodiless_query_is_refused(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        empty = SurfaceElements(np.zeros((0, 3)), np.zeros((0, 3)), np.zeros(0))
+        state = IntrusionState(empty, (10.0, 0.0, -4.0))
+        with pytest.raises(SolverInputError, match="no surface elements"):
+            solver.envelope(state)
+
+    def test_the_section_is_the_in_plane_hull_of_the_body(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        section = solver.section_from_state(sole_state())
+        assert section.area_m2 > 0.0
+        np.testing.assert_allclose(section.velocity_m_s[0], 12.0 * math.cos(math.radians(20.0)))
+
+
+class TestEnvelope:
+    """F1's own limits, judged in F1's own vocabulary."""
+
+    def test_no_query_beats_beyond_validation(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """Even a slow, well-resolved one: there is nothing to validate against."""
+        slow = solver.envelope(sole_state(speed_m_s=0.5))
+        fast = solver.envelope(sole_state(speed_m_s=25.0))
+        assert slow.status is EnvelopeStatus.BEYOND_VALIDATION
+        assert fast.status is EnvelopeStatus.BEYOND_VALIDATION
+
+    def test_the_structural_caveats_are_on_every_verdict(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        verdict = solver.envelope(sole_state())
+        for caveat in (
+            Caveat.PLANE_STRAIN_NO_OUT_OF_PLANE,
+            Caveat.RATE_INDEPENDENT_PLASTICITY,
+            Caveat.DECLARED_EFFECTIVE_WIDTH,
+            Caveat.NO_MEASURED_COMPARISON,
+        ):
+            assert caveat in verdict.caveats
+        assert verdict.summary()
+
+    def test_no_rft_specific_caveat_leaks_onto_an_f1_verdict(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """Describing a continuum's flaws in RFT's vocabulary hides its own."""
+        verdict = solver.envelope(sole_state())
+        for caveat in (
+            Caveat.SHADOWING,
+            Caveat.SHARP_CORNERS,
+            Caveat.TRANSIENT_RESPONSE,
+            Caveat.ELEMENT_SIZE_EFFECTS,
+        ):
+            assert caveat not in verdict.caveats
+
+    def test_the_under_resolved_edge_is_declared(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        verdict = solver.envelope(sole_state())
+        assert Caveat.UNDER_RESOLVED_LEADING_EDGE in verdict.caveats
+
+    def test_the_declared_width_travels_on_the_verdict(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        verdict = solver.envelope(sole_state())
+        assert verdict.details["effective_width_m"] == pytest.approx(0.030)
+
+    def test_too_fine_a_grid_is_refused(self, material: SandContinuum) -> None:
+        """The mirror image of F0's trap: refining below the grain scale."""
+        verdict = evaluate_f1_envelope(
+            speed_m_s=10.0,
+            feature_lengths_m={"clubhead": 0.1},
+            grain_diameter_m=material.grain_diameter_m,
+            cell_size_m=material.grain_diameter_m,
+            effective_width_m=0.03,
+        )
+        assert verdict.status is EnvelopeStatus.REFUSED
+        assert "grain diameters" in " ".join(verdict.reasons)
+
+    def test_a_feature_of_a_few_grains_is_refused(
+        self, material: SandContinuum
+    ) -> None:
+        verdict = evaluate_f1_envelope(
+            speed_m_s=10.0,
+            feature_lengths_m={"speck": 3.0 * material.grain_diameter_m},
+            grain_diameter_m=material.grain_diameter_m,
+            cell_size_m=0.002,
+            effective_width_m=0.03,
+        )
+        assert verdict.status is EnvelopeStatus.REFUSED
+
+    def test_no_feature_scale_is_refused(self, material: SandContinuum) -> None:
+        with pytest.raises(SolverInputError, match="at least one feature scale"):
+            evaluate_f1_envelope(
+                speed_m_s=10.0,
+                feature_lengths_m={},
+                grain_diameter_m=material.grain_diameter_m,
+                cell_size_m=0.002,
+                effective_width_m=0.03,
+            )
+
+    def test_a_strict_policy_raises_on_a_refusal(
+        self, material: SandContinuum
+    ) -> None:
+        strict = PlaneStrainMPMSolver(
+            material=material,
+            cell_size_m=material.grain_diameter_m,
+            effective_width_m=0.03,
+            refusal_policy=RefusalPolicy.STRICT,
+        )
+        with pytest.raises(OutOfEnvelopeError):
+            strict.solve(sole_state())
+
+
+class TestRefusedQuantities:
+    """ADR-0033's "Refused" means the API raises, not that docs discourage."""
+
+    @pytest.mark.parametrize("quantity", list(RefusedQuantity))
+    def test_every_refused_quantity_raises(
+        self, quantity: RefusedQuantity
+    ) -> None:
+        with pytest.raises(OutOfEnvelopeError, match=quantity.value):
+            require_quotable(quantity)
+
+    def test_club_force_names_f0_as_its_owner(self) -> None:
+        with pytest.raises(OutOfEnvelopeError, match="F0"):
+            require_quotable(RefusedQuantity.CLUB_FORCE)
+
+    def test_out_of_plane_is_refused_rather_than_approximated(self) -> None:
+        with pytest.raises(OutOfEnvelopeError, match="no approximate answer"):
+            require_quotable(RefusedQuantity.OUT_OF_PLANE)
+
+    def test_an_unrecognised_quantity_raises_rather_than_passing(self) -> None:
+        """A silent no-op the first time somebody misspells one is the bug."""
+        with pytest.raises(SolverInputError, match="not a refused F1 quantity"):
+            require_quotable("club force")
+
+
+@pytest.mark.slow
+class TestRunTrace:
+    """What the march exposes for verification and for the later field work."""
+
+    @pytest.fixture(scope="class")
+    def run(self, material: SandContinuum):
+        solver = PlaneStrainMPMSolver(
+            material=material,
+            cell_size_m=0.004,
+            effective_width_m=0.030,
+            bed_depth_m=0.06,
+            refusal_policy=RefusalPolicy.REPORT,
+            max_steps=4000,
+        )
+        return solver.run(sole_state())
+
+    def test_mass_is_invariant_across_the_whole_march(self, run) -> None:
+        masses = {step.total_mass_kg_per_m for step in run.steps}
+        assert len(masses) == 1
+
+    def test_it_digs_a_divot(self, run) -> None:
+        assert run.divot_depth_m() > 0.0
+
+    def test_the_peak_load_has_a_time(self, run) -> None:
+        assert 0.0 < run.peak_force_time_s() <= run.duration_s
+
+    def test_the_backstop_stays_a_backstop(self, run) -> None:
+        """Constant pushouts would mean the swept contact is not working."""
+        assert run.max_pushed_out() < 0.05 * run.particles.n_particles
+
+    def test_an_averaging_window_is_required(self, run) -> None:
+        with pytest.raises(SolverInputError, match="window_s"):
+            run.averaged_force_n_per_m(0.0)
+
+    def test_a_zero_step_march_is_refused(
+        self, material: SandContinuum, run
+    ) -> None:
+        solver = PlaneStrainMPMSolver(
+            material=material, cell_size_m=0.004, effective_width_m=0.03
+        )
+        with pytest.raises(SolverInputError, match="n_steps must be positive"):
+            solver.march(
+                run.particles,
+                None,
+                run.grid,
+                n_steps=0,
+                time_step_s=1e-5,
+                free_surface_height_m=0.0,
+                bed_x_bounds_m=(-0.1, 0.1),
+            )

--- a/tests/bunkershot3d/solvers/mpm/test_solver.py
+++ b/tests/bunkershot3d/solvers/mpm/test_solver.py
@@ -134,9 +134,7 @@ class TestProtocolConformance:
         )
 
     @pytest.mark.slow
-    def test_the_force_opposes_the_motion(
-        self, solver: PlaneStrainMPMSolver
-    ) -> None:
+    def test_the_force_opposes_the_motion(self, solver: PlaneStrainMPMSolver) -> None:
         state = sole_state()
         result = solver.solve(state)
         assert float(result.wrench.force_n @ state.velocity_m_s) < 0.0
@@ -258,18 +256,14 @@ class TestTimeStep:
 class TestApproachHistory:
     """A continuum has no instantaneous answer, and says so."""
 
-    def test_a_static_query_is_refused(
-        self, solver: PlaneStrainMPMSolver
-    ) -> None:
+    def test_a_static_query_is_refused(self, solver: PlaneStrainMPMSolver) -> None:
         state = IntrusionState(
             sole_state().elements, (0.0, 0.0, 0.0), free_surface_height_m=0.0
         )
         with pytest.raises(SolverInputError, match="no approach direction"):
             solver.run(state)
 
-    def test_a_bodiless_query_is_refused(
-        self, solver: PlaneStrainMPMSolver
-    ) -> None:
+    def test_a_bodiless_query_is_refused(self, solver: PlaneStrainMPMSolver) -> None:
         empty = SurfaceElements(np.zeros((0, 3)), np.zeros((0, 3)), np.zeros(0))
         state = IntrusionState(empty, (10.0, 0.0, -4.0))
         with pytest.raises(SolverInputError, match="no surface elements"):
@@ -280,7 +274,9 @@ class TestApproachHistory:
     ) -> None:
         section = solver.section_from_state(sole_state())
         assert section.area_m2 > 0.0
-        np.testing.assert_allclose(section.velocity_m_s[0], 12.0 * math.cos(math.radians(20.0)))
+        np.testing.assert_allclose(
+            section.velocity_m_s[0], 12.0 * math.cos(math.radians(20.0))
+        )
 
 
 class TestEnvelope:
@@ -367,9 +363,7 @@ class TestEnvelope:
                 effective_width_m=0.03,
             )
 
-    def test_a_strict_policy_raises_on_a_refusal(
-        self, material: SandContinuum
-    ) -> None:
+    def test_a_strict_policy_raises_on_a_refusal(self, material: SandContinuum) -> None:
         strict = PlaneStrainMPMSolver(
             material=material,
             cell_size_m=material.grain_diameter_m,
@@ -384,9 +378,7 @@ class TestRefusedQuantities:
     """ADR-0033's "Refused" means the API raises, not that docs discourage."""
 
     @pytest.mark.parametrize("quantity", list(RefusedQuantity))
-    def test_every_refused_quantity_raises(
-        self, quantity: RefusedQuantity
-    ) -> None:
+    def test_every_refused_quantity_raises(self, quantity: RefusedQuantity) -> None:
         with pytest.raises(OutOfEnvelopeError, match=quantity.value):
             require_quotable(quantity)
 
@@ -438,9 +430,7 @@ class TestRunTrace:
         with pytest.raises(SolverInputError, match="window_s"):
             run.averaged_force_n_per_m(0.0)
 
-    def test_a_zero_step_march_is_refused(
-        self, material: SandContinuum, run
-    ) -> None:
+    def test_a_zero_step_march_is_refused(self, material: SandContinuum, run) -> None:
         solver = PlaneStrainMPMSolver(
             material=material, cell_size_m=0.004, effective_width_m=0.03
         )

--- a/tests/bunkershot3d/solvers/mpm/test_verification.py
+++ b/tests/bunkershot3d/solvers/mpm/test_verification.py
@@ -1,0 +1,272 @@
+"""Code verification for F1: conservation, an analytic case, GCI, and F0.
+
+This module is the reason the tier is allowed to exist.  The
+NASA-STD-7009B self-assessment records **validation at level 0 of 4**, so
+a new solver that cannot demonstrate its own correctness makes that score
+worse rather than better.
+
+Note what each test is entitled to assert.  The conservation identities
+are properties of the scheme, so they are asserted to round-off.  The
+analytic case is asserted against a closed-form answer.  The F0
+cross-check asserts only what a comparison between **two uncalibrated
+models** can support -- that both oppose the motion, and that the
+divergence is finite and reported -- because asserting agreement would be
+claiming a validation that neither tier has.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bunkershot3d.sand import playing_condition
+from bunkershot3d.sand.presets import PlayingCondition
+from bunkershot3d.solvers import (
+    DRFTSolver,
+    IntrusionState,
+    MaterialResponse,
+    RefusalPolicy,
+    SurfaceElements,
+)
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.solver import PlaneStrainMPMSolver
+from bunkershot3d.solvers.mpm.verification import (
+    column_grid_convergence,
+    cross_check_against_f0,
+    elastic_column_equilibrium,
+    energy_residuals,
+    free_fall_residuals,
+)
+from bunkershot3d.vandv.conservation import ConservationClass
+from bunkershot3d.vandv.convergence import observed_order_from_residuals
+from bunkershot3d.vandv.exceptions import ConservationClassError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def material() -> SandContinuum:
+    return SandContinuum.from_sand_state(playing_condition(PlayingCondition.FIRM))
+
+
+def wedge_state(speed_m_s: float = 12.0, attack_deg: float = 20.0) -> IntrusionState:
+    """A 40 x 16 mm sole section entering at a stated attack angle."""
+    corners = np.array(
+        [
+            [-0.020, 0.0, -0.008],
+            [0.020, 0.0, -0.008],
+            [0.020, 0.0, 0.008],
+            [-0.020, 0.0, 0.008],
+            [0.024, 0.0, -0.004],
+        ]
+    )
+    normals = np.tile([0.0, 0.0, -1.0], (corners.shape[0], 1))
+    areas = np.full(corners.shape[0], 4.0e-4)
+    angle = np.radians(attack_deg)
+    velocity = (
+        speed_m_s * np.cos(angle),
+        0.0,
+        -speed_m_s * np.sin(angle),
+    )
+    return IntrusionState(
+        SurfaceElements(corners, normals, areas),
+        velocity,
+        free_surface_height_m=0.0,
+    )
+
+
+class TestMassAndMomentumConservation:
+    """Identities of the scheme, so round-off class and no step size."""
+
+    @pytest.fixture(scope="class")
+    def residuals(self, material: SandContinuum):
+        return free_fall_residuals(material, n_steps=40)
+
+    def test_mass_is_conserved_exactly(self, residuals) -> None:
+        mass = residuals[0]
+        assert mass.conservation_class is ConservationClass.ROUND_OFF
+        assert mass.residual == 0.0
+        assert mass.within_round_off
+
+    def test_momentum_matches_the_gravity_impulse(self, residuals) -> None:
+        momentum = residuals[1]
+        assert momentum.conservation_class is ConservationClass.ROUND_OFF
+        assert momentum.within_round_off, momentum.summary()
+
+    def test_a_round_off_residual_refuses_an_order_test(self, residuals) -> None:
+        """The V&V machinery, not this suite, is what forbids it."""
+        with pytest.raises(ConservationClassError):
+            observed_order_from_residuals(list(residuals))
+
+
+class TestEnergyConservation:
+    """Truncation class: the order of the decay is the test, not a tolerance."""
+
+    @pytest.fixture(scope="class")
+    def residuals(self, material: SandContinuum):
+        return energy_residuals(material)
+
+    def test_every_residual_is_truncation_class(self, residuals) -> None:
+        for residual in residuals:
+            assert residual.conservation_class is ConservationClass.TRUNCATION
+            assert residual.step_size_s is not None
+
+    def test_a_truncation_residual_refuses_a_fixed_tolerance(self, residuals) -> None:
+        with pytest.raises(ConservationClassError):
+            _ = residuals[0].within_round_off
+
+    def test_the_residual_decays_first_order_in_the_step(self, residuals) -> None:
+        """Symplectic Euler loses exactly ``M g^2 dt^2 / 2`` per step.
+
+        Over a fixed window that is ``M g^2 dt T / 2``, so the observed
+        order should sit on 1 rather than merely be positive -- and it is
+        asserted as a band, because "greater than zero" would pass for a
+        scheme that had no order at all.
+        """
+        order = observed_order_from_residuals(list(residuals))
+        assert 0.85 < order.order < 1.15, order.summary()
+
+    def test_the_energy_error_is_small_at_the_finest_step(self, residuals) -> None:
+        finest = min(residuals, key=lambda item: item.step_size_s or float("inf"))
+        assert finest.relative < 1e-2, finest.summary()
+
+
+class TestElasticColumn:
+    """The analytic case: 1-D consolidation, found rather than seeded."""
+
+    @pytest.fixture(scope="class")
+    def column(self, material: SandContinuum):
+        return elastic_column_equilibrium(material, cell_size_m=0.003)
+
+    def test_it_relaxed(self, column) -> None:
+        assert column.relaxed_fraction < 1e-3, column.summary()
+
+    def test_the_equilibrium_is_elastic(self, column) -> None:
+        """So the analytic elastic answer is exact, not an approximation."""
+        assert column.n_yielded == 0, column.summary()
+
+    def test_it_finds_the_closed_form_stress(self, column) -> None:
+        assert column.relative_error < 0.05, column.summary()
+
+    def test_it_finds_the_closed_form_strain_energy(self, column) -> None:
+        """The elastic pathway, checked statically.
+
+        A conservative *elastic* case does not exist for cohesionless
+        sand -- anything that rebounds goes into tension and yields at the
+        cone tip -- so the stored energy is checked against
+        ``W (rho g)^2 H^3 / (6 M)`` at equilibrium instead.
+        """
+        assert column.elastic_energy_relative_error < 0.10, (
+            f"{column.summary()}; U = {column.elastic_energy_j_per_m:.6g} against "
+            f"{column.analytic_elastic_energy_j_per_m:.6g} J/m analytic"
+        )
+
+    def test_the_stress_is_compressive(self, column) -> None:
+        assert column.mean_vertical_stress_pa < 0.0
+
+    def test_the_wall_bands_actually_land_on_the_column(self, column) -> None:
+        """The failure this case had first, kept as a regression.
+
+        A generously padded grid puts the "fixed base" two cells below the
+        column and the confining side walls two cells outside it. The
+        column then stands in free space, falls, and reports a mean
+        stress of zero through an otherwise entirely plausible run.
+        """
+        assert abs(column.mean_vertical_stress_pa) > 1.0
+
+    def test_a_deeper_column_carries_more_stress(self, material: SandContinuum) -> None:
+        """A sanity direction the analytic formula alone would not catch."""
+        shallow = elastic_column_equilibrium(
+            material, cell_size_m=0.004, height_m=0.024
+        )
+        deep = elastic_column_equilibrium(material, cell_size_m=0.004, height_m=0.048)
+        assert deep.mean_vertical_stress_pa < shallow.mean_vertical_stress_pa
+
+
+class TestGridConvergence:
+    """Reported through the existing Celik implementation, not a new one."""
+
+    @pytest.fixture(scope="class")
+    def study(self, material: SandContinuum):
+        return column_grid_convergence(material)
+
+    def test_three_levels_were_solved(self, study) -> None:
+        levels, _, _ = study
+        assert len(levels) == 3
+        assert len({level.n_particles for level in levels}) == 3
+
+    def test_the_error_falls_under_refinement(self, study) -> None:
+        levels, _, _ = study
+        errors = [level.absolute_error_pa for level in levels]
+        assert errors[0] > errors[-1], [level.summary() for level in levels]
+
+    def test_a_first_order_or_better_rate_is_observed(self, study) -> None:
+        _, order, _ = study
+        assert order.order > 0.8, order.summary()
+        assert order.monotone, order.summary()
+
+    def test_the_gci_is_reported_and_bounded(self, study) -> None:
+        _, _, gci = study
+        assert np.isfinite(gci.gci_fine)
+        assert gci.gci_fine < 0.10, gci.summary()
+
+    def test_the_convergence_is_monotonic(self, study) -> None:
+        """Oscillatory convergence would make the Richardson band a fiction."""
+        _, _, gci = study
+        assert not gci.is_oscillatory, gci.summary()
+
+    def test_the_study_reuses_the_repo_celik_machinery(self, study) -> None:
+        _, _, gci = study
+        assert gci.n_grids == 3
+        assert gci.quantity.startswith("F1 elastic column")
+
+    def test_fewer_than_three_grids_is_refused(self, material: SandContinuum) -> None:
+        from bunkershot3d.solvers.exceptions import SolverInputError
+
+        with pytest.raises(SolverInputError, match="at least three grids"):
+            column_grid_convergence(material, cell_sizes_m=(0.006, 0.004))
+
+
+class TestF0CrossCheck:
+    """A consistency check between two uncalibrated models, and nothing more."""
+
+    @pytest.fixture(scope="class")
+    def comparison(self, material: SandContinuum):
+        sand = playing_condition(PlayingCondition.FIRM)
+        f0 = DRFTSolver(
+            material=MaterialResponse.from_sand_state(sand),
+            refusal_policy=RefusalPolicy.REPORT,
+        )
+        f1 = PlaneStrainMPMSolver(
+            material=material,
+            cell_size_m=0.004,
+            effective_width_m=0.030,
+            bed_depth_m=0.06,
+            refusal_policy=RefusalPolicy.REPORT,
+            max_steps=4000,
+        )
+        return cross_check_against_f0(wedge_state(), f0, f1)
+
+    def test_both_tiers_oppose_the_motion(self, comparison) -> None:
+        """The one thing a comparison of two uncalibrated models can assert."""
+        velocity = np.array([np.cos(np.radians(20.0)), 0.0, -np.sin(np.radians(20.0))])
+        assert float(comparison.f0_force_n @ velocity) < 0.0, comparison.summary()
+        assert float(comparison.f1_force_n @ velocity) < 0.0, comparison.summary()
+
+    def test_the_divergence_is_finite_and_reported(self, comparison) -> None:
+        assert np.isfinite(comparison.magnitude_ratio)
+        assert comparison.magnitude_ratio > 0.0
+        assert -1.0 <= comparison.direction_agreement <= 1.0
+
+    def test_f1_produces_a_divot_that_f0_cannot(self, comparison) -> None:
+        """The reason ADR-0033 chose a continuum at all."""
+        assert comparison.f1_divot_depth_m > 0.0, comparison.summary()
+
+    def test_both_split_their_force_into_two_parts(self, comparison) -> None:
+        assert 0.0 <= comparison.f0_inertial_fraction <= 1.0
+        assert 0.0 <= comparison.f1_flux_fraction <= 1.0
+
+    def test_the_summary_names_the_declared_width(self, comparison) -> None:
+        """No magnitude may be reproduced without its assumption."""
+        assert "width=" in comparison.summary()
+        assert comparison.effective_width_m == pytest.approx(0.030)


### PR DESCRIPTION
Implements the **F1 2-D plane-strain material-point sand solver** decided by
[ADR-0033](docs/adr/0033-bunkershot3d-sand-field-tier.md) (#8709), which
unblocks Track B of epic #8699 (#8710-#8713). F0 never forms a sand velocity at
any resolution, so the fields Track B consumes cannot be post-processed out of
it; a continuum produces them by construction.

Scoped to **solver core plus its verification**. Field extraction (#8710) and
the visual layers (#8711-#8713) are not here. Closes nothing.

---

## Verified is not validated

The suite below shows this solver **solves its equations correctly**. It is not
evidence that those equations describe golf bunker sand, and this PR does not
claim it is. Validation for this package stands at **NASA-STD-7009B level 0 of
4** because #8616 found no published measurement of any quantity the tier
produces. The F1 envelope therefore enforces a `BEYOND_VALIDATION` floor that
**no query can beat** — `EXTRAPOLATED` means "outside the stated limits but
inside the published validation set", and there is no such set. That floor
exists so adding a tier cannot quietly raise a reported validation level.

## Constitutive model: capped Drucker-Prager, and why not mu(I)

This is the justification a reviewer cannot check from the diff, so it is
first.

The obvious choice for flowing sand is the **mu(I) rheology**, and it is the
wrong one here. Barker, Schaeffer, Bohorquez & Gray (2015), *"Well-posed and
ill-posed behaviour of the mu(I)-rheology for granular flow"*, **J. Fluid Mech.
779:794-818**, show the incrementally-linearised equations **lose
hyperbolicity** — the initial-value problem becomes Hadamard-unstable — for
inertial numbers below `I_1` and above `I_2`. Perturbation growth rate then
rises without bound with wavenumber, so the computation **does not converge
under refinement**: a finer grid makes the answer *worse*, and any apparently
converged result is the discretisation quietly acting as the regulariser.

Both ill-posed regimes are *inside* a bunker shot, not outside it: the
quiescent bed far from the club sits at `I -> 0`, and the leading edge reaches
`I ~ 11` on this package's own envelope constants. A tier whose entire
deliverable is a field that ADR-0033 requires to be **grid-refined and
GCI-reported** cannot rest on equations that are ill-posed in exactly the
regime being refined.

Regularising mu(I) into a well-posed band (Barker & Gray 2017, JFM 828:5-32) is
possible, but its constants are fitted, unmeasured for this sand, and would
become a second uncalibrated parameter set beside the one #7999 already
records.

**Shipped instead:** rate-independent **Drucker-Prager elastoplasticity with a
compressive cap**, integrated as a return mapping on principal Hencky
(logarithmic) strains.

- Drucker & Prager (1952), *Q. Appl. Math.* 10:157-165 — the yield surface.
- Klar, Gast, Pradhana, Fu, Schroeder, Jiang & Teran (2016), *"Drucker-Prager
  elastoplasticity for sand"*, **ACM TOG 35(4):103** — the principal-strain
  return mapping, and the same material model the **F2 reference tier**
  (Newton `SolverImplicitMPM`) uses, which ADR-0033 requires so one calibration
  carries between the tiers.
- Bonet & Wood (2008) section 6.6 — Hencky hyperelasticity.

Rate independence is the point: the constitutive response contributes no term
that can lose hyperbolicity, so the characteristic speeds are the elastic wave
speeds — real and positive for any admissible `(lambda, mu)` — and refinement
is meaningful at every inertial number.

**One correction to the published algorithm.** Klar's tip case also sends
`||dev(eps)|| = 0` to the cone tip. That wrongly claims purely *isotropic
compression*, which is an admissible state deep inside the cone and the
commonest state in a settled bed. The tip branch here keys on the trace alone.

**The cap is not a tuning constant.** A bare DP cone is open in compression, so
nothing stops a bed compacting past the packing limit of its own grains. The
cap is read off the sand package's existing `PackingState`:

```
eps_v_cap = ln(phi / phi_max)
```

A loose bed (`Dr = 0`) can compact ~15%, a firm one (`Dr = 0.875`) ~2%. That is
critical-state behaviour arriving from the sand model rather than from a second
set of invented constants. The cohesive cone tip comes from the moisture model,
and a **saturated** bed raises rather than guessing its dilation suction — the
sand package has no default there and F1 has no better answer than it does.

Sand constants otherwise come straight from `usga_reference_sand` and the
packing/moisture machinery. The only F1-specific additions are a Hardin &
Richart (1963) small-strain modulus keyed on the **existing** void ratio and
`Angularity`, and a conventional drained Poisson ratio — both recorded in the
provenance, and both weak levers, since in a rate-independent plastic model the
limit state that sets the forces is fixed by the friction angle and the cap
while the modulus only sets the wave speed and hence the timestep.

## Transfer scheme: APIC

- **PIC** resets each particle's velocity to the interpolated grid value,
  discarding every mode the grid cannot represent. That is fatal here in a
  specific way: the shear bands ADR-0033 asks F1 to *show* are exactly the
  fine-scale velocity structure PIC erases, so a PIC solve would render a
  smooth picture of a localisation it had itself damped away.
- **FLIP** carries the increment instead, preserving that energy but leaving
  null-space noise the grid never sees. In a plastic material the noise feeds
  the return mapping as ringing and spurious yielding.
- **APIC** (Jiang, Schroeder, Selle, Teran & Stomakhin 2015, **ACM TOG
  34(4):51**) carries a per-particle affine velocity field `C_p`. It is as
  stable as PIC and conserves **both linear and angular momentum** exactly
  across the transfer.

The choice is made **falsifiable rather than cited**. The round-trip test
measures the true APIC angular momentum, which is *not* `sum m (x x v)` — it
carries the affine spin term `(dx^2/4)(C_zx - C_xz)`, and omitting that term is
the usual way to "prove" APIC lacks the property. A companion test asserts that
dropping the affine term (i.e. PIC) is strictly worse, so if APIC were
pointless machinery this suite would say so.

Basis: quadratic B-splines (Steffen, Kirby & Berzins 2008), `C1` so
cell-crossing noise does not arise. Two of their identities are verified to
round-off and carry the conservation guarantees below: partition of unity (mass
transfer exact) and zero gradient sum (internal forces sum to zero for *any*
stress field).

MLS-MPM would be defensible, but it couples the transfer and the force
discretisation; keeping them separate is what lets the two be verified
independently.

## Timestep

CFL on the **computed** dilatational wave speed, not a hardcoded number:

```
dt = C * dx / (c_p + v_max),   c_p = sqrt((lambda + 2 mu) / rho)
```

so a stiffer sand shortens the step by itself. `v_max` includes the **body**
speed, which is what stops the club crossing more than a fraction of a cell in
one step. Checked at runtime with a `raise`, never an `assert`, because
`python -O` strips assertions and a CFL condition that evaporates under an
optimisation flag is worse than none.

## Verification — numbers

Through the existing `vandv/` conservation, convergence and Celik GCI
implementations, not a second copy.

**Conservation.** Round-off class and truncation class are kept separate, and
the V&V machinery itself enforces the distinction — a round-off residual
carries no step size, so nobody can fit an order to floating-point noise.

| quantity | class | residual |
| --- | --- | --- |
| total particle mass | round-off | **0.0** (exact) |
| linear momentum vs `M g n dt` | round-off | within `1e-12` relative |
| total energy, C = 0.4 / 0.2 / 0.1 | truncation | 2.21e-8 / 1.14e-8 / 5.74e-9 relative |

Energy **observed order 1.00**, matching the closed form for symplectic Euler
(`M g^2 dt T / 2`). Asserted as a band `0.85 < p < 1.15` rather than `p > 0`,
which would pass for a scheme with no order at all.

**Analytic case** — a 1-D consolidation column, relaxed from **unstressed** to
static equilibrium and compared against `<sigma_zz> = -rho g H / 2`. The
solver's own bed seeding uses the geostatic state, but this case has to *find*
it, so it is a result rather than a restatement. The equilibrium is verified
elastic (`n_yielded == 0`), which makes the analytic elastic answer the *exact*
solution of the elastoplastic model rather than an approximation to it.

| dx | particles | `<sigma_zz>` | analytic | error |
| --- | --- | --- | --- | --- |
| 6 mm | 128 | -418.043 Pa | -403.115 Pa | 3.70% |
| 4 mm | 288 | -412.058 Pa | -403.115 Pa | 2.22% |
| 3 mm | 512 | -409.741 Pa | -403.115 Pa | **1.64%** |

Stored strain energy is **5.8%** from `W (rho g)^2 H^3 / (6 M)`.

**Grid convergence** — monotone, refinement ratios 1.5 and 1.33:

- observed order **1.178** (pairwise 1.042, 1.264)
- Celik apparent order **p = 1.72**
- **`GCI_fine` = 1.105%**, `u_num` = 2.26 Pa

**Why not Bagnold.** The obvious granular analytic case is unavailable *by
construction*: the Bagnold profile is a consequence of mu(I) rate dependence,
and this model is deliberately rate-independent. A rate-independent plastic
solid on an incline gives plug flow over a basal shear band, not a 3/2 power
law. Using it anyway would be testing a rheology this solver does not have.

## F0 cross-check — and where they diverge

40 x 16 mm sole section, 20 deg attack, 30 mm **declared** effective width. Per
ADR-0033 this is a consistency check between two uncalibrated models and **not
a validation**: agreement would raise neither tier above validation level 0. So
the tests assert only that both oppose the motion and that the divergence is
finite and reported.

| v (m/s) | \|F0\| | \|F1\| | ratio | dir. cos | F0 inertial share | F1 flux share |
| --- | --- | --- | --- | --- | --- | --- |
| 5 | 12.57 N | 24.68 N | 1.96 | 0.846 | 0.518 | 0.683 |
| 12 | 40.71 N | 60.75 N | 1.49 | 0.645 | 0.932 | 0.691 |
| 25 | 166.6 N | 445.8 N | 2.68 | 0.873 | 0.991 | 0.645 |

Max depth agrees (8 mm both). F1 reports a **divot of 8.0-10.3 mm**; F0
produces none at all, which is the entire reason ADR-0033 chose a continuum.

**The informative divergence is the last two columns.** F0's inertial share
climbs 0.52 -> 0.93 -> 0.99 with speed while F1's momentum-flux share stays
flat at ~0.65-0.69. F0's `lambda rho v_n^2` term grows quadratically with
**nothing to bound it**; the continuum's reaction is limited by how fast the
yield surface lets sand be accelerated out of the way. The two tiers therefore
disagree *by construction* in exactly the regime a greenside shot occupies —
which localises where F0's constitutive shortcut breaks down, and is the most
useful output of the comparison.

Magnitude comparison is conditional on the declared width, which is why
`effective_width_m` is a **required constructor argument with no default** and
travels on every verdict. The direction cosine is the one number here that does
not depend on it.

## Two bugs the tests caught while being written

- **The Coulomb slide replaced the tangential velocity with the friction bound
  instead of reducing it by it**, so a *frictionless* club braked sand to a
  dead stop. Only the frictionless case exposes this; a `mu > 0` test alone
  looks plausible.
- **The column's wall bands landed off the column.** `DomainWalls` acts over
  the outermost two node layers, so a generously padded grid put the "fixed
  base" two cells *below* the column and the confining walls two cells
  *outside* it. The column stood in free space, fell, and reported a mean
  vertical stress of **3e-9 Pa** through an entirely plausible-looking run.
  Kept as a regression test.

Also, deriving the closed-form 2x2 SVD angle convention rather than copying it
caught a sign error: expanding `A = R(phi) diag(s) R(theta)^T` gives phi as the
half-*sum* and theta as the half-*difference* of the two `arctan2` angles.

The elastic-energy conservation case likewise had to be rebuilt around a real
finding: a pre-compressed block released to oscillate rebounds past its rest
state into tension, where the return map correctly annihilates the deviatoric
strain at the cone tip (129 of 144 particles yielding per step). That is
physical plastic dissipation, not truncation error, so the truncation test is
free fall — whose residual has a closed form — and the elastic pathway is
covered by a static check against the column's analytic strain energy.

## Fit with the existing architecture

- Implements `GranularSolver`; a caller written against the protocol can hold
  either tier (tested).
- Returns `SolverResult` with `fidelity_tier=F1`, a `ValidityVerdict`, and a
  `depth_force_n` / `inertial_force_n` split that is an **exact partition of
  the contact impulse** (stress-and-weight part vs momentum flux). It is *not*
  F0's `alpha |z~|` vs `lambda rho v_n^2` decomposition and the docstring says
  so; it is the analogous physical partition, computed from an exact momentum
  ledger rather than from a fitted form.
- The contact wrench **is** that momentum ledger: the impulse removed from the
  sand by the grid-level collision projection is the impulse delivered to the
  club, so there is no second force model that could disagree with it.
- F1 gets **its own envelope** rather than reusing `evaluate_envelope`. Three
  of F0's standing caveats (no wake model, sharp-corner accuracy, steady-state
  assumption) are statements about *resistive force theory*; attaching them to
  a continuum would describe F1's weaknesses in F0's vocabulary and hide the
  ones it has. A test asserts none of them leak onto an F1 verdict. The shared
  value objects (`ValidityVerdict`, `EnvelopeStatus`, `Caveat`,
  `dimensionless_groups`, `worst_of`) are reused so callers handle both
  identically.
- Refinement runs the **opposite way** from F0: F0's `I_G` rises as its surface
  mesh is refined, while F1 *refuses* a grid finer than ~2 grain diameters,
  where a continuum is being asked to resolve individual grains.
- ADR-0033's "Refused" rows **raise**: `require_quotable` rejects club force,
  ball launch and any out-of-plane distribution — including raising on an
  unrecognised name, since a silent no-op the first time somebody misspells one
  is the bug.
- Three anti-tunnelling mechanisms, since one is not enough at 25 m/s: the CFL
  step includes the body speed; a node is collided if the body *will* reach it
  within the step; and any particle still inside after advection is pushed back
  out. The third is reported per step, because a backstop that fires constantly
  means the first two are not working.
- No new dependencies. NumPy 2.2.6 only; the convex hull is an in-tree monotone
  chain.
- `raise`, never `assert`, for every contract check.

## Deliberately left out

Scoped in the follow-up issue: the ball as a plane-strain body, multi-body
contact ordering, F1 time-marching a whole shot, a plastic-limit analytic case,
MMS, temporal GCI, and calibration toward F2.

On the third of those: `solve()` currently builds a **declared** approach
history — the body is reversed along its own velocity until clear of the bed,
then driven back to the queried pose at constant velocity — because a continuum
has no "stress at this pose" without a history. F1 raises rather than inventing
one for a static query. A genuine F1 shot would march the head's real
trajectory once, in the shape of `solvers/shot.py::simulate_shot`.

Cost, measured: ~38 ms/step at 3,060 particles on a 4 mm grid, so seconds per
query — consistent with ADR-0032's "seconds to minutes" and three orders off
F0's ~15 ms. It is a study tier, not a drop-in for the design sweep.

## Test status

New tests: 167, all passing. Existing F0 solver and `vandv/` suites pass
unchanged; no test was weakened.

Two pre-existing failures on this machine, both confirmed identical on
`origin/main`:

- `tests/bunkershot3d/solvers/test_shot.py::TestPerformanceBudget` — a
  wall-clock budget test, **69.0 ms on `origin/main` against 66.6 ms on this
  branch**, so it is machine load and this branch is marginally faster.
- The suite-marker ratchet and test-layout gates fail identically on
  `origin/main` (pre-existing debt in `tests/research/` and a root-level test
  file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Follow-up scoped in #8733.
