### PR TITLE
feat(bunkershot3d): cross-tier comparison view, F0 against F1 (#8713)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -254,6 +254,85 @@ merged across an A/B pair for the same reason #8728 fixed the colour ramp. This
 is a rendering of existing F0 output, not new physics: the scene and the traces
 inherit `BEYOND_VALIDATION`, and no quantity here is calibrated for bunker sand.
 
+Issue #8713 (epic #8699) then puts the two tiers side by side on the
+quantities both produce, which is the only honest way to show F1 output at
+all: NASA-STD-7009B validation and use history both stand at 0 of 4, and
+`MAX_VALIDATED_SPEED_M_S` is 1.44 m/s, so a 25 m/s record is 17x past the
+published corpus from its first sample and never returns. The view therefore
+states what agreement does and does not license _inside the frame_ rather
+than in a caption -- computed from `vandv.credibility` and the solver's own
+envelope constants, so the sentence cannot drift from the code -- and the
+statement is that consistency between two uncalibrated models is not
+validation, that neither tier's level moves because of anything on the page,
+and that what the comparison _can_ do is falsify. Every ratio is judged
+against a **declared** band of 0.25 on `|ln(F1/F0)|`, declared because issue
+#8616 established there is no measurement of any of these quantities out of
+bunker sand and therefore no model error to calibrate a tolerance against.
+F1 has no whole-shot march yet (#8733), so each F1 point is a separate march
+to one recorded pose under a declared straight-line constant-speed approach;
+the points are drawn unjoined and the figure says why, because a line through
+independent marches would draw a trajectory nobody computed.
+
+At the workbench's own design point -- the 58 deg preset at 25 m/s, a 20 mm
+declared effective width and F1 at dx = 3 mm on an 80 mm bed -- the pair
+disagrees differently from the way ADR-0033's flat test section did, and the
+difference is itself the finding. At the peak of the strike `|F1|/|F0|` is
+**0.384**, not the 1.49-2.68 the 40 x 16 mm section gave: on a lofted head at
+its own declared width F1 reports roughly a third of F0's magnitude rather
+than twice it, so the ratio ADR-0033 measured does not transfer and must not
+be quoted for a wedge. The direction cosine, on the other hand, is **0.996**
+across the loaded stretch against 0.65-0.87 on the test section, so the two
+tiers agree about _where the load points_ far better on real geometry than on
+the section the check was written for. Depth agrees exactly, which is a
+control rather than a result: both tiers are handed the same pose. F1's divot
+section is **1.47x** F0's, which is not a like-for-like disagreement either --
+F0 transports no sand, so its divot is the swept lower envelope of the head,
+while F1's is the depression the sand actually left. Speed lost is F0's
+alone, since F1's section is driven kinematically; what is reported is each
+tier's resultant **projected on the direction of travel** and integrated over
+the probed window on the same quadrature, 8.82 m/s against 4.23 m/s, with
+F0's own record showing 7.80 m/s over that window so the quadrature error is
+visible rather than absorbed into the divergence.
+
+The inertial-share result reproduces exactly and is the sharpest one. Over a
+declared 5/12/25 m/s sweep at the deepest recorded pose, F0 credits
+0.959 -> 0.996 -> 0.999 of its force to its dynamic term while F1 credits
+0.644 -> 0.654 -> 0.658 to momentum flux: F0's `lambda rho v_n^2` grows
+quadratically with nothing bounding it, the continuum's reaction is limited
+by how fast the yield surface lets sand accelerate out of the way, and the
+crossing therefore sits _below_ the whole greenside range. A shot that enters
+at 25 m/s and leaves at 17.2 never decelerates through it, which is why the
+sweep is carried beside the shot probes as its own declared experiment and
+labelled as one.
+
+Two defects in the F1 tier were found by pointing that sweep at a real pose.
+The approach distance was **unbounded**: `_approach` divides the height it has
+to climb by the velocity's vertical direction cosine, and that cosine passes
+through zero at the deepest sample of every real shot -- measured -0.0026 on
+this record, so a 24 mm climb asked for a 9.5 m run-in, and `_build_bed` then
+sized the bed to cover it. Nothing caught it but the step cap, after the
+allocation. It now takes whichever of the two clearances is shorter, backing
+out through the surface or running in from beyond the body's own length, so
+the choice no longer turns on a sign that changes mid-shot. The grid ceiling
+was likewise an accident of the approach: a descending body starts in the air
+and happens to raise it, a horizontal run-in does not, and the first ejected
+particle then leaves the domain. Headroom is now stated in cells. Separately,
+`F0CrossCheck` was comparing two `SolverResult.max_depth_m` fields that do not
+mean the same thing -- F0 reports its deepest _engaged_ element there, the
+#8701 contact diagnostic, while F1 reports the deepest submerged element; they
+coincide on a flat section and differ by 33x on a lofted head -- so the check
+now carries the submerged depth off the shared query and the comparison uses
+that. The view also names, rather than quietly reports, the probes where F0
+has switched itself off: it returns zero the moment no element is both
+submerged and leading-edge while the sole is still in the divot (#8702), and
+the ratios of 51x and 295x at the entry and exit probes are divisions by an
+engagement criterion rather than physical disagreements.
+
+The check is deliberately not on the per-shot path: it costs about 11 minutes
+against milliseconds for a design, so the workbench runs it from its own
+button and the view is empty until asked. It is the fourth follower of the one
+transport `SoleLoadFieldWidget` owns.
+
 Child issue #8697 then couples two first bending modes and one torsional mode
 to that distributed-grip authority. Its registered 0.25/0.125 ms atlas covers
 384 trajectories and 1,536 nested-horizon summaries. Domain, activation,

--- a/src/bunkershot3d/solvers/mpm/__init__.py
+++ b/src/bunkershot3d/solvers/mpm/__init__.py
@@ -95,8 +95,10 @@ from .solver import (
 from .state import (
     DomainWalls,
     ParticleState,
+    SurfaceDepression,
     WallCondition,
     settled_bed,
+    surface_depression,
     surface_profile_m,
 )
 from .verification import (
@@ -133,6 +135,7 @@ __all__ = [
     "RigidSection",
     "SandContinuum",
     "StepDiagnostics",
+    "SurfaceDepression",
     "WallCondition",
     "apic_angular_momentum",
     "cfl_time_step_s",
@@ -152,6 +155,7 @@ __all__ = [
     "reconstruct",
     "require_quotable",
     "settled_bed",
+    "surface_depression",
     "surface_profile_m",
     "yield_function",
 ]

--- a/src/bunkershot3d/solvers/mpm/solver.py
+++ b/src/bunkershot3d/solvers/mpm/solver.py
@@ -106,6 +106,10 @@ for the club's own motion, which enters the same condition."""
 _DIMENSION = 2
 _MASS_FLOOR_KG = 1e-15
 _MIN_APPROACH_CLEARANCE_CELLS = 2.0
+_MIN_DIRECTION = 1e-9
+"""Floor on a direction cosine before it becomes a divisor."""
+_EJECTA_HEADROOM_CELLS = 6.0
+"""Cells of empty grid above the free surface, for sand thrown up."""
 _SURFACE_BINS = 64
 
 _NO_CONTACT = ContactImpulse(
@@ -836,6 +840,27 @@ class PlaneStrainMPMSolver:
     def _approach(self, state: IntrusionState) -> tuple[RigidSection, float]:
         """Reverse the body along its velocity until it is clear of the bed.
 
+        Two ways to be clear, and the shorter one wins
+        ----------------------------------------------
+
+        **Back out through the surface.**  Reversing along the velocity
+        lifts the body by ``distance * |direction_z|``, so clearing the
+        free surface costs ``height / |direction_z|``.
+
+        **Run in from beside the bed.**  Reversing along a mostly
+        horizontal velocity puts the body beyond its own length, which is
+        also clear of where the strike happens.
+
+        Taking whichever is shorter is not a tidy-up.  Choosing on the
+        *sign* of ``direction_z``, as this did, divides by a number that
+        passes through zero in the middle of every real shot: on the
+        workbench's own 25 m/s greenside record the deepest sample has
+        ``direction_z = -0.0026``, so a 24 mm climb asked for a **9.5 m**
+        run-in -- and :meth:`_build_bed` then sizes the bed to cover the
+        whole approach, so an ordinary-looking query allocates a 9.5 m bed
+        and marches tens of thousands of steps.  Nothing caught it but the
+        ``max_steps`` cap, after the allocation.
+
         Returns:
             ``(starting_section, approach_distance_m)``.
 
@@ -857,16 +882,14 @@ class PlaneStrainMPMSolver:
         direction = section.velocity_m_s / speed
         lower, upper = section.bounds_m()
         clearance = _MIN_APPROACH_CLEARANCE_CELLS * self.cell_size_m
+        span = float(upper[0] - lower[0])
+        horizontal = (span + clearance) / max(abs(direction[0]), _MIN_DIRECTION)
+        distance = horizontal
         if direction[1] < 0.0:
-            # Descending: back off until the lowest point clears the surface.
-            distance = (state.free_surface_height_m + clearance - lower[1]) / (
-                -direction[1]
+            vertical = (state.free_surface_height_m + clearance - lower[1]) / max(
+                -direction[1], _MIN_DIRECTION
             )
-        else:
-            # Level or rising: there is no height to back off to, so run in
-            # horizontally from beyond the body's own length.
-            span = float(upper[0] - lower[0])
-            distance = (span + clearance) / max(abs(direction[0]), 1e-9)
+            distance = min(vertical, horizontal)
         distance = max(float(distance), clearance)
         return section.translated(-distance * direction), distance
 
@@ -895,9 +918,23 @@ class PlaneStrainMPMSolver:
         surface = state.free_surface_height_m
         floor = surface - self.bed_depth_m
 
+        # Headroom above the free surface, stated rather than inherited.
+        # A descending approach starts the body in the air and so happens to
+        # raise the grid ceiling on its way past; a horizontal run-in does
+        # not, and the grid top then lands exactly on the free surface --
+        # where the first ejected particle leaves the domain and the run
+        # dies with "a particle left the grid interior". Sand thrown up has
+        # to have somewhere to go whatever the approach looked like.
+        headroom = _EJECTA_HEADROOM_CELLS * self.cell_size_m
         grid = PlaneStrainGrid.covering(
             (bed_lower, min(floor, float(min(lower_start[1], lower_end[1])))),
-            (bed_upper, max(surface, float(max(upper_start[1], upper_end[1])))),
+            (
+                bed_upper,
+                max(
+                    surface + headroom,
+                    float(max(upper_start[1], upper_end[1])),
+                ),
+            ),
             self.cell_size_m,
         )
         particles = settled_bed(

--- a/src/bunkershot3d/solvers/mpm/solver.py
+++ b/src/bunkershot3d/solvers/mpm/solver.py
@@ -81,8 +81,10 @@ from .grid import (
 from .state import (
     DomainWalls,
     ParticleState,
+    SurfaceDepression,
     apply_wall_conditions,
     settled_bed,
+    surface_depression,
     surface_profile_m,
 )
 
@@ -341,6 +343,34 @@ class MPMRun:
         total = self.averaged_force_n_per_m(window_s)
         stress = self.averaged_stress_force_n_per_m(window_s)
         return stress, total - stress
+
+    def surface_depression(self, *, n_bins: int = _SURFACE_BINS) -> SurfaceDepression:
+        """The divot the *sand* carries: how deep, and how much section.
+
+        Read off the particles, because in MPM the free surface *is*
+        wherever the particles stop.  The depth alone was enough for the
+        cross-check ADR-0033 shipped; comparing against F0's divot needs
+        the area as well, because
+        :class:`~bunkershot3d.metrics.divot.DivotMetrics` reports a
+        section area and a mass and there is nothing to compare a depth
+        against there.
+
+        Args:
+            n_bins: Horizontal bins across the bed.
+
+        Returns:
+            The measurement, carrying its own empty-bin count so a caller
+            can see whether the area is complete or a lower bound.
+
+        Raises:
+            SolverInputError: If no bin holds a particle.
+        """
+        return surface_depression(
+            self.particles,
+            free_surface_height_m=self.free_surface_height_m,
+            x_bounds_m=self.bed_x_bounds_m,
+            n_bins=n_bins,
+        )
 
     def divot_depth_m(self, *, n_bins: int = _SURFACE_BINS) -> float:
         """Deepest depression of the free surface below its original level.

--- a/src/bunkershot3d/solvers/mpm/state.py
+++ b/src/bunkershot3d/solvers/mpm/state.py
@@ -41,9 +41,11 @@ from .grid import PlaneStrainGrid
 __all__ = [
     "DomainWalls",
     "ParticleState",
+    "SurfaceDepression",
     "WallCondition",
     "apply_wall_conditions",
     "settled_bed",
+    "surface_depression",
     "surface_profile_m",
 ]
 
@@ -380,3 +382,176 @@ def surface_profile_m(
     if bool(inside.any()):
         np.maximum.at(heights, index[inside], particles.position_m[inside, 1])
     return centres, np.where(np.isfinite(heights), heights, np.nan)
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceDepression:
+    """How far the free surface fell, and how much section that removed.
+
+    :meth:`~bunkershot3d.solvers.mpm.solver.MPMRun.divot_depth_m` answers
+    the first question alone.  The cross-tier comparison of issue #8713
+    needs the second as well, because F0 reports its divot as an area and
+    a mass (:class:`~bunkershot3d.metrics.divot.DivotMetrics`) and a depth
+    cannot be compared against either.
+
+    The empty-bin count is why this is a value object rather than a float.
+    A bin the sand has left entirely has no surface height at all, so it
+    can contribute no depth to the integral: skipping it under-reports the
+    area and filling it in invents one.  The count therefore travels with
+    the number, and :attr:`fully_resolved` is what a caller checks before
+    quoting it.
+
+    Attributes:
+        section_area_m2: ``integral of (surface - height) dx`` over the
+            populated bins [m^2]. Per unit out-of-plane width, like every
+            other plane-strain quantity in this package.
+        max_depth_m: Deepest single bin, non-negative.
+        n_bins: Bins the profile was taken on.
+        n_empty_bins: Of those, bins holding no particle.
+        bed_width_m: Horizontal extent the profile spans [m].
+    """
+
+    section_area_m2: float
+    max_depth_m: float
+    n_bins: int
+    n_empty_bins: int
+    bed_width_m: float
+
+    def __post_init__(self) -> None:
+        """Validate the measurement.
+
+        Raises:
+            SolverInputError: If the area or depth is negative or not
+                finite, if the bin counts are inconsistent, or if the bed
+                width is not positive. A ``raise`` and not an ``assert``:
+                ``python -O`` strips assertions, and a negative divot area
+                would otherwise reach a comparison as a number.
+        """
+        for name, value in (
+            ("section_area_m2", self.section_area_m2),
+            ("max_depth_m", self.max_depth_m),
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise SolverInputError(
+                    f"{name} must be finite and non-negative, got {value!r}"
+                )
+        if int(self.n_bins) < 1:
+            raise SolverInputError(f"n_bins must be positive, got {self.n_bins!r}")
+        if not 0 <= int(self.n_empty_bins) <= int(self.n_bins):
+            raise SolverInputError(
+                f"n_empty_bins must lie in [0, {self.n_bins}], got "
+                f"{self.n_empty_bins!r}"
+            )
+        if not math.isfinite(self.bed_width_m) or self.bed_width_m <= 0.0:
+            raise SolverInputError(
+                f"bed_width_m must be positive, got {self.bed_width_m!r}"
+            )
+
+    @property
+    def fully_resolved(self) -> bool:
+        """Whether every bin held sand, so the area integral is complete."""
+        return self.n_empty_bins == 0
+
+    def displaced_mass_kg(self, *, width_m: float, bulk_density_kg_m3: float) -> float:
+        """Mass of sand this section corresponds to at a **declared** width.
+
+        Plane strain has no out-of-plane extent, so there is no such thing
+        as a mass here until a width is declared.  It is a required keyword
+        with no default for the same reason
+        :attr:`~bunkershot3d.solvers.mpm.solver.PlaneStrainMPMSolver.effective_width_m`
+        is: the number is conditional on an assumption, and the assumption
+        has to be stated by whoever quotes it.
+
+        Args:
+            width_m: Declared out-of-plane width [m].
+            bulk_density_kg_m3: Sand bulk density [kg/m^3].
+
+        Returns:
+            The displaced mass [kg].
+
+        Raises:
+            SolverInputError: If either argument is not positive.
+        """
+        if not math.isfinite(width_m) or width_m <= 0.0:
+            raise SolverInputError(f"width_m must be positive, got {width_m!r}")
+        if not math.isfinite(bulk_density_kg_m3) or bulk_density_kg_m3 <= 0.0:
+            raise SolverInputError(
+                f"bulk_density_kg_m3 must be positive, got {bulk_density_kg_m3!r}"
+            )
+        return self.section_area_m2 * float(width_m) * float(bulk_density_kg_m3)
+
+    def summary(self) -> str:
+        """A line fit for a comparison report."""
+        resolved = (
+            "every bin held sand"
+            if self.fully_resolved
+            else f"{self.n_empty_bins} of {self.n_bins} bins held no sand, so the "
+            "area is a lower bound"
+        )
+        return (
+            f"section {self.section_area_m2 * 1e4:.4g} cm^2 over "
+            f"{self.bed_width_m * 1e3:.4g} mm, deepest "
+            f"{self.max_depth_m * 1e3:.4g} mm ({resolved})"
+        )
+
+
+def surface_depression(
+    particles: ParticleState,
+    *,
+    free_surface_height_m: float,
+    x_bounds_m: tuple[float, float],
+    n_bins: int,
+) -> SurfaceDepression:
+    """Measure the divot the sand itself carries, as a depth **and** an area.
+
+    Read off :func:`surface_profile_m`, so the free surface is wherever the
+    particles stopped rather than a tracked interface.  Heaped shoulders --
+    bins standing *above* the undisturbed level -- are clipped to zero
+    rather than subtracted: the quantity asked for is how much section was
+    removed from below the original surface, and letting a heap cancel a
+    hole would report a shallow divot for a bed that had merely been
+    rearranged.
+
+    Args:
+        particles: The bed, after the march.
+        free_surface_height_m: The undisturbed surface [m].
+        x_bounds_m: Horizontal range to profile.
+        n_bins: Bins across that range.
+
+    Returns:
+        The measurement, carrying its own empty-bin count.
+
+    Raises:
+        SolverInputError: If ``n_bins`` is not positive, if the bounds do
+            not increase, or if **no** bin holds a particle -- which is not
+            a zero divot but an unmeasured one, and a zero would read as
+            the first.
+    """
+    _centres, heights = surface_profile_m(
+        particles, x_bounds_m=x_bounds_m, n_bins=n_bins
+    )
+    populated = np.isfinite(heights)
+    if not bool(populated.any()):
+        raise SolverInputError(
+            "no particle lies inside the profiled range, so the free surface "
+            "was not measured anywhere; a zero divot would read as a measured "
+            "flat bed rather than as an empty window"
+        )
+    depth = np.zeros_like(heights)
+    depth[populated] = np.maximum(
+        float(free_surface_height_m) - heights[populated], 0.0
+    )
+    lower, upper = (float(value) for value in x_bounds_m)
+    # Midpoint, not trapezoid. The profile is a binned maximum -- piecewise
+    # constant over each bin -- rather than a sampled smooth curve, so the
+    # midpoint rule is exact for it, while the trapezoid rule over the bin
+    # *centres* would silently drop half a bin at each end of the bed.
+    bin_width_m = (upper - lower) / float(int(n_bins))
+
+    return SurfaceDepression(
+        section_area_m2=float(depth[populated].sum() * bin_width_m),
+        max_depth_m=float(depth[populated].max()),
+        n_bins=int(n_bins),
+        n_empty_bins=int((~populated).sum()),
+        bed_width_m=upper - lower,
+    )

--- a/src/bunkershot3d/solvers/mpm/verification.py
+++ b/src/bunkershot3d/solvers/mpm/verification.py
@@ -699,6 +699,33 @@ class F0CrossCheck:
         return self.f1_divot.section_area_m2
 
     @property
+    def f1_divot_fully_resolved(self) -> bool:
+        """Whether every surface bin held sand, so the area is complete."""
+        return self.f1_divot.fully_resolved
+
+    @property
+    def f1_divot_bins(self) -> tuple[int, int]:
+        """``(empty, total)`` surface bins the divot was profiled on."""
+        return (self.f1_divot.n_empty_bins, self.f1_divot.n_bins)
+
+    def f1_divot_mass_kg(self, *, width_m: float, bulk_density_kg_m3: float) -> float:
+        """F1's removed section as a mass, at a **declared** width.
+
+        Args:
+            width_m: Declared out-of-plane width [m].
+            bulk_density_kg_m3: Sand bulk density [kg/m^3].
+
+        Returns:
+            The displaced mass [kg].
+
+        Raises:
+            SolverInputError: If either argument is not positive.
+        """
+        return self.f1_divot.displaced_mass_kg(
+            width_m=width_m, bulk_density_kg_m3=bulk_density_kg_m3
+        )
+
+    @property
     def magnitude_ratio(self) -> float:
         """``|F1| / |F0|``. Meaningful only alongside the declared width."""
         f0 = float(np.linalg.norm(self.f0_force_n))

--- a/src/bunkershot3d/solvers/mpm/verification.py
+++ b/src/bunkershot3d/solvers/mpm/verification.py
@@ -74,7 +74,13 @@ from ..protocol import IntrusionState, SolverResult
 from .constitutive import SandContinuum, principal_stretches
 from .grid import PlaneStrainGrid
 from .solver import MPMRun, PlaneStrainMPMSolver
-from .state import DomainWalls, ParticleState, WallCondition, settled_bed
+from .state import (
+    DomainWalls,
+    ParticleState,
+    SurfaceDepression,
+    WallCondition,
+    settled_bed,
+)
 
 __all__ = [
     "ColumnEquilibrium",
@@ -639,8 +645,11 @@ class F0CrossCheck:
         f1_flux_force_n: F1's momentum-flux part.
         f0_max_depth_m: Deepest submerged point per F0.
         f1_max_depth_m: The same per F1.
-        f1_divot_depth_m: F1's free-surface depression, which F0 cannot
-            produce at all.
+        f1_divot: F1's free-surface depression -- depth *and* section area
+            -- which F0 cannot produce at all. F0's own "divot" is the
+            swept lower envelope of the head, so the two are different
+            measurements of the same word and the comparison has to say so
+            (issue #8713).
         effective_width_m: The declared width F1's magnitude rests on.
     """
 
@@ -653,8 +662,24 @@ class F0CrossCheck:
     f1_flux_force_n: NDArray[np.float64]
     f0_max_depth_m: float
     f1_max_depth_m: float
-    f1_divot_depth_m: float
+    f1_divot: SurfaceDepression
     effective_width_m: float
+
+    @property
+    def f1_divot_depth_m(self) -> float:
+        """Deepest the sand's own free surface fell [m]."""
+        return self.f1_divot.max_depth_m
+
+    @property
+    def f1_divot_section_area_m2(self) -> float:
+        """Section of sand F1 removed from below the original surface [m^2].
+
+        Per unit out-of-plane width, so it compares directly against
+        :attr:`~bunkershot3d.metrics.divot.DivotMetrics.section_area_m2`
+        without either side declaring a width. The mass does need one; see
+        :meth:`~bunkershot3d.solvers.mpm.state.SurfaceDepression.displaced_mass_kg`.
+        """
+        return self.f1_divot.section_area_m2
 
     @property
     def magnitude_ratio(self) -> float:
@@ -703,7 +728,9 @@ class F0CrossCheck:
             f"inertial share F0={self.f0_inertial_fraction:.3f} vs flux share "
             f"F1={self.f1_flux_fraction:.3f}; depth F0={self.f0_max_depth_m * 1e3:.3g} "
             f"mm vs F1={self.f1_max_depth_m * 1e3:.3g} mm; F1 divot "
-            f"{self.f1_divot_depth_m * 1e3:.3g} mm (F0 produces none)"
+            f"{self.f1_divot_depth_m * 1e3:.3g} mm deep, "
+            f"{self.f1_divot_section_area_m2 * 1e4:.3g} cm^2 in section "
+            "(F0 moves no sand, so it produces neither)"
         )
 
 
@@ -745,7 +772,7 @@ def cross_check_against_f0(
         f1_flux_force_n=np.array([flux_part[0] * width, 0.0, flux_part[1] * width]),
         f0_max_depth_m=f0_result.max_depth_m,
         f1_max_depth_m=max(float(depths.max()) if depths.size else 0.0, 0.0),
-        f1_divot_depth_m=run.divot_depth_m(),
+        f1_divot=run.surface_depression(),
         effective_width_m=width,
     )
 

--- a/src/bunkershot3d/solvers/mpm/verification.py
+++ b/src/bunkershot3d/solvers/mpm/verification.py
@@ -643,8 +643,24 @@ class F0CrossCheck:
         f0_inertial_force_n: F0's dynamic part.
         f1_stress_force_n: F1's stress-and-weight part.
         f1_flux_force_n: F1's momentum-flux part.
-        f0_max_depth_m: Deepest submerged point per F0.
-        f1_max_depth_m: The same per F1.
+        submerged_depth_m: Deepest submerged element of the **shared
+            query**, read off the geometry and therefore identical for
+            both tiers. It exists because ``f0_max_depth_m`` and
+            ``f1_max_depth_m`` are *not* the same measurement, despite
+            being the same protocol field: F0 reports its deepest
+            **engaged** element -- leading-edge and submerged, the contact
+            diagnostic issue #8701 warned against conflating with a
+            geometric depth -- while F1 reports the deepest submerged
+            element outright. On the flat sole section this cross-check
+            was written for they coincide; on a lofted head, most of whose
+            elements never lead, they differ by an order of magnitude.
+            Anything comparing depth *across* the tiers must use this
+            field and not those two.
+        f0_max_depth_m: F0's own ``SolverResult.max_depth_m``: its deepest
+            **engaged** element. Not monotone, and zero whenever nothing
+            meets the engagement criterion.
+        f1_max_depth_m: F1's own ``SolverResult.max_depth_m``: the deepest
+            submerged element, engaged or not.
         f1_divot: F1's free-surface depression -- depth *and* section area
             -- which F0 cannot produce at all. F0's own "divot" is the
             swept lower envelope of the head, so the two are different
@@ -660,6 +676,7 @@ class F0CrossCheck:
     f0_inertial_force_n: NDArray[np.float64]
     f1_stress_force_n: NDArray[np.float64]
     f1_flux_force_n: NDArray[np.float64]
+    submerged_depth_m: float
     f0_max_depth_m: float
     f1_max_depth_m: float
     f1_divot: SurfaceDepression
@@ -726,8 +743,10 @@ class F0CrossCheck:
             f"ratio={self.magnitude_ratio:.3g}, "
             f"direction cos={self.direction_agreement:.4f}; "
             f"inertial share F0={self.f0_inertial_fraction:.3f} vs flux share "
-            f"F1={self.f1_flux_fraction:.3f}; depth F0={self.f0_max_depth_m * 1e3:.3g} "
-            f"mm vs F1={self.f1_max_depth_m * 1e3:.3g} mm; F1 divot "
+            f"F1={self.f1_flux_fraction:.3f}; submerged depth "
+            f"{self.submerged_depth_m * 1e3:.3g} mm (F0 engaged "
+            f"{self.f0_max_depth_m * 1e3:.3g} mm, F1 reports "
+            f"{self.f1_max_depth_m * 1e3:.3g} mm); F1 divot "
             f"{self.f1_divot_depth_m * 1e3:.3g} mm deep, "
             f"{self.f1_divot_section_area_m2 * 1e4:.3g} cm^2 in section "
             "(F0 moves no sand, so it produces neither)"
@@ -759,6 +778,7 @@ def cross_check_against_f0(
     width = f1_solver.effective_width_m
     total = (stress_part + flux_part) * width
     depths = -state.element_depths_m()
+    submerged = max(float(depths.max()) if depths.size else 0.0, 0.0)
 
     return F0CrossCheck(
         speed_m_s=state.speed_m_s,
@@ -770,6 +790,7 @@ def cross_check_against_f0(
             [stress_part[0] * width, 0.0, stress_part[1] * width]
         ),
         f1_flux_force_n=np.array([flux_part[0] * width, 0.0, flux_part[1] * width]),
+        submerged_depth_m=submerged,
         f0_max_depth_m=f0_result.max_depth_m,
         f1_max_depth_m=max(float(depths.max()) if depths.size else 0.0, 0.0),
         f1_divot=run.surface_depression(),

--- a/src/tools/bunker_shot_gui/agreement.py
+++ b/src/tools/bunker_shot_gui/agreement.py
@@ -1,0 +1,366 @@
+"""The vocabulary of agreement between two fidelity tiers (issue #8713).
+
+What is being agreed *about*, in what unit, what each tier means by it,
+what a ratio of the two is worth, and -- the part the issue asks for by
+name -- what agreement between them does and does not license.
+
+Separate from :mod:`~src.tools.bunker_shot_gui.crosstier`, which owns the
+probes and the comparison, because these are the terms any pair of tiers
+would be compared in. The F1 tier is the first to be put beside F0; ADR-0032
+specifies four.
+
+Nothing here runs a solver, and nothing here draws.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+from bunkershot3d.solvers.envelope import MAX_VALIDATED_SPEED_M_S
+from bunkershot3d.vandv.credibility import (
+    CREDIBILITY_ASSESSMENT,
+    CredibilityFactor,
+    envelope_exceedance,
+)
+
+__all__ = [
+    "DECLARED_AGREEMENT_BAND",
+    "AgreementClass",
+    "ComparedQuantity",
+    "DivergenceSpan",
+    "QuantityAgreement",
+    "licence_statement",
+]
+
+DECLARED_AGREEMENT_BAND = 0.25
+"""Half-width of the agreement band, on ``|ln(F1 / F0)|``.
+
+**Declared, not derived.** No measurement exists that could set it: issue
+#8616 established there is no published data for any of these quantities
+out of bunker sand, so there is no model error to calibrate a tolerance
+against. It is a reporting threshold -- roughly "within 28 %, either way"
+-- chosen so that the ratios ADR-0033 measured (1.49 to 2.68) read as the
+divergence they are rather than as noise, and it travels with every
+:class:`QuantityAgreement` so a reader can see what was applied.
+
+The band is on the *logarithm* of the ratio because a factor of two too
+large and a factor of two too small are the same disagreement, and a band
+on the plain ratio would call one of them worse than the other."""
+
+_STAMP_MAX_CHARS = 240
+
+
+class ComparedQuantity(StrEnum):
+    """A quantity both tiers produce -- and what each of them means by it.
+
+    The note is not decoration. Two of these five are the same word for two
+    different measurements, and drawing them on one axis without saying so
+    would be the most misleading thing this view could do.
+    """
+
+    WRENCH = "wrench"
+    SOLE_DEPTH = "sole_depth"
+    DIVOT_SECTION = "divot_section"
+    DIVOT_MASS = "divot_mass"
+    SPEED_LOST = "speed_lost"
+
+    @property
+    def label(self) -> str:
+        """A short heading for this quantity."""
+        return _QUANTITY_LABEL[self]
+
+    @property
+    def unit(self) -> str:
+        """The unit it is reported in. Stated, never assumed."""
+        return _QUANTITY_UNIT[self]
+
+    @property
+    def display_scale(self) -> float:
+        """Multiplier from SI to the unit in :attr:`unit`."""
+        return _QUANTITY_SCALE[self]
+
+    @property
+    def note(self) -> str:
+        """What each tier means by this quantity, where they differ."""
+        return _QUANTITY_NOTE[self]
+
+
+_QUANTITY_LABEL: dict[ComparedQuantity, str] = {
+    ComparedQuantity.WRENCH: "Sand force on the head",
+    ComparedQuantity.SOLE_DEPTH: "Sole depth",
+    ComparedQuantity.DIVOT_SECTION: "Divot section",
+    ComparedQuantity.DIVOT_MASS: "Divot mass",
+    ComparedQuantity.SPEED_LOST: "Speed lost",
+}
+
+_QUANTITY_UNIT: dict[ComparedQuantity, str] = {
+    ComparedQuantity.WRENCH: "N",
+    ComparedQuantity.SOLE_DEPTH: "mm",
+    ComparedQuantity.DIVOT_SECTION: "cm^2",
+    ComparedQuantity.DIVOT_MASS: "g",
+    ComparedQuantity.SPEED_LOST: "m/s",
+}
+
+_QUANTITY_SCALE: dict[ComparedQuantity, float] = {
+    ComparedQuantity.WRENCH: 1.0,
+    ComparedQuantity.SOLE_DEPTH: 1.0e3,
+    ComparedQuantity.DIVOT_SECTION: 1.0e4,
+    ComparedQuantity.DIVOT_MASS: 1.0e3,
+    ComparedQuantity.SPEED_LOST: 1.0,
+}
+
+_QUANTITY_NOTE: dict[ComparedQuantity, str] = {
+    ComparedQuantity.WRENCH: (
+        "resultant magnitude. F0 integrates a fitted traction over the head; "
+        "F1 reads an exact momentum ledger off the grid nodes the section "
+        "projected, per unit width, so its magnitude is conditional on the "
+        "declared effective width while its direction is not"
+    ),
+    ComparedQuantity.SOLE_DEPTH: (
+        "the deepest submerged element of the shared query -- geometry, not "
+        "physics, so this is a control row: a disagreement here would mean the "
+        "pose did not reach one of the tiers unchanged. It is deliberately not "
+        "either tier's own SolverResult.max_depth_m, because F0 reports its "
+        "deepest *engaged* element there while F1 reports the deepest "
+        "submerged one, and on a lofted head those differ by an order of "
+        "magnitude"
+    ),
+    ComparedQuantity.DIVOT_SECTION: (
+        "the same word for two different measurements. F0 transports no sand, "
+        "so its divot is the swept lower envelope of the head itself -- where "
+        "the head has been. F1's is where the sand ended up: the depression "
+        "left in the free surface after the pass"
+    ),
+    ComparedQuantity.DIVOT_MASS: (
+        "each tier's own divot section carried to a mass at one declared "
+        "out-of-plane width and the bed's bulk density, so the comparison is "
+        "not confounded by two different width assumptions; it inherits the "
+        "envelope-versus-sand difference of the section it comes from"
+    ),
+    ComparedQuantity.SPEED_LOST: (
+        "F0's alone. F1's section is driven kinematically at constant "
+        "velocity, so it loses no speed of its own; the F1 figure is what its "
+        "force would have taken off the same head over the same window, which "
+        "is one-way coupled -- F1 was never asked what the slower head would "
+        "have done"
+    ),
+}
+
+
+class AgreementClass(StrEnum):
+    """The verdict on one ratio, against the declared band."""
+
+    CONSISTENT = "consistent"
+    """Inside the band. Which licenses nothing; see :func:`licence_statement`."""
+
+    DIVERGENT = "divergent"
+    """Outside it. At least one tier is wrong, and that is worth knowing."""
+
+    INCOMPARABLE = "incomparable"
+    """One tier or both produced nothing, so there is no ratio to judge.
+
+    Distinct from agreement on purpose: two zeroes are not a match, they
+    are an unanswered question, and classing them as consistent would let
+    a quantity nobody computed read as a quantity both tiers confirmed."""
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityAgreement:
+    """One quantity, both tiers' answers, and the verdict on their ratio.
+
+    Attributes:
+        quantity: Which quantity.
+        f0_value: F0's answer, in SI.
+        f1_value: F1's answer, in SI.
+        band: Half-width of the agreement band on ``|ln ratio|``.
+    """
+
+    quantity: ComparedQuantity
+    f0_value: float
+    f1_value: float
+    band: float = DECLARED_AGREEMENT_BAND
+
+    def __post_init__(self) -> None:
+        """Validate the pair.
+
+        Raises:
+            ValueError: If either value is negative or not finite, or if the
+                band is not positive and finite. These are ``raise`` and not
+                ``assert``: ``python -O`` strips assertions, and a zero band
+                would silently class every finite discretisation error as a
+                divergence.
+        """
+        for name, value in (("f0_value", self.f0_value), ("f1_value", self.f1_value)):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(
+                    f"{name} must be finite and non-negative -- these are "
+                    f"magnitudes -- got {value!r}"
+                )
+        if not math.isfinite(self.band) or self.band <= 0.0:
+            raise ValueError(
+                f"the agreement band must be positive and finite, got {self.band!r}"
+            )
+
+    @property
+    def comparable(self) -> bool:
+        """Whether both tiers produced something to form a ratio from."""
+        return self.f0_value > 0.0 and self.f1_value > 0.0
+
+    @property
+    def ratio(self) -> float:
+        """``F1 / F0``; ``nan`` when there is no ratio to take."""
+        if not self.comparable:
+            return math.nan
+        return self.f1_value / self.f0_value
+
+    @property
+    def log_ratio(self) -> float:
+        """``|ln(F1 / F0)|``, the symmetric measure of disagreement."""
+        if not self.comparable:
+            return math.nan
+        return abs(math.log(self.ratio))
+
+    @property
+    def relative_difference(self) -> float:
+        """``(F1 - F0) / F0``; ``nan`` when there is no ratio to take."""
+        if not self.comparable:
+            return math.nan
+        return (self.f1_value - self.f0_value) / self.f0_value
+
+    @property
+    def agreement(self) -> AgreementClass:
+        """The verdict on the ratio."""
+        if not self.comparable:
+            return AgreementClass.INCOMPARABLE
+        return (
+            AgreementClass.CONSISTENT
+            if self.log_ratio <= self.band
+            else AgreementClass.DIVERGENT
+        )
+
+    @property
+    def diverged(self) -> bool:
+        """Whether the two tiers left the declared band."""
+        return self.agreement is AgreementClass.DIVERGENT
+
+    def display(self, value: float) -> float:
+        """Convert one SI value into this quantity's reporting unit."""
+        return value * self.quantity.display_scale
+
+    def summary(self) -> str:
+        """A line fit for the agreement table drawn inside the view."""
+        unit = self.quantity.unit
+        head = (
+            f"{self.quantity.label}: F0 {self.display(self.f0_value):.4g} {unit}, "
+            f"F1 {self.display(self.f1_value):.4g} {unit}"
+        )
+        if not self.comparable:
+            return f"{head} -- incomparable, at least one tier produced nothing"
+        return (
+            f"{head}, ratio {self.ratio:.3g}x "
+            f"({self.relative_difference:+.0%}), "
+            f"{self.agreement.value} against a declared band of "
+            f"{self.band:g} on |ln ratio|"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DivergenceSpan:
+    """A stretch of the record over which one quantity left the band.
+
+    Attributes:
+        quantity: Which quantity diverged.
+        start_s: When the stretch opens [s].
+        end_s: When it closes [s].
+        worst_ratio: The largest departure from 1.0 inside it, as a ratio.
+        n_probes: How many probes it covers.
+    """
+
+    quantity: ComparedQuantity
+    start_s: float
+    end_s: float
+    worst_ratio: float
+    n_probes: int
+
+    @property
+    def duration_s(self) -> float:
+        """How long the stretch lasts [s]."""
+        return self.end_s - self.start_s
+
+    @property
+    def label(self) -> str:
+        """One line naming the quantity, the stretch and the worst ratio."""
+        return (
+            f"{self.quantity.label} diverges "
+            f"{self.start_s * 1e3:.2f}-{self.end_s * 1e3:.2f} ms, "
+            f"worst {self.worst_ratio:.3g}x "
+            f"({self.n_probes} probe{'' if self.n_probes == 1 else 's'})"
+        )
+
+
+def licence_statement(
+    *,
+    speed_m_s: float,
+    effective_width_m: float | None = None,
+    feature_length_m: float = 0.100,
+) -> str:
+    """State what agreement between the two tiers does and does not license.
+
+    Computed rather than quoted. The validation level comes from
+    :data:`~bunkershot3d.vandv.credibility.CREDIBILITY_ASSESSMENT`, the
+    exceedance from
+    :func:`~bunkershot3d.vandv.credibility.envelope_exceedance`, and the
+    speed ceiling from
+    :data:`~bunkershot3d.solvers.envelope.MAX_VALIDATED_SPEED_M_S`, so the
+    sentence cannot drift away from the code it is describing.
+
+    Args:
+        speed_m_s: The delivery speed the comparison was run at.
+        effective_width_m: The declared out-of-plane width F1's magnitudes
+            rest on; named when there is one, since no F1 magnitude may be
+            reproduced without it.
+        feature_length_m: Scale the Froude number is formed on.
+
+    Returns:
+        The statement, several sentences, meant to be drawn inside the
+        view rather than captioned beneath it.
+    """
+    validation = next(
+        item
+        for item in CREDIBILITY_ASSESSMENT
+        if item.factor is CredibilityFactor.VALIDATION
+    )
+    exceedance = envelope_exceedance(
+        speed_m_s=speed_m_s, feature_length_m=feature_length_m
+    )
+    width = (
+        ""
+        if effective_width_m is None
+        else (
+            f" F1's magnitudes are per unit width, raised to forces at a "
+            f"declared effective width of {effective_width_m * 1e3:g} mm; that "
+            "assumption is not a result and no F1 magnitude may be reproduced "
+            "without it."
+        )
+    )
+    return (
+        "What this comparison licenses: nothing about sand. It is a "
+        "consistency check between two uncalibrated models, and agreement "
+        "between two uncalibrated models is not validation. Neither tier's "
+        "NASA-STD-7009B validation level moves because of anything on this "
+        f"page: validation stands at {validation.achieved_level} of "
+        f"{validation.threshold_level + 1} against a threshold of "
+        f"{validation.threshold_level}, because neither tier is being "
+        "compared to a measurement. What the comparison can do is falsify -- "
+        "a disagreement beyond the declared band means at least one of the "
+        "two is wrong, and that is the whole of its value.\n"
+        f"The delivery point is {exceedance.speed_exceedance:.0f}x the "
+        f"fastest intrusion in the published corpus "
+        f"({MAX_VALIDATED_SPEED_M_S:g} m/s) and "
+        f"{exceedance.froude_exceedance:.0f}x 3D-RFT's stated Froude limit at "
+        f"the {feature_length_m * 1e3:g} mm clubhead scale, so the record is "
+        "outside the published corpus from its first sample and never "
+        f"returns.{width}"
+    )

--- a/src/tools/bunker_shot_gui/bridge.py
+++ b/src/tools/bunker_shot_gui/bridge.py
@@ -32,11 +32,12 @@ No Qt, no arithmetic that is not either the solver's or the metric's.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike, NDArray
 from scipy.spatial.transform import Rotation
 
 from bunkershot3d.geometry import (
@@ -62,8 +63,12 @@ from bunkershot3d.solvers import (
     ShotResult,
     SurfaceElements,
 )
+from bunkershot3d.solvers.mpm.solver import PlaneStrainMPMSolver
+from bunkershot3d.solvers.mpm.verification import cross_check_against_f0
 from src.shared.python.core.contracts import require
 
+from .agreement import DECLARED_AGREEMENT_BAND
+from .crosstier import CrossTierComparison, CrossTierProbe
 from .design import SwingSetup
 from .field import SoleLoadField
 from .traces import ValidityBand
@@ -73,9 +78,11 @@ __all__ = [
     "HeadBuild",
     "SoleLoadMap",
     "build_head",
+    "compare_tiers",
     "delivery_rotation",
     "entry_kinematics",
     "free_surface_height_m",
+    "probe_frames",
     "sole_load_field",
     "sole_load_map",
     "sole_load_trace",
@@ -545,3 +552,252 @@ def _bin_edges(stations: NDArray[np.float64], n_bins: int) -> NDArray[np.float64
     if high <= low:
         high = low + 1.0
     return np.linspace(low, high, n_bins + 1, dtype=np.float64)
+
+
+def probe_frames(result: ShotResult, n_probes: int) -> tuple[int, ...]:
+    """Choose which samples of an F0 record to hand to F1.
+
+    Only **engaged** samples are candidates. A probe taken during the
+    free-flight lead-in would hand both tiers a query with no contact, and
+    two zeroes are not an agreement -- they are a wasted march, and F1's
+    march is the expensive half of this comparison by three orders of
+    magnitude.
+
+    The sample at which F0's own force peaked is always included, because
+    that is the moment the shot-level agreement is quoted at and the moment
+    a designer looks for.
+
+    Args:
+        result: The F0 record.
+        n_probes: How many samples to probe. Clamped to the number of
+            engaged samples available.
+
+    Returns:
+        Sample indices, ascending and unique.
+
+    Raises:
+        ValueError: If ``n_probes`` is not positive, or if the record has
+            no engaged sample at all -- a shot that never touched the sand
+            has nothing to cross-check.
+    """
+    if int(n_probes) < 1:
+        raise ValueError(f"n_probes must be positive, got {n_probes!r}")
+    engaged = np.flatnonzero(np.asarray(result.active_areas_m2) > 0.0)
+    if engaged.size == 0:
+        raise ValueError(
+            "this record has no engaged sample, so there is nothing for the "
+            "field tier to be compared against; the head never reached the sand"
+        )
+    wanted = min(int(n_probes), int(engaged.size))
+    chosen = engaged[np.linspace(0, engaged.size - 1, wanted).round().astype(int)]
+    peak = int(np.argmax(np.linalg.norm(result.forces_n, axis=1)))
+    if peak in set(engaged.tolist()):
+        chosen = np.append(chosen, peak)
+    return tuple(int(frame) for frame in np.unique(chosen))
+
+
+def _state_at(
+    build: HeadBuild,
+    result: ShotResult,
+    kinematics: HeadKinematics,
+    frame: int,
+    *,
+    surface_m: float,
+    speed_m_s: float | None = None,
+) -> IntrusionState:
+    """Rebuild the query ``simulate_shot`` solved at one sample.
+
+    The head does not rotate during the shot, so the recorded position and
+    velocity reproduce the state the march actually solved -- the same
+    replay :func:`sole_load_field` and :func:`validity_band` already use, so
+    all three views describe one shot rather than three re-derivations of
+    it.
+
+    Args:
+        build: The lofted head.
+        result: The F0 record.
+        kinematics: The entry pose, supplying the constant orientation and
+            the angular velocity the march carried.
+        frame: Which sample.
+        surface_m: The free surface the march ran against.
+        speed_m_s: Rescale the recorded velocity to this speed, keeping its
+            direction. Used by the declared speed sweep; ``None`` leaves
+            the recorded velocity untouched.
+
+    Returns:
+        The query, given to both tiers unchanged.
+
+    Raises:
+        ValueError: If a rescale is asked for at a sample with no velocity
+            to take a direction from.
+    """
+    oriented = build.elements_body.transformed(rotation=kinematics.orientation)
+    position = result.positions_m[frame]
+    velocity = np.asarray(result.velocities_m_s[frame], dtype=np.float64)
+    if speed_m_s is not None:
+        recorded = float(np.linalg.norm(velocity))
+        if recorded <= 0.0:
+            raise ValueError(
+                f"sample {frame} has no velocity, so there is no direction to "
+                "rescale for the declared speed sweep"
+            )
+        velocity = velocity * (float(speed_m_s) / recorded)
+    return IntrusionState(
+        oriented.translated(position),
+        velocity,
+        angular_velocity_rad_s=kinematics.angular_velocity_rad_s,
+        reference_point_m=position,
+        free_surface_height_m=surface_m,
+    )
+
+
+def _probe(
+    f0_solver: DRFTSolver,
+    f1_solver: PlaneStrainMPMSolver,
+    state: IntrusionState,
+    *,
+    frame: int,
+    time_s: float,
+    f0_divot_section_area_m2: float,
+    f0_sole_depth_m: float,
+    declared_width_m: float,
+    bulk_density_kg_m3: float,
+) -> CrossTierProbe:
+    """Run one instant through both tiers and wrap the result."""
+    return CrossTierProbe(
+        frame=frame,
+        time_s=time_s,
+        check=cross_check_against_f0(state, f0_solver, f1_solver),
+        f0_divot_section_area_m2=f0_divot_section_area_m2,
+        f0_sole_depth_m=f0_sole_depth_m,
+        declared_width_m=declared_width_m,
+        bulk_density_kg_m3=bulk_density_kg_m3,
+    )
+
+
+def compare_tiers(
+    *,
+    f0_solver: DRFTSolver,
+    f1_solver: PlaneStrainMPMSolver,
+    build: HeadBuild,
+    result: ShotResult,
+    kinematics: HeadKinematics,
+    f0_divot_section_area_m2: ArrayLike,
+    band: ValidityBand,
+    head_mass_kg: float,
+    bulk_density_kg_m3: float,
+    n_probes: int = 4,
+    sweep_speeds_m_s: Sequence[float] = (),
+    agreement_band: float = DECLARED_AGREEMENT_BAND,
+) -> CrossTierComparison:
+    """Run F1 at chosen instants of an F0 record and assemble the comparison.
+
+    Expensive by construction, and the cost is where the honesty is: F1 has
+    no instantaneous answer, so each probe is a whole march from clear of
+    the bed to the queried pose. Four probes of a greenside shot cost of
+    order a minute at the resolution ADR-0033 specifies, which is why this
+    is not on the workbench's per-shot path.
+
+    Both solvers should be built with a permissive refusal policy. A bunker
+    shot is far outside either tier's stated envelope, and a strict policy
+    would refuse before producing anything to compare -- which is a correct
+    refusal and a useless comparison.
+
+    Args:
+        f0_solver: The F0 solver the record was produced with.
+        f1_solver: The F1 solver, carrying its declared effective width.
+        build: The lofted head.
+        result: The F0 record.
+        kinematics: The entry pose, for the constant orientation.
+        f0_divot_section_area_m2: ``(T,)`` F0's swept-envelope section per
+            sample [m^2]. Normally
+            :attr:`~.shot3d.DivotSection.section_area_m2` off the scene the
+            3-D view is drawn from, passed in rather than recomputed so the
+            comparison and that view cannot disagree about one divot.
+        band: F0's per-sample validity band, inherited unchanged.
+        head_mass_kg: The head, for the derived speed-lost integral.
+        bulk_density_kg_m3: The bed's bulk density, for both divot masses.
+        n_probes: How many engaged samples to probe.
+        sweep_speeds_m_s: Speeds for a declared sweep at the deepest
+            recorded pose. Supply these when the crossover matters: a
+            greenside shot does not decelerate through the inertial-share
+            crossing, so the shot probes alone can only report which side
+            of it the whole record sits on. Note that a *slow* probe is the
+            expensive one, not the fast one: the approach is a fixed
+            distance and the CFL step is set by the elastic wave speed, so
+            the step count goes as ``(c_p + v) / v`` and a 4 m/s probe
+            costs order thirty times a 25 m/s one.
+        agreement_band: Half-width of the agreement band on ``|ln ratio|``.
+
+    Returns:
+        The comparison.
+
+    Raises:
+        ValueError: If the record has no engaged sample, or if the divot
+            section does not describe the same record.
+    """
+    section_area = np.asarray(f0_divot_section_area_m2, dtype=np.float64).reshape(-1)
+    if section_area.size != result.n_steps:
+        raise ValueError(
+            "the divot section describes a different record: "
+            f"{section_area.size} samples against {result.n_steps}"
+        )
+    surface_m = free_surface_height_m(result)
+    depths = np.maximum(np.asarray(result.sole_depths_m, dtype=np.float64), 0.0)
+    width = f1_solver.effective_width_m
+
+    frames = probe_frames(result, n_probes)
+    shot_probes = tuple(
+        _probe(
+            f0_solver,
+            f1_solver,
+            _state_at(build, result, kinematics, frame, surface_m=surface_m),
+            frame=frame,
+            time_s=float(result.times_s[frame]),
+            f0_divot_section_area_m2=float(section_area[frame]),
+            f0_sole_depth_m=float(depths[frame]),
+            declared_width_m=width,
+            bulk_density_kg_m3=bulk_density_kg_m3,
+        )
+        for frame in frames
+    )
+
+    deepest = int(np.argmax(depths))
+    sweep_probes = tuple(
+        _probe(
+            f0_solver,
+            f1_solver,
+            _state_at(
+                build,
+                result,
+                kinematics,
+                deepest,
+                surface_m=surface_m,
+                speed_m_s=float(speed),
+            ),
+            frame=deepest,
+            time_s=float(result.times_s[deepest]),
+            f0_divot_section_area_m2=float(section_area[deepest]),
+            f0_sole_depth_m=float(depths[deepest]),
+            declared_width_m=width,
+            bulk_density_kg_m3=bulk_density_kg_m3,
+        )
+        for speed in sweep_speeds_m_s
+    )
+
+    return CrossTierComparison(
+        shot_probes=shot_probes,
+        time_s=np.asarray(result.times_s, dtype=np.float64),
+        f0_force_n=np.asarray(result.forces_n, dtype=np.float64),
+        f0_sole_depth_m=depths,
+        f0_speed_m_s=np.linalg.norm(
+            np.asarray(result.velocities_m_s, dtype=np.float64), axis=1
+        ),
+        f0_divot_section_area_m2=section_area,
+        band=band,
+        head_mass_kg=float(head_mass_kg),
+        declared_width_m=width,
+        bulk_density_kg_m3=float(bulk_density_kg_m3),
+        sweep_probes=sweep_probes,
+        agreement_band=agreement_band,
+    )

--- a/src/tools/bunker_shot_gui/bridge.py
+++ b/src/tools/bunker_shot_gui/bridge.py
@@ -790,14 +790,13 @@ def compare_tiers(
         time_s=np.asarray(result.times_s, dtype=np.float64),
         f0_force_n=np.asarray(result.forces_n, dtype=np.float64),
         f0_sole_depth_m=depths,
-        f0_speed_m_s=np.linalg.norm(
-            np.asarray(result.velocities_m_s, dtype=np.float64), axis=1
-        ),
+        f0_velocity_m_s=np.asarray(result.velocities_m_s, dtype=np.float64),
         f0_divot_section_area_m2=section_area,
         band=band,
         head_mass_kg=float(head_mass_kg),
         declared_width_m=width,
         bulk_density_kg_m3=float(bulk_density_kg_m3),
+        f1_cell_size_m=float(f1_solver.cell_size_m),
         sweep_probes=sweep_probes,
         agreement_band=agreement_band,
     )

--- a/src/tools/bunker_shot_gui/crosstier.py
+++ b/src/tools/bunker_shot_gui/crosstier.py
@@ -78,7 +78,7 @@ from .agreement import (
     QuantityAgreement,
     licence_statement,
 )
-from .traces import ValidityBand
+from .traces import ValidityBand, ValiditySpan
 
 __all__ = [
     "DECLARED_AGREEMENT_BAND",
@@ -256,7 +256,7 @@ class CrossTierProbe:
     @property
     def f1_divot_mass_kg(self) -> float:
         """F1's removed section carried to a mass at the same width."""
-        return self.check.f1_divot.displaced_mass_kg(
+        return self.check.f1_divot_mass_kg(
             width_m=self.declared_width_m,
             bulk_density_kg_m3=self.bulk_density_kg_m3,
         )
@@ -264,15 +264,15 @@ class CrossTierProbe:
     @property
     def divot_fully_resolved(self) -> bool:
         """Whether every bin of F1's free surface held sand."""
-        return self.check.f1_divot.fully_resolved
+        return self.check.f1_divot_fully_resolved
 
     def divot_caveat(self) -> str:
         """What has to be said beside F1's divot numbers, or an empty string."""
         if self.divot_fully_resolved:
             return ""
+        empty, total = self.check.f1_divot_bins
         return (
-            f"{self.check.f1_divot.n_empty_bins} of "
-            f"{self.check.f1_divot.n_bins} surface bins held no sand at "
+            f"{empty} of {total} surface bins held no sand at "
             f"{self.time_s * 1e3:.2f} ms, so F1's divot section is a lower bound"
         )
 
@@ -558,6 +558,24 @@ class CrossTierComparison:
     def worst_status(self) -> EnvelopeStatus:
         """The worst verdict anywhere in the record, inherited from F0."""
         return self.band.worst
+
+    def status_at(self, frame: int) -> EnvelopeStatus:
+        """The verdict the numbers at one sample must be read under.
+
+        Args:
+            frame: The sample index.
+
+        Returns:
+            The verdict, straight from F0's band. Nothing here improves it.
+
+        Raises:
+            ValueError: If the index is outside the record.
+        """
+        return self.band.status_at(frame)
+
+    def validity_spans(self) -> tuple[ValiditySpan, ...]:
+        """The contiguous stretches of one verdict, for shading the panels."""
+        return self.band.spans()
 
     @property
     def f0_force_magnitude_n(self) -> NDArray[np.float64]:

--- a/src/tools/bunker_shot_gui/crosstier.py
+++ b/src/tools/bunker_shot_gui/crosstier.py
@@ -1,0 +1,911 @@
+"""F0 against F1 on the quantities both produce (issue #8713, epic #8699).
+
+This module computes; it draws nothing. No Qt, no matplotlib, in keeping
+with the split the workbench established in issue #8618.
+
+What the comparison is for
+--------------------------
+
+Track B's field pictures come from a tier that cannot be validated against
+reality at true scale. What it *can* be is checked for consistency against
+F0 on the quantities both tiers produce -- and where the two disagree, that
+disagreement is the most useful output in the epic, because it localises
+where F0's constitutive shortcut stops describing the physics.
+
+So the arithmetic here is built to surface divergence rather than to
+average it away. Every compared quantity carries a ratio and a verdict on
+that ratio against a **declared** band; stretches of the record where the
+two part company become :class:`DivergenceSpan` objects a renderer can
+shade; and the sharpest single result -- the crossing of F0's inertial
+share and F1's momentum-flux share -- is located by interpolation and
+reported with its mechanism rather than as a number on its own.
+
+What agreement licenses, and what it does not
+---------------------------------------------
+
+Nothing here is validation. ADR-0033 states it plainly and
+:func:`licence_statement` restates it inside every view built on this
+module, computed from :mod:`bunkershot3d.vandv.credibility` and the
+solver's own envelope constants rather than quoted, so the sentence cannot
+drift away from the code. Two uncalibrated models agreeing is two
+uncalibrated models agreeing. The comparison can **falsify** -- a
+disagreement beyond the declared band means at least one tier is wrong --
+and that asymmetry is the whole of its value.
+
+What F1 could not be asked
+--------------------------
+
+F1's :meth:`~bunkershot3d.solvers.mpm.solver.PlaneStrainMPMSolver.solve`
+answers an *instantaneous* query by building a declared straight-line
+constant-speed approach to the queried pose, and raises on a static one;
+whole-shot marching is deferred to issue #8733. So there is no F1 force
+*history* to overlay on F0's. What there is instead is a set of probes:
+individual instants along F0's record, each handed to both tiers unchanged,
+each conditional on its own declared approach. The view draws them as
+points on F0's continuous curve, and says so. Two consequences follow and
+both are carried explicitly rather than hidden:
+
+* **Speed lost** is F0's alone. F1's section is driven kinematically, so it
+  loses no speed at all. What is reported is what F1's force *would* have
+  removed from the same head over the same window -- one-way coupled, since
+  F1 was never asked what the slower head would have done.
+* **The divot** is not the same measurement on the two sides. F0 moves no
+  sand, so its divot is the swept lower envelope of the head; F1's is where
+  the sand actually ended up. Comparing them is worth doing and is not a
+  like-for-like check, so :attr:`ComparedQuantity.note` says which is which
+  wherever the number is drawn.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from bunkershot3d.solvers import EnvelopeStatus, FidelityTier
+from bunkershot3d.solvers.envelope import MAX_VALIDATED_SPEED_M_S
+from bunkershot3d.solvers.mpm.verification import F0CrossCheck
+from bunkershot3d.vandv.credibility import envelope_exceedance
+
+from .agreement import (
+    DECLARED_AGREEMENT_BAND,
+    AgreementClass,
+    ComparedQuantity,
+    DivergenceSpan,
+    QuantityAgreement,
+    licence_statement,
+)
+from .traces import ValidityBand
+
+__all__ = [
+    "DECLARED_AGREEMENT_BAND",
+    "AgreementClass",
+    "ComparedQuantity",
+    "CrossTierComparison",
+    "CrossTierProbe",
+    "DivergenceSpan",
+    "InertialCrossover",
+    "QuantityAgreement",
+    "inertial_share_crossover",
+    "licence_statement",
+]
+"""Re-exported from :mod:`~src.tools.bunker_shot_gui.agreement` so a caller
+comparing two tiers has one import site rather than two."""
+
+_STAMP_MAX_CHARS = 240
+
+
+@dataclass(frozen=True)
+class CrossTierProbe:
+    """One instant, handed to both tiers unchanged.
+
+    The F0 half is the tier's answer at the recorded pose, which is the
+    same query :func:`~bunkershot3d.solvers.shot.simulate_shot` solved at
+    that sample. The F1 half is a whole march: F1 has no instantaneous
+    answer, so it reverses the section along its own velocity until it is
+    clear of the bed and drives it back at constant speed. That declared
+    approach is the modelling assumption the F1 number rests on, and it is
+    what makes the two comparable at all.
+
+    Attributes:
+        frame: Index into the F0 record this probe was taken at. Zero for a
+            probe from a declared speed sweep, which indexes no record.
+        time_s: The moment [s].
+        check: The paired result, from the F1 package's own cross-check.
+        f0_divot_section_area_m2: F0's swept-envelope section at this
+            sample [m^2].
+        f0_sole_depth_m: F0's sole depth at this sample [m].
+        declared_width_m: The out-of-plane width **both** divot masses are
+            formed at, so the mass comparison rests on one assumption
+            rather than two.
+        bulk_density_kg_m3: The bed's bulk density, for the same masses.
+    """
+
+    frame: int
+    time_s: float
+    check: F0CrossCheck
+    f0_divot_section_area_m2: float
+    f0_sole_depth_m: float
+    declared_width_m: float
+    bulk_density_kg_m3: float
+
+    def __post_init__(self) -> None:
+        """Validate the probe.
+
+        Raises:
+            ValueError: If the frame is negative, the time is not finite,
+                or a declared width or density is not positive.
+        """
+        if int(self.frame) < 0:
+            raise ValueError(f"frame must be non-negative, got {self.frame!r}")
+        if not math.isfinite(self.time_s):
+            raise ValueError(f"time_s must be finite, got {self.time_s!r}")
+        for name, value in (
+            ("declared_width_m", self.declared_width_m),
+            ("bulk_density_kg_m3", self.bulk_density_kg_m3),
+            ("f0_divot_section_area_m2", self.f0_divot_section_area_m2),
+            ("f0_sole_depth_m", self.f0_sole_depth_m),
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(
+                    f"{name} must be finite and non-negative, got {value!r}"
+                )
+        if self.declared_width_m <= 0.0 or self.bulk_density_kg_m3 <= 0.0:
+            raise ValueError(
+                "a divot mass needs a positive declared width and density; "
+                f"got {self.declared_width_m!r} m and "
+                f"{self.bulk_density_kg_m3!r} kg/m^3"
+            )
+
+    # ------------------------------------------------------------- readings
+
+    @property
+    def speed_m_s(self) -> float:
+        """Intrusion speed the pair was run at [m/s]."""
+        return self.check.speed_m_s
+
+    @property
+    def f0_force_magnitude_n(self) -> float:
+        """``|F0|`` [N]."""
+        return float(np.linalg.norm(self.check.f0_force_n))
+
+    @property
+    def f1_force_magnitude_n(self) -> float:
+        """``|F1|`` [N], at the declared effective width."""
+        return float(np.linalg.norm(self.check.f1_force_n))
+
+    @property
+    def direction_agreement(self) -> float:
+        """Cosine between the two resultants.
+
+        The one number in the comparison that does not depend on the
+        declared width at all, and therefore the one that is not
+        conditional on a modelling assumption.
+        """
+        return self.check.direction_agreement
+
+    @property
+    def f0_inertial_fraction(self) -> float:
+        """Share of F0's force carried by its ``lambda rho v_n^2`` term."""
+        return self.check.f0_inertial_fraction
+
+    @property
+    def f1_flux_fraction(self) -> float:
+        """Share of F1's reaction carried by momentum flux."""
+        return self.check.f1_flux_fraction
+
+    @property
+    def inertial_share_gap(self) -> float:
+        """F0's inertial share minus F1's flux share.
+
+        Negative below the crossover, positive above it. The sign change is
+        the sharpest single result in the comparison; see
+        :func:`inertial_share_crossover`.
+        """
+        return self.f0_inertial_fraction - self.f1_flux_fraction
+
+    @property
+    def submerged_depth_m(self) -> float:
+        """Deepest submerged element of the shared query [m].
+
+        The depth **both** tiers were handed, read off the geometry. The
+        compared depth row uses this rather than either tier's own
+        ``SolverResult.max_depth_m``, because those two fields do not mean
+        the same thing across the tiers -- see
+        :attr:`~bunkershot3d.solvers.mpm.verification.F0CrossCheck.submerged_depth_m`.
+        """
+        return self.check.submerged_depth_m
+
+    @property
+    def f0_engaged_depth_m(self) -> float:
+        """F0's deepest **engaged** element [m] -- a contact diagnostic.
+
+        Reported beside the compared depth rather than as it. On a lofted
+        head most elements never lead, so this runs far shallower than the
+        geometry; issue #8701 is the history of that distinction being
+        conflated once already.
+        """
+        return self.check.f0_max_depth_m
+
+    @property
+    def f1_divot_section_area_m2(self) -> float:
+        """Section of sand F1 removed from below the original surface [m^2]."""
+        return self.check.f1_divot_section_area_m2
+
+    @property
+    def f0_divot_mass_kg(self) -> float:
+        """F0's swept section carried to a mass at the declared width."""
+        return (
+            self.f0_divot_section_area_m2
+            * self.declared_width_m
+            * self.bulk_density_kg_m3
+        )
+
+    @property
+    def f1_divot_mass_kg(self) -> float:
+        """F1's removed section carried to a mass at the same width."""
+        return self.check.f1_divot.displaced_mass_kg(
+            width_m=self.declared_width_m,
+            bulk_density_kg_m3=self.bulk_density_kg_m3,
+        )
+
+    @property
+    def divot_fully_resolved(self) -> bool:
+        """Whether every bin of F1's free surface held sand."""
+        return self.check.f1_divot.fully_resolved
+
+    def divot_caveat(self) -> str:
+        """What has to be said beside F1's divot numbers, or an empty string."""
+        if self.divot_fully_resolved:
+            return ""
+        return (
+            f"{self.check.f1_divot.n_empty_bins} of "
+            f"{self.check.f1_divot.n_bins} surface bins held no sand at "
+            f"{self.time_s * 1e3:.2f} ms, so F1's divot section is a lower bound"
+        )
+
+    # ------------------------------------------------------------ agreement
+
+    def agreement(
+        self, quantity: ComparedQuantity, *, band: float = DECLARED_AGREEMENT_BAND
+    ) -> QuantityAgreement:
+        """Compare one instantaneous quantity at this probe.
+
+        Args:
+            quantity: Which quantity.
+            band: Half-width of the agreement band on ``|ln ratio|``.
+
+        Returns:
+            The agreement.
+
+        Raises:
+            ValueError: If asked for :attr:`ComparedQuantity.SPEED_LOST`,
+                which is a window integral and has no value at an instant.
+                Returning zero, or the instantaneous force, would put a
+                number in a row that has no meaning here.
+        """
+        if quantity is ComparedQuantity.SPEED_LOST:
+            raise ValueError(
+                "speed lost is measured over a window, not at an instant; ask "
+                "the comparison, which owns the probed window"
+            )
+        pairs = {
+            ComparedQuantity.WRENCH: (
+                self.f0_force_magnitude_n,
+                self.f1_force_magnitude_n,
+            ),
+            ComparedQuantity.SOLE_DEPTH: (
+                self.check.submerged_depth_m,
+                self.check.f1_max_depth_m,
+            ),
+            ComparedQuantity.DIVOT_SECTION: (
+                self.f0_divot_section_area_m2,
+                self.f1_divot_section_area_m2,
+            ),
+            ComparedQuantity.DIVOT_MASS: (
+                self.f0_divot_mass_kg,
+                self.f1_divot_mass_kg,
+            ),
+        }
+        f0_value, f1_value = pairs[quantity]
+        return QuantityAgreement(
+            quantity=quantity, f0_value=f0_value, f1_value=f1_value, band=band
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InertialCrossover:
+    """Where F0's inertial share crosses F1's momentum-flux share.
+
+    The sharpest single result the comparison produces, because the two
+    shares diverge *by construction* rather than by numerical accident:
+    F0's ``lambda rho v_n^2`` term grows quadratically with nothing to
+    bound it, while the continuum's reaction is limited by how fast the
+    yield surface lets sand be accelerated out of the way. Below the
+    crossing F0 attributes less of its force to inertia than the continuum
+    does; above it, more, and the gap keeps widening.
+
+    Attributes:
+        speed_m_s: Intrusion speed at which the two shares are equal.
+        shared_share: The share both tiers report there.
+        lower_speed_m_s: Speed of the probe below the crossing.
+        upper_speed_m_s: Speed of the probe above it.
+        time_s: The moment, when the crossing was bracketed along a shot
+            rather than a declared speed sweep; ``None`` otherwise.
+    """
+
+    speed_m_s: float
+    shared_share: float
+    lower_speed_m_s: float
+    upper_speed_m_s: float
+    time_s: float | None = None
+
+    def summary(self) -> str:
+        """The sentence the crossover panel is captioned with."""
+        moment = "" if self.time_s is None else f" ({self.time_s * 1e3:.2f} ms)"
+        return (
+            f"F0's inertial share crosses F1's momentum-flux share at "
+            f"{self.speed_m_s:.3g} m/s{moment}, both at "
+            f"{self.shared_share:.2f}, bracketed between "
+            f"{self.lower_speed_m_s:.3g} and {self.upper_speed_m_s:.3g} m/s. "
+            "Below it F0 credits less of its force to inertia than the "
+            "continuum does; above it, more, and the gap widens with speed "
+            "because F0's dynamic term is unbounded in v while the "
+            "continuum's reaction is limited by how fast the yield surface "
+            "lets sand accelerate out of the way"
+        )
+
+
+def inertial_share_crossover(
+    probes: Sequence[CrossTierProbe],
+) -> InertialCrossover | None:
+    """Locate the crossing of the two inertial shares, or report none.
+
+    Linear interpolation between the two probes that bracket the sign
+    change of :attr:`CrossTierProbe.inertial_share_gap`. Nothing is
+    extrapolated: a probe set that never brackets the crossing returns
+    ``None`` rather than a number invented outside its own range.
+
+    Args:
+        probes: Probes, in any order; they are sorted by speed here.
+
+    Returns:
+        The crossing, or ``None`` when the probed range does not contain
+        one.
+    """
+    ordered = sorted(probes, key=lambda item: item.speed_m_s)
+    for lower, upper in zip(ordered, ordered[1:], strict=False):
+        low_gap = lower.inertial_share_gap
+        high_gap = upper.inertial_share_gap
+        if low_gap == high_gap or (low_gap > 0.0) == (high_gap > 0.0):
+            continue
+        span = upper.speed_m_s - lower.speed_m_s
+        fraction = low_gap / (low_gap - high_gap)
+        share = lower.f0_inertial_fraction + fraction * (
+            upper.f0_inertial_fraction - lower.f0_inertial_fraction
+        )
+        moment = (
+            lower.time_s + fraction * (upper.time_s - lower.time_s)
+            if lower.time_s != upper.time_s
+            else None
+        )
+        return InertialCrossover(
+            speed_m_s=lower.speed_m_s + fraction * span,
+            shared_share=float(share),
+            lower_speed_m_s=lower.speed_m_s,
+            upper_speed_m_s=upper.speed_m_s,
+            time_s=moment,
+        )
+    return None
+
+
+@dataclass(frozen=True)
+class CrossTierComparison:
+    """F0's record, F1's probes on it, and where the two part company.
+
+    Attributes:
+        shot_probes: Probes taken along the F0 record, on the shared
+            cursor. At least one is required.
+        time_s: ``(T,)`` F0's own sample times [s] -- the axis the
+            workbench's single transport scrubs.
+        f0_force_n: ``(T, 3)`` sand force on the head [N].
+        f0_sole_depth_m: ``(T,)`` sole depth below the free surface [m].
+        f0_speed_m_s: ``(T,)`` head speed [m/s].
+        f0_divot_section_area_m2: ``(T,)`` swept-envelope section [m^2].
+        band: F0's per-sample validity band, inherited unchanged. Nothing
+            here improves it.
+        head_mass_kg: The head, for the derived speed-lost integral.
+        declared_width_m: The out-of-plane width both divot masses use.
+        bulk_density_kg_m3: The bed's bulk density, for the same masses.
+        sweep_probes: Probes from a **declared speed sweep** at a fixed
+            pose, which is a separate experiment from the shot and is
+            labelled as one. Present so the inertial-share crossover can be
+            bracketed even when the shot itself never slows through it --
+            a greenside delivery does not.
+        agreement_band: Half-width of the agreement band on ``|ln ratio|``.
+    """
+
+    shot_probes: tuple[CrossTierProbe, ...]
+    time_s: NDArray[np.float64]
+    f0_force_n: NDArray[np.float64]
+    f0_sole_depth_m: NDArray[np.float64]
+    f0_speed_m_s: NDArray[np.float64]
+    f0_divot_section_area_m2: NDArray[np.float64]
+    band: ValidityBand
+    head_mass_kg: float
+    declared_width_m: float
+    bulk_density_kg_m3: float
+    sweep_probes: tuple[CrossTierProbe, ...] = ()
+    agreement_band: float = DECLARED_AGREEMENT_BAND
+
+    def __post_init__(self) -> None:
+        """Validate the comparison against the record it is drawn on.
+
+        Raises:
+            ValueError: If there are no probes, if any array disagrees with
+                the time axis, if a probe indexes outside the record, or if
+                a probe's own time disagrees with the sample it names. The
+                last is the important one: a probe drawn at the wrong
+                moment is worse than a missing probe, because it looks like
+                a measurement of a moment it did not measure.
+        """
+        probes = tuple(self.shot_probes)
+        if not probes:
+            raise ValueError(
+                "a cross-tier comparison needs at least one probe; an empty "
+                "overlay would read as two tiers that were never compared"
+            )
+        times = np.asarray(self.time_s, dtype=np.float64).reshape(-1)
+        if times.size < 2:
+            raise ValueError(
+                f"the F0 record needs at least 2 samples, got {times.size}"
+            )
+        if np.any(np.diff(times) <= 0.0):
+            raise ValueError("time_s must be strictly increasing")
+        forces = np.asarray(self.f0_force_n, dtype=np.float64)
+        if forces.shape != (times.size, 3):
+            raise ValueError(
+                f"f0_force_n must have shape {(times.size, 3)}, got {forces.shape}"
+            )
+        columns = {
+            "f0_sole_depth_m": np.asarray(self.f0_sole_depth_m, dtype=np.float64),
+            "f0_speed_m_s": np.asarray(self.f0_speed_m_s, dtype=np.float64),
+            "f0_divot_section_area_m2": np.asarray(
+                self.f0_divot_section_area_m2, dtype=np.float64
+            ),
+        }
+        for name, column in columns.items():
+            if column.shape != (times.size,):
+                raise ValueError(
+                    f"{name} must have shape {(times.size,)}, got {column.shape}"
+                )
+        if self.band.n_frames != times.size:
+            raise ValueError(
+                "the validity band describes a different record: "
+                f"{self.band.n_frames} samples against {times.size}"
+            )
+        for probe in probes:
+            if not 0 <= probe.frame < times.size:
+                raise ValueError(
+                    f"probe frame {probe.frame} is outside the F0 record, which "
+                    f"has {times.size} samples"
+                )
+            if not math.isclose(
+                probe.time_s, float(times[probe.frame]), rel_tol=0.0, abs_tol=1e-9
+            ):
+                raise ValueError(
+                    f"probe at frame {probe.frame} carries t="
+                    f"{probe.time_s * 1e3:.4f} ms while that sample is at "
+                    f"t={float(times[probe.frame]) * 1e3:.4f} ms; a probe drawn "
+                    "at the wrong moment reads as a measurement of a moment it "
+                    "did not measure"
+                )
+        for name, value in (
+            ("head_mass_kg", self.head_mass_kg),
+            ("declared_width_m", self.declared_width_m),
+            ("bulk_density_kg_m3", self.bulk_density_kg_m3),
+            ("agreement_band", self.agreement_band),
+        ):
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be positive, got {value!r}")
+        object.__setattr__(self, "shot_probes", probes)
+        object.__setattr__(self, "sweep_probes", tuple(self.sweep_probes))
+        object.__setattr__(self, "time_s", times)
+        object.__setattr__(self, "f0_force_n", forces)
+        for name, column in columns.items():
+            object.__setattr__(self, name, column)
+
+    # ------------------------------------------------------------ the record
+
+    @property
+    def n_frames(self) -> int:
+        """Samples in the F0 record."""
+        return int(self.time_s.size)
+
+    @property
+    def n_probes(self) -> int:
+        """Probes taken along it."""
+        return len(self.shot_probes)
+
+    @property
+    def tiers(self) -> tuple[FidelityTier, FidelityTier]:
+        """The pair being compared, in the order every readout names them."""
+        return (FidelityTier.F0, FidelityTier.F1)
+
+    @property
+    def worst_status(self) -> EnvelopeStatus:
+        """The worst verdict anywhere in the record, inherited from F0."""
+        return self.band.worst
+
+    @property
+    def f0_force_magnitude_n(self) -> NDArray[np.float64]:
+        """``(T,)`` resultant magnitude of F0's recorded force [N]."""
+        return np.linalg.norm(self.f0_force_n, axis=1)
+
+    @property
+    def probe_frames(self) -> tuple[int, ...]:
+        """Sample indices the probes sit on."""
+        return tuple(probe.frame for probe in self.shot_probes)
+
+    @property
+    def probe_times_s(self) -> tuple[float, ...]:
+        """Moments the probes sit at [s]."""
+        return tuple(probe.time_s for probe in self.shot_probes)
+
+    @property
+    def probe_speeds_m_s(self) -> tuple[float, ...]:
+        """Intrusion speeds the probes were run at [m/s]."""
+        return tuple(probe.speed_m_s for probe in self.shot_probes)
+
+    @property
+    def peak_probe(self) -> CrossTierProbe:
+        """The probe at which F0's own force was largest.
+
+        The shot-level agreement is quoted here rather than averaged over
+        the probes, because a mean over a window that is mostly free flight
+        would report a divergence smaller than the one at the moment a
+        designer is looking at.
+        """
+        return max(self.shot_probes, key=lambda probe: probe.f0_force_magnitude_n)
+
+    def probe_values(
+        self, quantity: ComparedQuantity
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """``(f0, f1)`` values of one instantaneous quantity at every probe.
+
+        Args:
+            quantity: Which quantity.
+
+        Returns:
+            Two ``(n_probes,)`` arrays, in SI.
+
+        Raises:
+            ValueError: For :attr:`ComparedQuantity.SPEED_LOST`, which has
+                no per-probe value.
+        """
+        pairs = [
+            probe.agreement(quantity, band=self.agreement_band)
+            for probe in self.shot_probes
+        ]
+        return (
+            np.array([item.f0_value for item in pairs]),
+            np.array([item.f1_value for item in pairs]),
+        )
+
+    # ---------------------------------------------------------- speed lost
+
+    @property
+    def probe_window(self) -> tuple[int, int]:
+        """``(first, last)`` sample indices the probes bracket.
+
+        Raises:
+            ValueError: If there is only one probe, so there is no window.
+        """
+        frames = self.probe_frames
+        if len(set(frames)) < 2:
+            raise ValueError(
+                "speed lost is measured over the window the probes bracket, and "
+                f"{len(frames)} probe(s) at {sorted(set(frames))} bracket none; "
+                "probe at least two distinct samples"
+            )
+        return (min(frames), max(frames))
+
+    @property
+    def f0_speed_lost_m_s(self) -> float:
+        """Speed F0's own record shows the head losing over the probed window."""
+        first, last = self.probe_window
+        return float(self.f0_speed_m_s[first] - self.f0_speed_m_s[last])
+
+    @property
+    def f1_speed_lost_m_s(self) -> float:
+        """What F1's force would have taken off the same head, same window.
+
+        F0's own per-sample speed decrements, each weighted by the
+        ``|F1| / |F0|`` ratio interpolated onto that sample from the
+        probes. Doing it this way rather than integrating F1's force
+        directly is deliberate: the two tiers' resultants do not point the
+        same way -- the measured direction cosines run 0.65 to 0.87 -- so
+        borrowing F1's *magnitude* while keeping F0's direction states
+        exactly what is and is not being taken from the field tier.
+
+        One-way coupled, and that is not a detail: F1 was queried at the
+        poses and speeds F0's head actually reached, so this is what F1's
+        force would have removed from a head that never slowed down more
+        than F0 says it did.
+        """
+        first, last = self.probe_window
+        ratio = self._probe_ratio_on_record()
+        # Trapezoidal: each interval is weighted by the mean of the ratio at
+        # its two ends, not by the ratio at its start, so a ratio that
+        # varies across the window is not biased towards its opening value.
+        interval = 0.5 * (ratio[first:last] + ratio[first + 1 : last + 1])
+        decrement = -np.diff(self.f0_speed_m_s[first : last + 1])
+        return float((interval * decrement).sum())
+
+    def f1_implied_speed_m_s(self) -> NDArray[np.float64]:
+        """``(T,)`` the speed history F1's force implies, over the probed window.
+
+        Starts from F0's own speed at the first probe and removes the
+        ratio-weighted decrements of :attr:`f1_speed_lost_m_s`, so the two
+        curves leave the same point and the gap between them at the end is
+        exactly the disagreement in speed lost. ``nan`` outside the probed
+        window, because outside it nothing was compared and a continued
+        line would assert a comparison that was never made.
+
+        Returns:
+            The implied speed [m/s].
+
+        Raises:
+            ValueError: If the probes bracket no window.
+        """
+        first, last = self.probe_window
+        ratio = self._probe_ratio_on_record()
+        interval = 0.5 * (ratio[first:last] + ratio[first + 1 : last + 1])
+        decrement = -np.diff(self.f0_speed_m_s[first : last + 1])
+        implied = np.full(self.n_frames, np.nan)
+        implied[first] = self.f0_speed_m_s[first]
+        implied[first + 1 : last + 1] = self.f0_speed_m_s[first] - np.cumsum(
+            interval * decrement
+        )
+        return implied
+
+    def _probe_ratio_on_record(self) -> NDArray[np.float64]:
+        """``(T,)`` the ``|F1| / |F0|`` ratio interpolated onto F0's axis."""
+        frames = np.array(self.probe_frames, dtype=np.float64)
+        ratios = np.array(
+            [
+                probe.f1_force_magnitude_n / probe.f0_force_magnitude_n
+                if probe.f0_force_magnitude_n > 0.0
+                else np.nan
+                for probe in self.shot_probes
+            ]
+        )
+        order = np.argsort(frames)
+        return np.interp(
+            np.arange(self.n_frames, dtype=np.float64),
+            frames[order],
+            ratios[order],
+        )
+
+    # ----------------------------------------------------------- agreement
+
+    def agreement(self, quantity: ComparedQuantity) -> QuantityAgreement:
+        """The shot-level agreement on one quantity.
+
+        Args:
+            quantity: Which quantity.
+
+        Returns:
+            The agreement. Instantaneous quantities are quoted at
+            :attr:`peak_probe`; speed lost is the window integral.
+
+        Raises:
+            ValueError: If speed lost is asked for and the probes bracket
+                no window.
+        """
+        if quantity is ComparedQuantity.SPEED_LOST:
+            return QuantityAgreement(
+                quantity=quantity,
+                f0_value=max(self.f0_speed_lost_m_s, 0.0),
+                f1_value=max(self.f1_speed_lost_m_s, 0.0),
+                band=self.agreement_band,
+            )
+        return self.peak_probe.agreement(quantity, band=self.agreement_band)
+
+    def agreements(self) -> tuple[QuantityAgreement, ...]:
+        """Every quantity that could be compared, in reporting order.
+
+        Speed lost is omitted rather than faked when fewer than two
+        distinct samples were probed.
+        """
+        results: list[QuantityAgreement] = []
+        for quantity in ComparedQuantity:
+            try:
+                results.append(self.agreement(quantity))
+            except ValueError:
+                continue
+        return tuple(results)
+
+    def agreement_series(
+        self, quantity: ComparedQuantity
+    ) -> tuple[QuantityAgreement, ...]:
+        """One agreement per probe, in record order."""
+        return tuple(
+            probe.agreement(quantity, band=self.agreement_band)
+            for probe in sorted(self.shot_probes, key=lambda item: item.frame)
+        )
+
+    def divergence_spans(
+        self, quantity: ComparedQuantity
+    ) -> tuple[DivergenceSpan, ...]:
+        """Stretches of the record over which one quantity left the band.
+
+        A run of consecutive divergent probes spans from the first to the
+        last of them. A **lone** divergent probe is widened to the midpoints
+        of its neighbours, so a single instant of disagreement is still
+        visible when it is shaded rather than collapsing to a zero-width
+        line nobody can see.
+
+        Args:
+            quantity: Which quantity to scan.
+
+        Returns:
+            The spans, in time order.
+        """
+        ordered = sorted(self.shot_probes, key=lambda item: item.frame)
+        flags = [
+            probe.agreement(quantity, band=self.agreement_band).diverged
+            for probe in ordered
+        ]
+        spans: list[DivergenceSpan] = []
+        start: int | None = None
+        for index in range(len(ordered) + 1):
+            live = index < len(ordered) and flags[index]
+            if live and start is None:
+                start = index
+            elif not live and start is not None:
+                spans.append(self._span(quantity, ordered, start, index - 1))
+                start = None
+        return tuple(spans)
+
+    def _span(
+        self,
+        quantity: ComparedQuantity,
+        ordered: list[CrossTierProbe],
+        first: int,
+        last: int,
+    ) -> DivergenceSpan:
+        """Build one span from a run of divergent probes."""
+        start_s = ordered[first].time_s
+        end_s = ordered[last].time_s
+        if first == last:
+            before = ordered[first - 1].time_s if first > 0 else float(self.time_s[0])
+            after = (
+                ordered[last + 1].time_s
+                if last + 1 < len(ordered)
+                else float(self.time_s[-1])
+            )
+            start_s = 0.5 * (before + start_s)
+            end_s = 0.5 * (end_s + after)
+        ratios = [
+            ordered[index].agreement(quantity, band=self.agreement_band).ratio
+            for index in range(first, last + 1)
+        ]
+        finite = [value for value in ratios if math.isfinite(value)]
+        worst = (
+            max(finite, key=lambda value: abs(math.log(value)) if value > 0.0 else 0.0)
+            if finite
+            else math.nan
+        )
+        return DivergenceSpan(
+            quantity=quantity,
+            start_s=start_s,
+            end_s=end_s,
+            worst_ratio=worst,
+            n_probes=last - first + 1,
+        )
+
+    # ----------------------------------------------------------- crossover
+
+    @property
+    def crossover_probes(self) -> tuple[CrossTierProbe, ...]:
+        """Which probe set the crossover is read from.
+
+        The declared speed sweep when there is one, because a greenside
+        shot does not slow through the crossing and the shot probes alone
+        would report only that the whole record sits above it.
+        """
+        return self.sweep_probes or self.shot_probes
+
+    def crossover(self) -> InertialCrossover | None:
+        """Locate the inertial-share crossing, or ``None`` if unbracketed."""
+        return inertial_share_crossover(self.crossover_probes)
+
+    def crossover_summary(self) -> str:
+        """State the crossing either way, since "not here" is also a result."""
+        crossing = self.crossover()
+        if crossing is not None:
+            return crossing.summary()
+        probes = sorted(self.crossover_probes, key=lambda item: item.speed_m_s)
+        gaps = [probe.inertial_share_gap for probe in probes]
+        side = "above" if gaps and gaps[0] > 0.0 else "below"
+        f0_range = (
+            f"{probes[0].f0_inertial_fraction:.2f}-"
+            f"{probes[-1].f0_inertial_fraction:.2f}"
+        )
+        f1_range = f"{probes[0].f1_flux_fraction:.2f}-{probes[-1].f1_flux_fraction:.2f}"
+        return (
+            f"No crossing inside the probed range: every probe sits {side} it. "
+            f"Over {probes[0].speed_m_s:.3g}-{probes[-1].speed_m_s:.3g} m/s, F0 "
+            f"credits {f0_range} of its force to its dynamic term while F1 "
+            f"credits {f1_range} to momentum flux. F0's term grows "
+            "quadratically in speed with nothing to bound it; the continuum's "
+            "reaction is limited by how fast the yield surface lets sand "
+            "accelerate out of the way, so the two disagree by construction in "
+            "exactly this regime"
+        )
+
+    # ------------------------------------------------------------- licence
+
+    def licence(self) -> str:
+        """What agreement on this page does and does not license."""
+        return licence_statement(
+            speed_m_s=float(self.f0_speed_m_s.max()),
+            effective_width_m=self.peak_probe.check.effective_width_m,
+        )
+
+    def licence_stamp(self) -> str:
+        """The short form, for an in-frame stamp beside the validity verdict."""
+        exceedance = envelope_exceedance(speed_m_s=float(self.f0_speed_m_s.max()))
+        text = (
+            "F0 vs F1 consistency check, not validation: two uncalibrated "
+            "models, NASA-STD-7009B validation 0 of 4, "
+            f"{exceedance.speed_exceedance:.0f}x past the "
+            f"{MAX_VALIDATED_SPEED_M_S:g} m/s published ceiling"
+        )
+        return text[:_STAMP_MAX_CHARS]
+
+    def summary(self) -> str:
+        """The whole comparison as text, licence first.
+
+        Returns:
+            The block a report or a headless run prints. The licence comes
+            first on purpose: a reader who stops after one paragraph should
+            have read the caveat rather than the ratios.
+        """
+        rows = "\n".join(f"  {item.summary()}" for item in self.agreements())
+        caveats = [
+            probe.divot_caveat() for probe in self.shot_probes if probe.divot_caveat()
+        ]
+        spans = [
+            span.label
+            for quantity in ComparedQuantity
+            for span in self._safe_spans(quantity)
+        ]
+        parts = [
+            self.licence(),
+            "",
+            f"Probed {self.n_probes} instant(s) of a {self.n_frames}-sample F0 "
+            f"record; each F1 point is its own march to that pose under a "
+            f"declared straight-line approach, not a marched shot (issue #8733).",
+            "",
+            "Agreement, quantity by quantity:",
+            rows,
+            "",
+            self.crossover_summary(),
+        ]
+        if spans:
+            parts += ["", "Divergence:", "\n".join(f"  {line}" for line in spans)]
+        if caveats:
+            parts += ["", "Caveats:", "\n".join(f"  {line}" for line in caveats)]
+        return "\n".join(parts)
+
+    def _safe_spans(self, quantity: ComparedQuantity) -> tuple[DivergenceSpan, ...]:
+        """Spans for one quantity, or none when it cannot be compared."""
+        try:
+            return self.divergence_spans(quantity)
+        except ValueError:
+            return ()

--- a/src/tools/bunker_shot_gui/crosstier.py
+++ b/src/tools/bunker_shot_gui/crosstier.py
@@ -97,6 +97,15 @@ comparing two tiers has one import site rather than two."""
 
 _STAMP_MAX_CHARS = 240
 
+_ADR_BULK_RESOLUTION_M = (0.001, 0.002)
+"""The cell-size band ADR-0033 specifies for the F1 tier."""
+
+_TIER_F0 = "f0"
+_TIER_F1 = "f1"
+
+_GRAZING_FRACTION = 0.05
+"""Below this share of the peak, F0's force is its engagement criterion."""
+
 
 @dataclass(frozen=True)
 class CrossTierProbe:
@@ -413,13 +422,19 @@ class CrossTierComparison:
             workbench's single transport scrubs.
         f0_force_n: ``(T, 3)`` sand force on the head [N].
         f0_sole_depth_m: ``(T,)`` sole depth below the free surface [m].
-        f0_speed_m_s: ``(T,)`` head speed [m/s].
+        f0_velocity_m_s: ``(T, 3)`` head velocity [m/s]. The vector, not
+            the speed, because the compared speed-lost quantity is each
+            tier's resultant *projected on the direction of travel*.
         f0_divot_section_area_m2: ``(T,)`` swept-envelope section [m^2].
         band: F0's per-sample validity band, inherited unchanged. Nothing
             here improves it.
         head_mass_kg: The head, for the derived speed-lost integral.
         declared_width_m: The out-of-plane width both divot masses use.
         bulk_density_kg_m3: The bed's bulk density, for the same masses.
+        f1_cell_size_m: The grid F1 was solved on [m]. Carried because it
+            is provenance, not a setting: ADR-0033 specifies bulk
+            resolution of 1-2 mm, and a comparison run coarser than that
+            has to say so in the picture rather than in whoever ran it.
         sweep_probes: Probes from a **declared speed sweep** at a fixed
             pose, which is a separate experiment from the shot and is
             labelled as one. Present so the inertial-share crossover can be
@@ -432,12 +447,13 @@ class CrossTierComparison:
     time_s: NDArray[np.float64]
     f0_force_n: NDArray[np.float64]
     f0_sole_depth_m: NDArray[np.float64]
-    f0_speed_m_s: NDArray[np.float64]
+    f0_velocity_m_s: NDArray[np.float64]
     f0_divot_section_area_m2: NDArray[np.float64]
     band: ValidityBand
     head_mass_kg: float
     declared_width_m: float
     bulk_density_kg_m3: float
+    f1_cell_size_m: float
     sweep_probes: tuple[CrossTierProbe, ...] = ()
     agreement_band: float = DECLARED_AGREEMENT_BAND
 
@@ -466,13 +482,14 @@ class CrossTierComparison:
         if np.any(np.diff(times) <= 0.0):
             raise ValueError("time_s must be strictly increasing")
         forces = np.asarray(self.f0_force_n, dtype=np.float64)
-        if forces.shape != (times.size, 3):
-            raise ValueError(
-                f"f0_force_n must have shape {(times.size, 3)}, got {forces.shape}"
-            )
+        velocities = np.asarray(self.f0_velocity_m_s, dtype=np.float64)
+        for name, block in (("f0_force_n", forces), ("f0_velocity_m_s", velocities)):
+            if block.shape != (times.size, 3):
+                raise ValueError(
+                    f"{name} must have shape {(times.size, 3)}, got {block.shape}"
+                )
         columns = {
             "f0_sole_depth_m": np.asarray(self.f0_sole_depth_m, dtype=np.float64),
-            "f0_speed_m_s": np.asarray(self.f0_speed_m_s, dtype=np.float64),
             "f0_divot_section_area_m2": np.asarray(
                 self.f0_divot_section_area_m2, dtype=np.float64
             ),
@@ -507,6 +524,7 @@ class CrossTierComparison:
             ("head_mass_kg", self.head_mass_kg),
             ("declared_width_m", self.declared_width_m),
             ("bulk_density_kg_m3", self.bulk_density_kg_m3),
+            ("f1_cell_size_m", self.f1_cell_size_m),
             ("agreement_band", self.agreement_band),
         ):
             if not math.isfinite(value) or value <= 0.0:
@@ -515,6 +533,7 @@ class CrossTierComparison:
         object.__setattr__(self, "sweep_probes", tuple(self.sweep_probes))
         object.__setattr__(self, "time_s", times)
         object.__setattr__(self, "f0_force_n", forces)
+        object.__setattr__(self, "f0_velocity_m_s", velocities)
         for name, column in columns.items():
             object.__setattr__(self, name, column)
 
@@ -544,6 +563,11 @@ class CrossTierComparison:
     def f0_force_magnitude_n(self) -> NDArray[np.float64]:
         """``(T,)`` resultant magnitude of F0's recorded force [N]."""
         return np.linalg.norm(self.f0_force_n, axis=1)
+
+    @property
+    def f0_speed_m_s(self) -> NDArray[np.float64]:
+        """``(T,)`` head speed [m/s], from the recorded velocity."""
+        return np.linalg.norm(self.f0_velocity_m_s, axis=1)
 
     @property
     def probe_frames(self) -> tuple[int, ...]:
@@ -614,46 +638,98 @@ class CrossTierComparison:
         return (min(frames), max(frames))
 
     @property
-    def f0_speed_lost_m_s(self) -> float:
-        """Speed F0's own record shows the head losing over the probed window."""
+    def f0_recorded_speed_lost_m_s(self) -> float:
+        """Speed F0's own record shows the head losing over the probed window.
+
+        The truth for F0, and *not* the number the agreement row compares:
+        it is read off every sample while F1 is known at a handful, so
+        putting the two side by side would report the quadrature as a
+        divergence. It is stated beside the compared pair so that
+        quadrature error is visible rather than absorbed.
+        """
         first, last = self.probe_window
-        return float(self.f0_speed_m_s[first] - self.f0_speed_m_s[last])
+        speed = self.f0_speed_m_s
+        return float(speed[first] - speed[last])
+
+    @property
+    def f0_speed_lost_m_s(self) -> float:
+        """What F0's force removes from the head over the probed window.
+
+        Integrated the same way as :attr:`f1_speed_lost_m_s`: the resultant
+        projected on the direction of travel, sampled at the probes,
+        interpolated between them and integrated. Same quadrature on both
+        sides, because comparing an exact number against a coarsely
+        sampled one measures the sampling.
+        """
+        return self._projected_speed_lost_m_s(_TIER_F0)
 
     @property
     def f1_speed_lost_m_s(self) -> float:
         """What F1's force would have taken off the same head, same window.
 
-        F0's own per-sample speed decrements, each weighted by the
-        ``|F1| / |F0|`` ratio interpolated onto that sample from the
-        probes. Doing it this way rather than integrating F1's force
-        directly is deliberate: the two tiers' resultants do not point the
-        same way -- the measured direction cosines run 0.65 to 0.87 -- so
-        borrowing F1's *magnitude* while keeping F0's direction states
-        exactly what is and is not being taken from the field tier.
+        The resultant **projected on the direction of travel**, so a force
+        that does not oppose the motion does not decelerate. The measured
+        direction cosines run from 0.14 at a grazing sample to 0.997 at the
+        peak, and a magnitude-only estimate would credit the first of those
+        with as much braking as the second.
 
         One-way coupled, and that is not a detail: F1 was queried at the
         poses and speeds F0's head actually reached, so this is what F1's
         force would have removed from a head that never slowed down more
         than F0 says it did.
         """
-        first, last = self.probe_window
-        ratio = self._probe_ratio_on_record()
-        # Trapezoidal: each interval is weighted by the mean of the ratio at
-        # its two ends, not by the ratio at its start, so a ratio that
-        # varies across the window is not biased towards its opening value.
-        interval = 0.5 * (ratio[first:last] + ratio[first + 1 : last + 1])
-        decrement = -np.diff(self.f0_speed_m_s[first : last + 1])
-        return float((interval * decrement).sum())
+        return self._projected_speed_lost_m_s(_TIER_F1)
 
-    def f1_implied_speed_m_s(self) -> NDArray[np.float64]:
-        """``(T,)`` the speed history F1's force implies, over the probed window.
+    def _projected_force_n(self, tier: str) -> NDArray[np.float64]:
+        """Braking force at each probe: the resultant against the motion.
 
-        Starts from F0's own speed at the first probe and removes the
-        ratio-weighted decrements of :attr:`f1_speed_lost_m_s`, so the two
-        curves leave the same point and the gap between them at the end is
-        exactly the disagreement in speed lost. ``nan`` outside the probed
-        window, because outside it nothing was compared and a continued
-        line would assert a comparison that was never made.
+        Args:
+            tier: ``"f0"`` or ``"f1"``.
+
+        Returns:
+            ``(n_probes,)`` the component of that tier's resultant opposing
+            the travel direction [N], in probe order. Negative where the
+            resultant pushes the head along, which is a real thing a
+            grazing sole can do and is not clipped away.
+        """
+        ordered = sorted(self.shot_probes, key=lambda item: item.frame)
+        braking = np.zeros(len(ordered))
+        for index, probe in enumerate(ordered):
+            velocity = self.f0_velocity_m_s[probe.frame]
+            speed = float(np.linalg.norm(velocity))
+            if speed <= 0.0:
+                continue
+            force = (
+                probe.check.f0_force_n if tier == _TIER_F0 else probe.check.f1_force_n
+            )
+            braking[index] = -float(np.asarray(force) @ velocity) / speed
+        return braking
+
+    def _projected_speed_lost_m_s(self, tier: str) -> float:
+        """Integrate one tier's braking force over the probed window.
+
+        Raises:
+            ValueError: If the probes bracket no window.
+        """
+        _ = self.probe_window
+        ordered = sorted(self.shot_probes, key=lambda item: item.frame)
+        times = np.array([probe.time_s for probe in ordered])
+        return float(
+            np.trapezoid(self._projected_force_n(tier), x=times) / self.head_mass_kg
+        )
+
+    def implied_speed_m_s(self, tier: str = _TIER_F1) -> NDArray[np.float64]:
+        """``(T,)`` the speed history one tier's braking force implies.
+
+        Starts from F0's own recorded speed at the first probe and removes
+        the running integral of the braking force, so both tiers' curves
+        leave the same point and the gap between them at the end is the
+        disagreement in speed lost. ``nan`` outside the probed window,
+        because outside it nothing was compared and a continued line would
+        assert a comparison that was never made.
+
+        Args:
+            tier: ``"f0"`` or ``"f1"``.
 
         Returns:
             The implied speed [m/s].
@@ -662,32 +738,49 @@ class CrossTierComparison:
             ValueError: If the probes bracket no window.
         """
         first, last = self.probe_window
-        ratio = self._probe_ratio_on_record()
-        interval = 0.5 * (ratio[first:last] + ratio[first + 1 : last + 1])
-        decrement = -np.diff(self.f0_speed_m_s[first : last + 1])
+        ordered = sorted(self.shot_probes, key=lambda item: item.frame)
+        times = np.array([probe.time_s for probe in ordered])
+        window = self.time_s[first : last + 1]
+        sampled = np.interp(window, times, self._projected_force_n(tier))
+        lost = np.concatenate(
+            ([0.0], np.cumsum(0.5 * (sampled[:-1] + sampled[1:]) * np.diff(window)))
+        )
         implied = np.full(self.n_frames, np.nan)
-        implied[first] = self.f0_speed_m_s[first]
-        implied[first + 1 : last + 1] = self.f0_speed_m_s[first] - np.cumsum(
-            interval * decrement
+        implied[first : last + 1] = (
+            float(self.f0_speed_m_s[first]) - lost / self.head_mass_kg
         )
         return implied
 
-    def _probe_ratio_on_record(self) -> NDArray[np.float64]:
-        """``(T,)`` the ``|F1| / |F0|`` ratio interpolated onto F0's axis."""
-        frames = np.array(self.probe_frames, dtype=np.float64)
-        ratios = np.array(
-            [
-                probe.f1_force_magnitude_n / probe.f0_force_magnitude_n
-                if probe.f0_force_magnitude_n > 0.0
-                else np.nan
-                for probe in self.shot_probes
-            ]
-        )
-        order = np.argsort(frames)
-        return np.interp(
-            np.arange(self.n_frames, dtype=np.float64),
-            frames[order],
-            ratios[order],
+    def engagement_caveat(self) -> str:
+        """Name the probes where F0 reported almost no force, or say nothing.
+
+        F0 reports zero the moment no element is both submerged *and*
+        leading-edge, which happens while the sole is still geometrically
+        in the divot -- the disengaged tail issue #8702 documents. A ratio
+        formed at such a sample is a division by an engagement criterion
+        rather than by a physical force, and it is by far the largest ratio
+        on the page, so it is named rather than left to dominate.
+
+        Returns:
+            One sentence, or an empty string when every probe carried load.
+        """
+        peak = self.peak_probe.f0_force_magnitude_n
+        if peak <= 0.0:
+            return ""
+        grazing = [
+            probe
+            for probe in sorted(self.shot_probes, key=lambda item: item.frame)
+            if probe.f0_force_magnitude_n < _GRAZING_FRACTION * peak
+        ]
+        if not grazing:
+            return ""
+        moments = ", ".join(f"{probe.time_s * 1e3:.2f} ms" for probe in grazing)
+        return (
+            f"At {moments} F0 reports under {_GRAZING_FRACTION:.0%} of its peak "
+            "force while the sole is still in the divot: it reports zero the "
+            "moment no element is both submerged and leading-edge (#8702). "
+            "Ratios at those probes divide by an engagement criterion, not by "
+            "a physical force, and they are the largest ratios on this page."
         )
 
     # ----------------------------------------------------------- agreement
@@ -850,6 +943,33 @@ class CrossTierComparison:
 
     # ------------------------------------------------------------- licence
 
+    def resolution_note(self) -> str:
+        """State the grid F1 was solved on against ADR-0033's own figure.
+
+        Returns:
+            One sentence, which says the resolution is coarser than the
+            specified band when it is. ADR-0033 bars this tier from
+            quoting club force at *any* resolution, so this is provenance
+            rather than a caveat that could be lifted by refining.
+        """
+        size_mm = self.f1_cell_size_m * 1e3
+        band = (
+            "inside"
+            if _ADR_BULK_RESOLUTION_M[0]
+            <= self.f1_cell_size_m
+            <= _ADR_BULK_RESOLUTION_M[1]
+            else "coarser than"
+            if self.f1_cell_size_m > _ADR_BULK_RESOLUTION_M[1]
+            else "finer than"
+        )
+        return (
+            f"F1 solved at dx = {size_mm:.3g} mm, {band} the "
+            f"{_ADR_BULK_RESOLUTION_M[0] * 1e3:g}-"
+            f"{_ADR_BULK_RESOLUTION_M[1] * 1e3:g} mm bulk resolution ADR-0033 "
+            "specifies; refining does not make the tier quotable for club "
+            "force, which stays F0's."
+        )
+
     def licence(self) -> str:
         """What agreement on this page does and does not license."""
         return licence_statement(
@@ -890,7 +1010,8 @@ class CrossTierComparison:
             "",
             f"Probed {self.n_probes} instant(s) of a {self.n_frames}-sample F0 "
             f"record; each F1 point is its own march to that pose under a "
-            f"declared straight-line approach, not a marched shot (issue #8733).",
+            f"declared straight-line approach, not a marched shot (issue #8733). "
+            f"{self.resolution_note()}",
             "",
             "Agreement, quantity by quantity:",
             rows,
@@ -899,6 +1020,9 @@ class CrossTierComparison:
         ]
         if spans:
             parts += ["", "Divergence:", "\n".join(f"  {line}" for line in spans)]
+        engagement = self.engagement_caveat()
+        if engagement:
+            caveats = [engagement, *caveats]
         if caveats:
             parts += ["", "Caveats:", "\n".join(f"  {line}" for line in caveats)]
         return "\n".join(parts)

--- a/src/tools/bunker_shot_gui/crosstier.py
+++ b/src/tools/bunker_shot_gui/crosstier.py
@@ -974,7 +974,10 @@ class CrossTierComparison:
         """What agreement on this page does and does not license."""
         return licence_statement(
             speed_m_s=float(self.f0_speed_m_s.max()),
-            effective_width_m=self.peak_probe.check.effective_width_m,
+            # This comparison's own declared width, not a probe's, because
+            # it is the width both divot masses were formed at and the two
+            # numbers must not be able to disagree.
+            effective_width_m=self.declared_width_m,
         )
 
     def licence_stamp(self) -> str:

--- a/src/tools/bunker_shot_gui/crosstier_run.py
+++ b/src/tools/bunker_shot_gui/crosstier_run.py
@@ -1,0 +1,159 @@
+"""Running the cross-tier check from the workbench's own inputs (#8713).
+
+A thin assembly layer, deliberately outside
+:class:`~src.tools.bunker_shot_gui.model.WorkbenchModel`: this is not on the
+per-shot path and must never be put there. F1 has no shot history yet
+(issue #8733), so each probe is a separate march to one recorded pose, and
+the whole check costs minutes where a design evaluation costs milliseconds.
+Keeping it a separate call is what stops it being run by accident.
+
+The defaults below are the interactive ones, and every one of them is
+recorded on the result rather than assumed by the reader: the grid F1 was
+solved on is drawn in the figure, and the declared effective width travels
+with every magnitude.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from bunkershot3d.solvers import DRFTSolver, MaterialResponse, RefusalPolicy
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.solver import PlaneStrainMPMSolver
+
+from .bridge import compare_tiers, entry_kinematics, validity_band
+from .crosstier import CrossTierComparison
+from .design import SandCondition, SwingSetup, WedgeDesign, WorkbenchInputError
+from .model import WorkbenchModel
+from .shot3d import shot_scene
+
+__all__ = [
+    "F1_BED_DEPTH_M",
+    "F1_CELL_SIZE_M",
+    "F1_MAX_STEPS",
+    "F1_PROBE_COUNT",
+    "F1_SWEEP_SPEEDS_M_S",
+    "cross_tier_check",
+]
+
+F1_CELL_SIZE_M = 0.003
+"""Grid ``dx`` the interactive cross-tier check runs F1 at.
+
+Coarser than the 1-2 mm bulk resolution ADR-0033 specifies, and stated as
+such: the cost of a probe goes roughly as ``dx**-3`` -- particle count in
+two dimensions and step count in one -- so the specified resolution turns a
+minutes-long check into a tens-of-minutes one. Refining does not make the
+tier quotable for club force either way; that stays F0's at every
+resolution. The value used is recorded on the comparison and drawn in the
+figure, so nobody has to ask which one produced a picture."""
+
+F1_BED_DEPTH_M = 0.080
+"""Sand depth below the free surface for F1's bed.
+
+Deep enough that a 12 mm divot does not reach the fixed floor, whose
+sticky condition would otherwise show up as a stiffer bed."""
+
+F1_PROBE_COUNT = 3
+"""Engaged samples of the F0 record handed to F1, by default."""
+
+F1_SWEEP_SPEEDS_M_S: tuple[float, ...] = (5.0, 12.0, 25.0)
+"""ADR-0033's own sweep, which is what brackets the inertial-share crossing.
+
+A greenside shot enters at 25 m/s and leaves above 17, so it never
+decelerates through the crossover; the sweep is a separate, declared
+experiment at one recorded pose and the view labels it as one."""
+
+F1_MAX_STEPS = 200000
+"""Cap on one F1 march. Generous, because the approach length depends on
+the queried pose; the CFL check inside the solver is the real guard."""
+
+
+def cross_tier_check(
+    model: WorkbenchModel,
+    design: WedgeDesign,
+    sand: SandCondition,
+    swing: SwingSetup,
+    *,
+    cell_size_m: float = F1_CELL_SIZE_M,
+    bed_depth_m: float = F1_BED_DEPTH_M,
+    n_probes: int = F1_PROBE_COUNT,
+    sweep_speeds_m_s: Sequence[float] = F1_SWEEP_SPEEDS_M_S,
+) -> CrossTierComparison:
+    """Put the F1 continuum beside F0 on one design (issue #8713).
+
+    **Not** on the per-shot path, and it must not be put there: F1 has
+    no shot history yet (issue #8733), so every probe is a separate
+    march to one recorded pose and the whole check costs minutes where
+    a shot costs milliseconds.
+
+    Both solvers are built with a permissive refusal policy. A greenside
+    bunker shot is far outside either tier's stated envelope, and a
+    strict policy would turn a refusal into an exception before there
+    was anything to compare -- which is a correct refusal and a useless
+    comparison. The verdict itself is unchanged: it travels on the band
+    and on the licence statement, and nothing here improves it.
+
+    Args:
+        model: The workbench model whose settings the F0 record is run
+            under. Passed rather than owned so the check uses exactly the
+            discretisation the design panel is showing.
+        design: The designer's inputs.
+        sand: The playing condition.
+        swing: The delivery.
+        cell_size_m: F1 grid ``dx``. The default is coarser than the
+            1-2 mm bulk resolution ADR-0033 specifies, because the
+            check is interactive and the cost goes as ``dx**-3``;
+            the resolution actually used is recorded on the result and
+            drawn in the figure rather than left to whoever ran it.
+        bed_depth_m: Sand depth below the free surface for F1's bed.
+        n_probes: How many engaged samples of the F0 record to probe.
+        sweep_speeds_m_s: Speeds for the declared sweep that brackets
+            the inertial-share crossover. A greenside shot does not
+            decelerate through the crossing, so without these the view
+            can only report which side of it the whole record sits on.
+
+    Returns:
+        The comparison.
+
+    Raises:
+        WorkbenchInputError: If the design is not a constructible sole.
+        OutOfEnvelopeError: If the F0 march itself refuses, in which
+            case there is no record to compare against.
+    """
+    geometry = design.geometry()
+    state = sand.sand_state()
+    build = model.head_build(geometry)
+    kinematics = entry_kinematics(build, swing)
+    result = model.shot_result(geometry, state, swing)
+    f0 = DRFTSolver(
+        material=MaterialResponse.from_sand_state(state),
+        dynamic_terms_active=bool(swing.dynamic_terms_active),
+        refusal_policy=RefusalPolicy.REPORT,
+    )
+    band = validity_band(f0, build, result, kinematics.orientation)
+    scene = shot_scene(build, result)
+    if band is None:
+        raise WorkbenchInputError(
+            "the shot recorded fewer than 2 samples, which is too short to "
+            "carry a validity band and therefore too short to cross-check"
+        )
+    return compare_tiers(
+        f0_solver=f0,
+        f1_solver=PlaneStrainMPMSolver(
+            material=SandContinuum.from_sand_state(state),
+            cell_size_m=cell_size_m,
+            effective_width_m=geometry.sole_width_m,
+            bed_depth_m=bed_depth_m,
+            refusal_policy=RefusalPolicy.REPORT,
+            max_steps=F1_MAX_STEPS,
+        ),
+        build=build,
+        result=result,
+        kinematics=kinematics,
+        f0_divot_section_area_m2=scene.divot.section_area_m2,
+        band=band,
+        head_mass_kg=geometry.head_mass_kg,
+        bulk_density_kg_m3=state.bulk_density_kg_m3,
+        n_probes=n_probes,
+        sweep_speeds_m_s=sweep_speeds_m_s,
+    )

--- a/src/tools/bunker_shot_gui/crosstier_run.py
+++ b/src/tools/bunker_shot_gui/crosstier_run.py
@@ -132,10 +132,11 @@ def cross_tier_check(
     )
     band = validity_band(f0, build, result, kinematics.orientation)
     scene = shot_scene(build, result)
-    if band is None:
+    if band is None or scene is None:
         raise WorkbenchInputError(
             "the shot recorded fewer than 2 samples, which is too short to "
-            "carry a validity band and therefore too short to cross-check"
+            "carry a validity band or a swept divot section, and therefore too "
+            "short to cross-check"
         )
     return compare_tiers(
         f0_solver=f0,

--- a/src/tools/bunker_shot_gui/gui.py
+++ b/src/tools/bunker_shot_gui/gui.py
@@ -53,6 +53,8 @@ from PyQt6.QtWidgets import (
 
 from src.shared.python.ui import HoverCopyTextBrowser
 
+from .crosstier import CrossTierComparison
+from .crosstier_run import cross_tier_check
 from .design import SandCondition, SolverSetup, SwingSetup, WorkbenchInputError
 from .field import LoadComponent, LoadScale, SoleLoadField
 from .model import DesignEvaluation, WorkbenchComparison, WorkbenchModel
@@ -60,7 +62,11 @@ from .render import field_scales
 from .render3d import SceneScale, scene_scale
 from .report import comparison_report, evaluation_report
 from .shot3d import ShotScene
-from .viewport_widgets import ShotViewportWidget, TracePanelWidget
+from .viewport_widgets import (
+    CrossTierWidget,
+    ShotViewportWidget,
+    TracePanelWidget,
+)
 from .widgets import (
     ConditionPanel,
     DesignPanel,
@@ -239,6 +245,22 @@ class BunkerShotWidget(QWidget):
         self._compare_button = QPushButton("Compare A vs B")
         self._compare_button.clicked.connect(self.run_comparison)
         column.addWidget(self._compare_button)
+
+        # Separate button, and separate for a reason rather than for tidiness.
+        # The cross-tier check marches the F1 continuum once per probe -- F1
+        # has no shot history yet (#8733) -- so it costs minutes where a
+        # design costs milliseconds. Running it on every evaluation would
+        # make the workbench unusable, and running it silently would make
+        # the wait inexplicable.
+        self._cross_tier_button = QPushButton("Cross-tier check A (F0 vs F1)")
+        self._cross_tier_button.setToolTip(
+            "Puts the F1 plane-strain MPM continuum beside F0 on design A. "
+            "Minutes, not milliseconds: F1 has no shot history yet, so each "
+            "probe is a separate march to one recorded pose. Consistency "
+            "between two uncalibrated models is not validation."
+        )
+        self._cross_tier_button.clicked.connect(self.run_cross_tier)
+        column.addWidget(self._cross_tier_button)
         column.addStretch()
 
         scroll = QScrollArea()
@@ -285,10 +307,18 @@ class BunkerShotWidget(QWidget):
         self._field_a.link(self._scene_a)
         self._field_a.link(self._traces_a)
 
+        cross_tier_page = QWidget()
+        cross_tier = QHBoxLayout(cross_tier_page)
+        self._cross_tier = CrossTierWidget("A: F0 against F1, on the shared cursor")
+        cross_tier.addWidget(self._cross_tier)
+        # The fourth follower of the one transport (#8705, #8706, #8708).
+        self._field_a.link(self._cross_tier)
+
         self._views = QTabWidget()
         self._views.addTab(maps_page, "Summed maps")
         self._views.addTab(fields_page, "Sole load field (per element, per sample)")
         self._views.addTab(shot_page, "Shot in 3-D and traces")
+        self._views.addTab(cross_tier_page, "Cross-tier check (F0 vs F1)")
         column.addWidget(self._views, stretch=3)
 
         self._results = HoverCopyTextBrowser()
@@ -360,6 +390,51 @@ class BunkerShotWidget(QWidget):
             return
         self.show_comparison(result)
 
+    def run_cross_tier(self) -> None:
+        """Put F1 beside F0 on design A, on demand.
+
+        Deliberately its own action rather than part of
+        :meth:`run_design_a`: the check marches the continuum once per
+        probe and costs minutes. The banner says so before the wait rather
+        than after it.
+        """
+        inputs = self._read_inputs()
+        if inputs is None:
+            return
+        settings, sand, swing = inputs
+        try:
+            design = self._design_a.design()
+        except WorkbenchInputError as error:
+            self._show_input_error(error)
+            return
+        self._banner.show_busy(
+            "Running the F1 continuum beside F0 on design A. This is minutes, "
+            "not milliseconds: F1 has no shot history yet, so every probe is "
+            "a separate march to one recorded pose."
+        )
+        result = self._guarded(
+            lambda: cross_tier_check(self._model_factory(settings), design, sand, swing)
+        )
+        if result is None:
+            return
+        self.show_cross_tier(result)
+
+    def show_cross_tier(self, comparison: CrossTierComparison) -> None:
+        """Display a cross-tier comparison and open its tab.
+
+        The banner keeps the shot's own verdict. Nothing on this page
+        improves it: agreement between two uncalibrated models is not
+        validation, and the licence statement inside the figure and the
+        status line under it both say so.
+
+        Args:
+            comparison: The comparison to show.
+        """
+        self._banner.show_status(comparison.worst_status)
+        self._cross_tier.set_comparison(comparison)
+        self._views.setCurrentIndex(self._views.count() - 1)
+        self._results.setPlainText(comparison.summary())
+
     def _read_inputs(
         self,
     ) -> tuple[SolverSetup, SandCondition, SwingSetup] | None:
@@ -409,6 +484,11 @@ class BunkerShotWidget(QWidget):
         self._bounce_map_b.clear()
         self._window_map_b.clear()
         self._field_b.clear()
+        # A cross-tier check belongs to the shot it was run on. Leaving the
+        # old one up beside a new design would put two different shots on
+        # one cursor, which is the one thing the shared transport exists to
+        # make impossible.
+        self._cross_tier.clear()
 
     def show_comparison(self, comparison: WorkbenchComparison) -> None:
         """Display an A/B comparison.
@@ -445,6 +525,7 @@ class BunkerShotWidget(QWidget):
         self._paint_field(comparison.left, self._field_a, scales)
         self._paint_field(comparison.right, self._field_b, scales)
         self._paint_shot(comparison.left, _shared_scene_scale(pair))
+        self._cross_tier.clear()
 
     def _paint_field(
         self,

--- a/src/tools/bunker_shot_gui/model.py
+++ b/src/tools/bunker_shot_gui/model.py
@@ -602,6 +602,43 @@ class WorkbenchModel:
             dynamic_terms_active=bool(swing.dynamic_terms_active),
         )
 
+    def shot_result(
+        self, geometry: WedgeGeometry, sand: SandState, swing: SwingSetup
+    ) -> ShotResult:
+        """Run one shot and return the **record**, before any reduction.
+
+        :meth:`run_shot` reduces the record to designer metrics and throws
+        the poses away. The cross-tier check of issue #8713 needs them
+        back: F1 has no instantaneous answer, so each of its probes is a
+        march to a pose F0 recorded, and a re-derived pose would be a
+        comparison of two different shots.
+
+        Args:
+            geometry: The resolved design vector.
+            sand: The sand state.
+            swing: The delivery.
+
+        Returns:
+            The whole strike.
+
+        Raises:
+            OutOfEnvelopeError: If the solver refuses any step. Unlike
+                :meth:`run_shot` this does not translate the refusal into
+                an outcome, because there is no outcome here to carry it.
+        """
+        build = self.head_build(geometry)
+        return simulate_shot(
+            self.solver(sand, swing),
+            build.elements_body,
+            head_mass_kg=geometry.head_mass_kg,
+            kinematics=entry_kinematics(build, swing),
+            settings=ShotSettings(
+                time_step_s=self._settings.time_step_s,
+                max_time_s=self._settings.max_time_s,
+            ),
+            sole_reference_body_m=build.sole_reference_body_m,
+        )
+
     def run_shot(
         self, geometry: WedgeGeometry, sand: SandState, swing: SwingSetup
     ) -> ShotOutcome:
@@ -619,19 +656,8 @@ class WorkbenchModel:
         solver = self.solver(sand, swing)
         delivered = deliver_wedge(geometry, swing.delivery())
         kinematics = entry_kinematics(build, swing)
-        settings = ShotSettings(
-            time_step_s=self._settings.time_step_s,
-            max_time_s=self._settings.max_time_s,
-        )
         try:
-            result = simulate_shot(
-                solver,
-                build.elements_body,
-                head_mass_kg=geometry.head_mass_kg,
-                kinematics=kinematics,
-                settings=settings,
-                sole_reference_body_m=build.sole_reference_body_m,
-            )
+            result = self.shot_result(geometry, sand, swing)
         except OutOfEnvelopeError as refusal:
             verdict = refusal.verdict
             require(

--- a/src/tools/bunker_shot_gui/render_crosstier.py
+++ b/src/tools/bunker_shot_gui/render_crosstier.py
@@ -353,7 +353,7 @@ class CrossTierArtists:
 
     def _shade_validity(self, axes: Axes) -> None:
         """Shade the record with the verdict that applied over each stretch."""
-        for span in self.comparison.band.spans():
+        for span in self.comparison.validity_spans():
             axes.axvspan(
                 span.start_s * 1e3,
                 span.end_s * 1e3,
@@ -549,7 +549,7 @@ class CrossTierArtists:
         moment = float(model.time_s[index]) * 1e3
         for cursor in self.cursors:
             cursor.set_xdata([moment, moment])
-        status = model.band.status_at(index)
+        status = model.status_at(index)
         self.readout.set_text(
             f"{moment:.2f} ms - {status.value.replace('_', ' ').upper()} - "
             f"|F0| {float(model.f0_force_magnitude_n[index]):.4g} N, "

--- a/src/tools/bunker_shot_gui/render_crosstier.py
+++ b/src/tools/bunker_shot_gui/render_crosstier.py
@@ -327,7 +327,15 @@ class CrossTierArtists:
         series.append(f1_points)
         self._draw_gaps(axes, quantity, times, f0_points, f1_points)
 
-        axes.set_ylabel(f"{quantity.label}\n[{quantity.unit}]", fontsize=_LABEL_SIZE)
+        # The speed panel draws a speed; the compared quantity is the gap
+        # between the two curves, which the heading has to say or the axis
+        # reads as though F0 lost 25 m/s.
+        heading = (
+            "Head speed\n(the gap is the loss)"
+            if quantity is ComparedQuantity.SPEED_LOST
+            else quantity.label
+        )
+        axes.set_ylabel(f"{heading}\n[{quantity.unit}]", fontsize=_LABEL_SIZE)
         axes.set_xlim(float(time_ms[0]), float(time_ms[-1]))
         axes.set_ylim(*_limits(series))
         axes.set_autoscale_on(False)

--- a/src/tools/bunker_shot_gui/render_crosstier.py
+++ b/src/tools/bunker_shot_gui/render_crosstier.py
@@ -1,0 +1,621 @@
+"""Drawing the cross-tier comparison (issue #8713, epic #8699).
+
+Headless, like every other renderer in this package: matplotlib and no GUI
+toolkit, so the same figure appears in a test, in a batch sweep and inside
+the Qt workbench.
+
+Four things this figure does that a plain overlay would not
+-----------------------------------------------------------
+
+**The F1 points are never joined.** F1 has no shot history -- each point is
+its own march to one pose under a declared straight-line approach (issue
+#8733) -- so a line through them would draw a trajectory that was never
+computed. They are markers, the legend says why, and the method line in the
+figure says it again in words.
+
+**The gap is an object.** At every probe a connector is drawn *between* the
+two tiers' values and labelled with the ratio, and stretches where a
+quantity left the declared band are shaded. "Divergence highlighted, not
+just plotted" is the issue's wording, and a reader should not have to
+measure a distance by eye to find the result.
+
+**The crossover has its own axes.** F0's inertial share and F1's
+momentum-flux share are drawn against *speed* rather than against time,
+because that is the variable they diverge in and because a greenside shot
+never slows through the crossing -- a time axis would show two flat lines
+and hide the sharpest single result in the epic.
+
+**The licence is inside the frame.** Not a caption: a screenshot of a panel
+keeps its contents and loses its surroundings, which is exactly how a
+picture from two uncalibrated models ends up in a deck as though it had
+been measured.
+
+Nothing autoscales. Every panel's limits are set once from the whole
+record and both tiers, for the reason issue #8728 fixed the sole field's
+colour ramp: an axis that re-ranges while the cursor moves makes the eye
+read noise as signal.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
+from matplotlib.text import Text
+
+from .agreement import AgreementClass, ComparedQuantity
+from .crosstier import CrossTierComparison
+from .render import stamp_axes
+from .report import status_colour
+
+__all__ = [
+    "PANEL_QUANTITIES",
+    "CrossTierArtists",
+    "cross_tier_still",
+    "draw_cross_tier",
+]
+
+PANEL_QUANTITIES: tuple[ComparedQuantity, ...] = (
+    ComparedQuantity.WRENCH,
+    ComparedQuantity.SOLE_DEPTH,
+    ComparedQuantity.DIVOT_SECTION,
+    ComparedQuantity.SPEED_LOST,
+)
+"""The quantities that resolve in time, in the order they are stacked.
+
+:attr:`~.agreement.ComparedQuantity.DIVOT_MASS` is absent on purpose: it is
+its own section times one declared width and one density, so a fourth curve
+of the same shape would look like a fourth measurement. It is in the
+agreement table, where the number belongs."""
+
+_F0_COLOUR = "#2f6f9f"
+_F1_COLOUR = "#9b1c1c"
+_CURSOR_COLOUR = "#3a3a3a"
+_CONSISTENT_COLOUR = "#1e7a4a"
+_DIVERGENT_COLOUR = "#b3441d"
+_INCOMPARABLE_COLOUR = "#7a7a7a"
+
+_AGREEMENT_COLOUR: dict[AgreementClass, str] = {
+    AgreementClass.CONSISTENT: _CONSISTENT_COLOUR,
+    AgreementClass.DIVERGENT: _DIVERGENT_COLOUR,
+    AgreementClass.INCOMPARABLE: _INCOMPARABLE_COLOUR,
+}
+
+_BAND_ALPHA = 0.16
+_VALIDITY_ALPHA = 0.10
+_BAND_ZORDER = 0.2
+_SERIES_ZORDER = 2.0
+_PADDING = 0.10
+_LABEL_SIZE = 6
+_TICK_SIZE = 5
+_TEXT_SIZE = 5.5
+
+
+def _limits(values: list[np.ndarray]) -> tuple[float, float]:
+    """The fixed y-range covering both tiers on one panel.
+
+    Args:
+        values: Every series the panel will draw, NaNs allowed.
+
+    Returns:
+        ``(low, high)``, never degenerate.
+    """
+    finite = np.concatenate(
+        [np.asarray(item, dtype=np.float64).reshape(-1) for item in values]
+    )
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        return (0.0, 1.0)
+    low, high = float(finite.min()), float(finite.max())
+    span = high - low
+    if span <= 0.0:
+        span = max(abs(high), 1.0)
+    pad = span * _PADDING
+    return (low - pad, high + pad)
+
+
+class CrossTierArtists:
+    """The comparison figure, built once, and the artists a scrub touches.
+
+    Only the cursors and one readout move. Everything else -- the curves,
+    the probe markers, the connectors, the shaded spans, the fixed limits,
+    the licence -- is built once, so scrubbing costs a redraw rather than a
+    rebuild.
+    """
+
+    def __init__(self, figure: Figure, comparison: CrossTierComparison) -> None:
+        """Build the figure for one comparison.
+
+        Args:
+            figure: The figure to build into; cleared first.
+            comparison: The comparison to draw.
+        """
+        self.comparison = comparison
+        figure.clear()
+        grid = figure.add_gridspec(
+            len(PANEL_QUANTITIES),
+            2,
+            width_ratios=(3.0, 2.0),
+            hspace=0.16,
+            wspace=0.22,
+        )
+        self.panels: list[Axes] = []
+        self.cursors: list[Line2D] = []
+        self.f0_series: list[Line2D] = []
+        self.f1_series: list[Line2D] = []
+        self.connectors: list[Line2D] = []
+        self.ratio_labels: list[Text] = []
+        self._divergence_bands = 0
+
+        shared: Axes | None = None
+        for row, quantity in enumerate(PANEL_QUANTITIES):
+            axes = figure.add_subplot(grid[row, 0], sharex=shared)
+            shared = shared or axes
+            self.panels.append(axes)
+            self._build_panel(axes, quantity)
+        self.panels[-1].set_xlabel("time [ms]", fontsize=_LABEL_SIZE)
+
+        self.crossover_axes = figure.add_subplot(grid[0:2, 1])
+        self.crossover_marked = False
+        self.crossover_caption = self._build_crossover(self.crossover_axes)
+
+        text_axes = figure.add_subplot(grid[2:, 1])
+        text_axes.axis("off")
+        self.agreement_text = self._build_agreement_table(text_axes)
+        self.method_text = self._build_method_note(text_axes)
+        self.licence_text = self._build_licence(text_axes)
+
+        self.stamp = stamp_axes(
+            self.panels[0],
+            comparison.worst_status,
+            comparison.tiers[1],
+            extra=comparison.licence_stamp(),
+        )
+        self.readout: Text = self.panels[0].text(
+            0.99,
+            0.03,
+            "",
+            transform=self.panels[0].transAxes,
+            ha="right",
+            va="bottom",
+            fontsize=_TEXT_SIZE,
+            color="#333333",
+            zorder=9,
+        )
+
+    # ------------------------------------------------------------ accessors
+
+    @property
+    def panel_quantities(self) -> tuple[ComparedQuantity, ...]:
+        """Which quantity each stacked panel shows, top to bottom."""
+        return PANEL_QUANTITIES
+
+    @property
+    def n_panels(self) -> int:
+        """How many stacked panels the figure owns."""
+        return len(self.panels)
+
+    @property
+    def n_connectors(self) -> int:
+        """How many tier-to-tier connectors were drawn."""
+        return len(self.connectors)
+
+    @property
+    def n_divergence_bands(self) -> int:
+        """How many divergent stretches were shaded."""
+        return self._divergence_bands
+
+    # -------------------------------------------------------------- panels
+
+    def _panel_series(
+        self, quantity: ComparedQuantity
+    ) -> tuple[np.ndarray, np.ndarray | None]:
+        """``(f0_curve, f1_curve)`` for one panel, in the reporting unit.
+
+        Args:
+            quantity: Which panel.
+
+        Returns:
+            F0's continuous record and, for the speed panel only, the
+            speed history F1's force implies. ``None`` elsewhere, because
+            F1 has no continuous history of anything else.
+        """
+        model = self.comparison
+        scale = quantity.display_scale
+        if quantity is ComparedQuantity.WRENCH:
+            return (model.f0_force_magnitude_n * scale, None)
+        if quantity is ComparedQuantity.SOLE_DEPTH:
+            return (model.f0_sole_depth_m * scale, None)
+        if quantity is ComparedQuantity.DIVOT_SECTION:
+            return (model.f0_divot_section_area_m2 * scale, None)
+        try:
+            implied = model.f1_implied_speed_m_s()
+        except ValueError:
+            implied = None
+        return (model.f0_speed_m_s, implied)
+
+    def _probe_points(
+        self, quantity: ComparedQuantity
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """``(time_ms, f0, f1)`` at every probe, in the reporting unit."""
+        model = self.comparison
+        ordered = sorted(model.shot_probes, key=lambda item: item.frame)
+        times = np.array([probe.time_s * 1e3 for probe in ordered])
+        if quantity is ComparedQuantity.SPEED_LOST:
+            f0 = np.array([model.f0_speed_m_s[probe.frame] for probe in ordered])
+            try:
+                implied = model.f1_implied_speed_m_s()
+            except ValueError:
+                return (times, f0, np.full(times.size, np.nan))
+            return (times, f0, np.array([implied[probe.frame] for probe in ordered]))
+        scale = quantity.display_scale
+        pairs = [probe.agreement(quantity) for probe in ordered]
+        return (
+            times,
+            np.array([item.f0_value * scale for item in pairs]),
+            np.array([item.f1_value * scale for item in pairs]),
+        )
+
+    def _build_panel(self, axes: Axes, quantity: ComparedQuantity) -> None:
+        """Draw one stacked panel: both tiers, the gaps, and the shading."""
+        model = self.comparison
+        time_ms = model.time_s * 1e3
+        self._shade_validity(axes)
+        self._shade_divergence(axes, quantity)
+
+        f0_curve, f1_curve = self._panel_series(quantity)
+        (f0_line,) = axes.plot(
+            time_ms,
+            f0_curve,
+            color=_F0_COLOUR,
+            linewidth=1.2,
+            label="F0 (3D-RFT), whole record",
+            zorder=_SERIES_ZORDER,
+        )
+        self.f0_series.append(f0_line)
+        series = [f0_curve]
+        if f1_curve is not None:
+            axes.plot(
+                time_ms,
+                f1_curve,
+                color=_F1_COLOUR,
+                linewidth=1.0,
+                linestyle="--",
+                label="F1-implied (one-way coupled)",
+                zorder=_SERIES_ZORDER,
+            )
+            series.append(f1_curve)
+
+        times, f0_points, f1_points = self._probe_points(quantity)
+        (f1_line,) = axes.plot(
+            times,
+            f1_points,
+            color=_F1_COLOUR,
+            linestyle="None",
+            marker="o",
+            markersize=3.5,
+            label="F1 (MPM), one march per probe -- not a history",
+            zorder=_SERIES_ZORDER + 1.0,
+        )
+        self.f1_series.append(f1_line)
+        series.append(f1_points)
+        self._draw_gaps(axes, quantity, times, f0_points, f1_points)
+
+        axes.set_ylabel(f"{quantity.label}\n[{quantity.unit}]", fontsize=_LABEL_SIZE)
+        axes.set_xlim(float(time_ms[0]), float(time_ms[-1]))
+        axes.set_ylim(*_limits(series))
+        axes.set_autoscale_on(False)
+        axes.tick_params(labelsize=_TICK_SIZE)
+        axes.legend(loc="upper left", fontsize=4.5, framealpha=0.6)
+        self.cursors.append(
+            axes.axvline(
+                float(time_ms[0]),
+                color=_CURSOR_COLOUR,
+                linewidth=1.0,
+                linestyle=":",
+                zorder=_SERIES_ZORDER + 2.0,
+            )
+        )
+
+    def _shade_validity(self, axes: Axes) -> None:
+        """Shade the record with the verdict that applied over each stretch."""
+        for span in self.comparison.band.spans():
+            axes.axvspan(
+                span.start_s * 1e3,
+                span.end_s * 1e3,
+                color=status_colour(span.status),
+                alpha=_VALIDITY_ALPHA,
+                linewidth=0.0,
+                zorder=_BAND_ZORDER,
+            )
+
+    def _shade_divergence(self, axes: Axes, quantity: ComparedQuantity) -> None:
+        """Shade the stretches where this quantity left the declared band."""
+        try:
+            spans = self.comparison.divergence_spans(quantity)
+        except ValueError:
+            return
+        for span in spans:
+            axes.axvspan(
+                span.start_s * 1e3,
+                span.end_s * 1e3,
+                color=_DIVERGENT_COLOUR,
+                alpha=_BAND_ALPHA,
+                linewidth=0.0,
+                zorder=_BAND_ZORDER + 0.1,
+            )
+            self._divergence_bands += 1
+
+    def _draw_gaps(
+        self,
+        axes: Axes,
+        quantity: ComparedQuantity,
+        times: np.ndarray,
+        f0_points: np.ndarray,
+        f1_points: np.ndarray,
+    ) -> None:
+        """Draw the disagreement itself: a connector per probe, labelled."""
+        ordered = sorted(self.comparison.shot_probes, key=lambda item: item.frame)
+        for index, probe in enumerate(ordered):
+            low = float(f0_points[index])
+            high = float(f1_points[index])
+            if not (np.isfinite(low) and np.isfinite(high)):
+                continue
+            if quantity is ComparedQuantity.SPEED_LOST:
+                agreement = self.comparison.agreement(ComparedQuantity.SPEED_LOST)
+            else:
+                agreement = probe.agreement(quantity)
+            colour = _AGREEMENT_COLOUR[agreement.agreement]
+            (connector,) = axes.plot(
+                [times[index], times[index]],
+                [low, high],
+                color=colour,
+                linewidth=1.4,
+                solid_capstyle="butt",
+                zorder=_SERIES_ZORDER + 0.5,
+            )
+            self.connectors.append(connector)
+            if not agreement.diverged or not np.isfinite(agreement.ratio):
+                continue
+            self.ratio_labels.append(
+                axes.annotate(
+                    f"{agreement.ratio:.3g}x",
+                    xy=(times[index], 0.5 * (low + high)),
+                    xytext=(3, 0),
+                    textcoords="offset points",
+                    fontsize=_TEXT_SIZE,
+                    color=colour,
+                    va="center",
+                    zorder=_SERIES_ZORDER + 3.0,
+                )
+            )
+
+    # ------------------------------------------------------------ crossover
+
+    def _build_crossover(self, axes: Axes) -> Text:
+        """Draw both inertial shares against speed and mark the crossing."""
+        model = self.comparison
+        probes = sorted(model.crossover_probes, key=lambda item: item.speed_m_s)
+        speeds = np.array([probe.speed_m_s for probe in probes])
+        axes.plot(
+            speeds,
+            [probe.f0_inertial_fraction for probe in probes],
+            color=_F0_COLOUR,
+            marker="o",
+            markersize=3.0,
+            linewidth=1.2,
+            label="F0 inertial share",
+        )
+        axes.plot(
+            speeds,
+            [probe.f1_flux_fraction for probe in probes],
+            color=_F1_COLOUR,
+            marker="s",
+            markersize=3.0,
+            linewidth=1.2,
+            label="F1 momentum-flux share",
+        )
+        crossing = model.crossover()
+        if crossing is not None:
+            axes.axvline(
+                crossing.speed_m_s,
+                color=_DIVERGENT_COLOUR,
+                linewidth=1.0,
+                linestyle="--",
+            )
+            axes.plot(
+                [crossing.speed_m_s],
+                [crossing.shared_share],
+                marker="*",
+                markersize=9.0,
+                color=_DIVERGENT_COLOUR,
+                linestyle="None",
+            )
+            self.crossover_marked = True
+        axes.set_xlabel("intrusion speed [m/s]", fontsize=_LABEL_SIZE)
+        axes.set_ylabel("share of resultant [-]", fontsize=_LABEL_SIZE)
+        axes.set_ylim(0.0, 1.05)
+        axes.set_autoscale_on(False)
+        axes.tick_params(labelsize=_TICK_SIZE)
+        axes.legend(loc="lower right", fontsize=4.5, framealpha=0.6)
+        source = (
+            "declared speed sweep at the deepest recorded pose"
+            if model.sweep_probes
+            else "probes along the shot"
+        )
+        return axes.text(
+            0.0,
+            -0.34,
+            f"{source}\n{_wrap(model.crossover_summary(), 74)}",
+            transform=axes.transAxes,
+            ha="left",
+            va="top",
+            fontsize=_TEXT_SIZE,
+            color="#333333",
+        )
+
+    # ---------------------------------------------------------------- text
+
+    def _build_agreement_table(self, axes: Axes) -> Text:
+        """Write the per-quantity agreement summary into the figure."""
+        rows = "\n".join(
+            _wrap(item.summary(), 74, indent="    ")
+            for item in self.comparison.agreements()
+        )
+        return axes.text(
+            0.0,
+            1.0,
+            f"Agreement, quantity by quantity\n{rows}",
+            transform=axes.transAxes,
+            ha="left",
+            va="top",
+            fontsize=_TEXT_SIZE,
+            color="#222222",
+            family="monospace",
+        )
+
+    def _build_method_note(self, axes: Axes) -> Text:
+        """State how the F1 points were produced, in the figure."""
+        model = self.comparison
+        caveats = [
+            probe.divot_caveat() for probe in model.shot_probes if probe.divot_caveat()
+        ]
+        note = (
+            f"Method: {model.n_probes} probe(s) of a {model.n_frames}-sample F0 "
+            "record. F1 has no shot history yet (#8733), so each F1 point is a "
+            "separate march to that pose under a declared straight-line "
+            "constant-speed approach. The points are therefore not joined."
+        )
+        if caveats:
+            note = f"{note} {caveats[0]}"
+        return axes.text(
+            0.0,
+            0.46,
+            _wrap(note, 76),
+            transform=axes.transAxes,
+            ha="left",
+            va="top",
+            fontsize=_TEXT_SIZE,
+            color="#444444",
+        )
+
+    def _build_licence(self, axes: Axes) -> Text:
+        """Write the licence statement into the figure, not under it."""
+        return axes.text(
+            0.0,
+            0.22,
+            _wrap(self.comparison.licence(), 76),
+            transform=axes.transAxes,
+            ha="left",
+            va="top",
+            fontsize=_TEXT_SIZE,
+            color="#7a1f1f",
+        )
+
+    # ------------------------------------------------------------ scrubbing
+
+    def update(self, frame: int) -> None:
+        """Move the shared cursor to one sample of the F0 record.
+
+        Args:
+            frame: The sample index.
+
+        Raises:
+            ValueError: If the index is outside the record. A clamped index
+                would leave the cursor describing a different moment from
+                the one the transport says it is showing.
+        """
+        model = self.comparison
+        if not 0 <= int(frame) < model.n_frames:
+            raise ValueError(
+                f"frame {frame} is outside the recorded shot, which has "
+                f"{model.n_frames} samples"
+            )
+        index = int(frame)
+        moment = float(model.time_s[index]) * 1e3
+        for cursor in self.cursors:
+            cursor.set_xdata([moment, moment])
+        status = model.band.status_at(index)
+        self.readout.set_text(
+            f"{moment:.2f} ms - {status.value.replace('_', ' ').upper()} - "
+            f"|F0| {float(model.f0_force_magnitude_n[index]):.4g} N, "
+            f"{float(model.f0_speed_m_s[index]):.4g} m/s"
+        )
+
+
+def _wrap(text: str, width: int, *, indent: str = "") -> str:
+    """Wrap a paragraph to a fixed column, preserving its own line breaks.
+
+    Args:
+        text: The paragraph.
+        width: Column to wrap at.
+        indent: Prefix for continuation lines.
+
+    Returns:
+        The wrapped text.
+    """
+    lines: list[str] = []
+    for paragraph in text.splitlines():
+        current = ""
+        for word in paragraph.split():
+            candidate = f"{current} {word}".strip()
+            if len(candidate) > width and current:
+                lines.append(current)
+                current = f"{indent}{word}"
+            else:
+                current = candidate
+        lines.append(current)
+    return "\n".join(lines)
+
+
+def draw_cross_tier(
+    figure: Figure, comparison: CrossTierComparison, *, frame: int | None = None
+) -> CrossTierArtists:
+    """Draw the comparison into an existing figure.
+
+    The figure is cleared and rebuilt, so this is the right call for a
+    still and the wrong one for scrubbing: hold the returned
+    :class:`CrossTierArtists` and call :meth:`~CrossTierArtists.update`,
+    which moves one line per panel and nothing else.
+
+    Args:
+        figure: The figure to draw into.
+        comparison: The comparison.
+        frame: Which sample to put the cursor on; defaults to the probe
+            F0's own force peaked at, which is the moment the shot-level
+            agreement is quoted at.
+
+    Returns:
+        The built artists.
+
+    Raises:
+        ValueError: If the frame is outside the record.
+    """
+    artists = CrossTierArtists(figure, comparison)
+    artists.update(comparison.peak_probe.frame if frame is None else frame)
+    return artists
+
+
+def cross_tier_still(
+    comparison: CrossTierComparison,
+    *,
+    frame: int | None = None,
+    figsize: tuple[float, float] = (11.0, 8.0),
+) -> Figure:
+    """Render the comparison as a standalone figure.
+
+    Args:
+        comparison: The comparison.
+        frame: Which sample to put the cursor on.
+        figsize: Figure size in inches.
+
+    Returns:
+        The figure.
+
+    Raises:
+        ValueError: If the frame is outside the record.
+    """
+    figure = Figure(figsize=figsize)
+    draw_cross_tier(figure, comparison, frame=frame)
+    return figure

--- a/src/tools/bunker_shot_gui/render_crosstier.py
+++ b/src/tools/bunker_shot_gui/render_crosstier.py
@@ -38,6 +38,8 @@ read noise as signal.
 
 from __future__ import annotations
 
+import contextlib
+
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -90,6 +92,11 @@ _PADDING = 0.10
 _LABEL_SIZE = 6
 _TICK_SIZE = 5
 _TEXT_SIZE = 5.5
+_LINE_SPACING = 1.3
+_POINTS_PER_INCH = 72.0
+_BLOCK_GAP_LINES = 1
+_WRAP_CHARS = 78
+_STAMP_WRAP_CHARS = 58
 
 
 def _limits(values: list[np.ndarray]) -> tuple[float, float]:
@@ -137,8 +144,12 @@ class CrossTierArtists:
             len(PANEL_QUANTITIES),
             2,
             width_ratios=(3.0, 2.0),
-            hspace=0.16,
-            wspace=0.22,
+            hspace=0.20,
+            wspace=0.20,
+            left=0.08,
+            right=0.985,
+            top=0.97,
+            bottom=0.06,
         )
         self.panels: list[Axes] = []
         self.cursors: list[Line2D] = []
@@ -156,21 +167,35 @@ class CrossTierArtists:
             self._build_panel(axes, quantity)
         self.panels[-1].set_xlabel("time [ms]", fontsize=_LABEL_SIZE)
 
-        self.crossover_axes = figure.add_subplot(grid[0:2, 1])
+        self.crossover_axes = figure.add_subplot(grid[0, 1])
         self.crossover_marked = False
-        self.crossover_caption = self._build_crossover(self.crossover_axes)
+        self._build_crossover(self.crossover_axes)
 
-        text_axes = figure.add_subplot(grid[2:, 1])
+        # One text column, laid out top-down by a running cursor rather
+        # than by four hand-chosen fractions. Four fixed positions cannot
+        # know how long the blocks are, and the blocks grow with the
+        # number of probes and with every caveat that turns out to apply
+        # -- so they overlapped, which is the one failure a page of
+        # caveats must not have.
+        text_axes = figure.add_subplot(grid[1:, 1])
         text_axes.axis("off")
-        self.agreement_text = self._build_agreement_table(text_axes)
-        self.method_text = self._build_method_note(text_axes)
-        self.licence_text = self._build_licence(text_axes)
+        cursor = _TextColumn(text_axes)
+        self.crossover_caption = cursor.add(
+            self._crossover_caption_text(), colour="#333333"
+        )
+        self.agreement_text = cursor.add(
+            self._agreement_table_text(), colour="#222222", monospace=True
+        )
+        self.method_text = cursor.add(self._method_text(), colour="#444444")
+        self.licence_text = cursor.add(
+            _wrap(comparison.licence(), _WRAP_CHARS), colour="#7a1f1f"
+        )
 
         self.stamp = stamp_axes(
             self.panels[0],
             comparison.worst_status,
             comparison.tiers[1],
-            extra=comparison.licence_stamp(),
+            extra=_wrap(comparison.licence_stamp(), _STAMP_WRAP_CHARS),
         )
         self.readout: Text = self.panels[0].text(
             0.99,
@@ -393,7 +418,7 @@ class CrossTierArtists:
 
     # ------------------------------------------------------------ crossover
 
-    def _build_crossover(self, axes: Axes) -> Text:
+    def _build_crossover(self, axes: Axes) -> None:
         """Draw both inertial shares against speed and mark the crossing."""
         model = self.comparison
         probes = sorted(model.crossover_probes, key=lambda item: item.speed_m_s)
@@ -439,48 +464,33 @@ class CrossTierArtists:
         axes.set_autoscale_on(False)
         axes.tick_params(labelsize=_TICK_SIZE)
         axes.legend(loc="lower right", fontsize=4.5, framealpha=0.6)
+
+    def _crossover_caption_text(self) -> str:
+        """The sentence the crossover panel is captioned with."""
+        model = self.comparison
         source = (
             "declared speed sweep at the deepest recorded pose"
             if model.sweep_probes
             else "probes along the shot"
         )
-        return axes.text(
-            0.0,
-            -0.34,
-            f"{source}\n{_wrap(model.crossover_summary(), 74)}",
-            transform=axes.transAxes,
-            ha="left",
-            va="top",
-            fontsize=_TEXT_SIZE,
-            color="#333333",
+        return _wrap(
+            f"Inertial-share crossover, from the {source}. {model.crossover_summary()}",
+            _WRAP_CHARS,
         )
 
     # ---------------------------------------------------------------- text
 
-    def _build_agreement_table(self, axes: Axes) -> Text:
-        """Write the per-quantity agreement summary into the figure."""
+    def _agreement_table_text(self) -> str:
+        """The per-quantity agreement summary, as drawn text."""
         rows = "\n".join(
-            _wrap(item.summary(), 74, indent="    ")
+            _wrap(item.summary(), _WRAP_CHARS, indent="    ")
             for item in self.comparison.agreements()
         )
-        return axes.text(
-            0.0,
-            1.0,
-            f"Agreement, quantity by quantity\n{rows}",
-            transform=axes.transAxes,
-            ha="left",
-            va="top",
-            fontsize=_TEXT_SIZE,
-            color="#222222",
-            family="monospace",
-        )
+        return f"Agreement, quantity by quantity\n{rows}"
 
-    def _build_method_note(self, axes: Axes) -> Text:
-        """State how the F1 points were produced, in the figure."""
+    def _method_text(self) -> str:
+        """How the F1 points were produced, and what qualifies them."""
         model = self.comparison
-        caveats = [
-            probe.divot_caveat() for probe in model.shot_probes if probe.divot_caveat()
-        ]
         note = (
             f"Method: {model.n_probes} probe(s) of a {model.n_frames}-sample F0 "
             "record. F1 has no shot history yet (#8733), so each F1 point is a "
@@ -488,31 +498,25 @@ class CrossTierArtists:
             "constant-speed approach. The points are therefore not joined. "
             f"{model.resolution_note()}"
         )
-        if caveats:
-            note = f"{note} {caveats[0]}"
-        return axes.text(
-            0.0,
-            0.46,
-            _wrap(note, 76),
-            transform=axes.transAxes,
-            ha="left",
-            va="top",
-            fontsize=_TEXT_SIZE,
-            color="#444444",
-        )
-
-    def _build_licence(self, axes: Axes) -> Text:
-        """Write the licence statement into the figure, not under it."""
-        return axes.text(
-            0.0,
-            0.22,
-            _wrap(self.comparison.licence(), 76),
-            transform=axes.transAxes,
-            ha="left",
-            va="top",
-            fontsize=_TEXT_SIZE,
-            color="#7a1f1f",
-        )
+        with contextlib.suppress(ValueError):
+            # ValueError when the probes bracket no window, in which case
+            # there is no speed-lost row to qualify.
+            note = (
+                f"{note} Speed lost is each tier's resultant projected on the "
+                "direction of travel, integrated over the probed window on the "
+                "same quadrature; F0's own record shows "
+                f"{model.f0_recorded_speed_lost_m_s:.3g} m/s over that window, "
+                "so the gap between that and the F0 row is the quadrature, not "
+                "a divergence."
+            )
+        for caveat in (
+            model.engagement_caveat(),
+            *(probe.divot_caveat() for probe in model.shot_probes),
+        ):
+            if caveat:
+                note = f"{note} {caveat}"
+                break
+        return _wrap(note, _WRAP_CHARS)
 
     # ------------------------------------------------------------ scrubbing
 
@@ -543,6 +547,53 @@ class CrossTierArtists:
             f"|F0| {float(model.f0_force_magnitude_n[index]):.4g} N, "
             f"{float(model.f0_speed_m_s[index]):.4g} m/s"
         )
+
+
+class _TextColumn:
+    """Stacks text blocks down an axes, tracking where the last one ended.
+
+    Four blocks at four hand-chosen fractions cannot know how long each
+    other is, and these blocks grow with the probe count and with every
+    caveat that turns out to apply. Overlapping caveats are the one
+    failure a page of caveats must not have.
+    """
+
+    def __init__(self, axes: Axes) -> None:
+        """Start a column at the top of ``axes``.
+
+        Args:
+            axes: The (invisible) axes to lay text out in.
+        """
+        self._axes = axes
+        self._cursor = 1.0
+        height_in = axes.figure.get_size_inches()[1] * axes.get_position().height
+        self._line = (_TEXT_SIZE * _LINE_SPACING / _POINTS_PER_INCH) / height_in
+
+    def add(self, block: str, *, colour: str, monospace: bool = False) -> Text:
+        """Draw one block below the last and advance the cursor.
+
+        Args:
+            block: The text, already wrapped.
+            colour: Its colour.
+            monospace: Whether to set it in a monospaced family, which the
+                agreement table wants so its columns line up.
+
+        Returns:
+            The text artist.
+        """
+        artist = self._axes.text(
+            0.0,
+            self._cursor,
+            block,
+            transform=self._axes.transAxes,
+            ha="left",
+            va="top",
+            fontsize=_TEXT_SIZE,
+            color=colour,
+            family="monospace" if monospace else None,
+        )
+        self._cursor -= (len(block.splitlines()) + _BLOCK_GAP_LINES) * self._line
+        return artist
 
 
 def _wrap(text: str, width: int, *, indent: str = "") -> str:

--- a/src/tools/bunker_shot_gui/render_crosstier.py
+++ b/src/tools/bunker_shot_gui/render_crosstier.py
@@ -230,7 +230,7 @@ class CrossTierArtists:
         if quantity is ComparedQuantity.DIVOT_SECTION:
             return (model.f0_divot_section_area_m2 * scale, None)
         try:
-            implied = model.f1_implied_speed_m_s()
+            implied = model.implied_speed_m_s()
         except ValueError:
             implied = None
         return (model.f0_speed_m_s, implied)
@@ -245,7 +245,7 @@ class CrossTierArtists:
         if quantity is ComparedQuantity.SPEED_LOST:
             f0 = np.array([model.f0_speed_m_s[probe.frame] for probe in ordered])
             try:
-                implied = model.f1_implied_speed_m_s()
+                implied = model.implied_speed_m_s()
             except ValueError:
                 return (times, f0, np.full(times.size, np.nan))
             return (times, f0, np.array([implied[probe.frame] for probe in ordered]))
@@ -485,7 +485,8 @@ class CrossTierArtists:
             f"Method: {model.n_probes} probe(s) of a {model.n_frames}-sample F0 "
             "record. F1 has no shot history yet (#8733), so each F1 point is a "
             "separate march to that pose under a declared straight-line "
-            "constant-speed approach. The points are therefore not joined."
+            "constant-speed approach. The points are therefore not joined. "
+            f"{model.resolution_note()}"
         )
         if caveats:
             note = f"{note} {caveats[0]}"

--- a/src/tools/bunker_shot_gui/viewport_widgets.py
+++ b/src/tools/bunker_shot_gui/viewport_widgets.py
@@ -1,6 +1,8 @@
-"""The 3-D scene view and the trace panel, as Qt views (issues #8706, #8708).
+"""The linked follower views: 3-D scene, traces, cross-tier check.
 
-Neither widget here owns a transport. :class:`~.widgets.SoleLoadFieldWidget`
+Issues #8706 and #8708 for the first two, #8713 for the third.
+
+No widget here owns a transport. :class:`~.widgets.SoleLoadFieldWidget`
 already has one -- a slider, a timer and a play button, built for the sole
 load field -- and #8708 asks for the three views to be scrubbed *in lockstep*,
 which is precisely the thing a second slider would break. Both classes below
@@ -25,20 +27,31 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from .crosstier import CrossTierComparison
 from .render import viewport_fallback
 from .render3d import SceneScale, ShotSceneArtists, scene_scale
+from .render_crosstier import CrossTierArtists
 from .render_traces import TracePanelArtists
 from .shot3d import CameraPreset, ShotScene
 from .traces import ShotTraces, ValidityBand
 from .widgets import build_canvas_column
 
 __all__ = [
+    "CrossTierWidget",
     "ShotViewportWidget",
     "TracePanelWidget",
 ]
 
 _MIN_SCENE_HEIGHT_PX = 340
 _MIN_TRACE_HEIGHT_PX = 420
+_MIN_CROSS_TIER_HEIGHT_PX = 460
+_IDLE_CROSS_TIER = (
+    "The cross-tier check has not been run. It puts F1 -- the 2-D "
+    "plane-strain MPM continuum -- beside F0 on the quantities both tiers "
+    "produce, and it is minutes of solving rather than milliseconds: F1 has "
+    "no shot history yet (#8733), so every probe is its own march to one "
+    "recorded pose."
+)
 
 
 class ShotViewportWidget(QWidget):
@@ -337,4 +350,143 @@ class TracePanelWidget(QWidget):
         self._readout.setText(
             f"{traces.time_display[self._frame]:.2f} {traces.time_unit} - "
             f"{status.value.replace('_', ' ').upper()}"
+        )
+
+
+class CrossTierWidget(QWidget):
+    """F0 against F1 on one cursor, run on demand (issue #8713).
+
+    A follower, like the two views above, and for a stronger reason than
+    tidiness: the whole point of the comparison is that both tiers are
+    describing the *same* moment of the *same* shot, so a cursor of its own
+    would be able to say otherwise.
+
+    It is also **empty until asked**. A cross-tier check is minutes of F1
+    marching -- F1 has no shot history (issue #8733), so each probe is a
+    separate march to one recorded pose -- and putting that on the path of
+    every design evaluation would make the workbench unusable. The
+    workbench runs it from its own button and hands the result here.
+
+    The status line restates the licence rather than leaving it to the
+    figure. Both carry it: the figure because a screenshot keeps its
+    contents and loses its surroundings, the status line because a reader
+    scrubbing the cursor is looking at the widget and not at the caption.
+    """
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        """Build an empty view.
+
+        Args:
+            title: Heading shown above the canvas.
+            parent: Parent widget.
+        """
+        super().__init__(parent)
+        self._title = str(title)
+        self._comparison: CrossTierComparison | None = None
+        self._artists: CrossTierArtists | None = None
+        self._frame = 0
+
+        layout, self._heading, self._canvas = build_canvas_column(
+            self,
+            self._title,
+            width_in=11.0,
+            height_in=8.0,
+            minimum_height_px=_MIN_CROSS_TIER_HEIGHT_PX,
+        )
+        self._readout = QLabel(_IDLE_CROSS_TIER)
+        self._readout.setWordWrap(True)
+        self._readout.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        layout.addWidget(self._readout)
+
+    # ------------------------------------------------------------ accessors
+
+    @property
+    def title(self) -> str:
+        """The heading shown above the canvas."""
+        return self._title
+
+    @property
+    def has_comparison(self) -> bool:
+        """Whether a comparison is loaded."""
+        return self._comparison is not None
+
+    @property
+    def n_frames(self) -> int:
+        """Samples in the loaded F0 record; zero when empty."""
+        return 0 if self._comparison is None else self._comparison.n_frames
+
+    @property
+    def frame_index(self) -> int:
+        """The sample currently under the cursor."""
+        return self._frame
+
+    @property
+    def status_text(self) -> str:
+        """What the status line is saying."""
+        return self._readout.text()
+
+    # --------------------------------------------------------------- content
+
+    def set_comparison(self, comparison: CrossTierComparison) -> None:
+        """Load one comparison and open on the probe F0's force peaked at.
+
+        Args:
+            comparison: The comparison to draw.
+        """
+        self._comparison = comparison
+        self._artists = CrossTierArtists(self._canvas.fig, comparison)
+        self._frame = comparison.peak_probe.frame
+        self._redraw()
+
+    def clear(self) -> None:
+        """Drop the comparison, so nothing stale stays under a new shot."""
+        self._comparison = None
+        self._artists = None
+        self._frame = 0
+        self._readout.setText(_IDLE_CROSS_TIER)
+        self._canvas.fig.clear()
+        self._canvas.draw_idle()
+
+    # ------------------------------------------------------------- following
+
+    def set_frame(self, frame: int) -> None:
+        """Move the cursor to one sample.
+
+        The :class:`~.widgets.FollowsFrame` entry point. A frame arriving
+        for an empty view is ignored rather than refused: the workbench
+        clears views independently, so a transport tick can legitimately
+        reach a view that has just been emptied.
+
+        Args:
+            frame: The sample index.
+
+        Raises:
+            ValueError: If a comparison is loaded and the index is outside
+                its record. A clamped index would leave this view showing a
+                different moment from the one driving it.
+        """
+        if self._comparison is None:
+            return
+        if not 0 <= int(frame) < self._comparison.n_frames:
+            raise ValueError(
+                f"frame {frame} is outside the shot, which has "
+                f"{self._comparison.n_frames} samples"
+            )
+        self._frame = int(frame)
+        self._redraw()
+
+    def _redraw(self) -> None:
+        """Repaint the canvas and restate the licence beside the moment."""
+        comparison = self._comparison
+        if comparison is None or self._artists is None:
+            return
+        self._artists.update(self._frame)
+        self._canvas.draw_idle()
+        moment = float(comparison.time_s[self._frame]) * 1e3
+        status = comparison.band.status_at(self._frame)
+        self._readout.setText(
+            f"{moment:.2f} ms - {status.value.replace('_', ' ').upper()} - "
+            f"{comparison.licence_stamp()}"
         )

--- a/src/tools/bunker_shot_gui/viewport_widgets.py
+++ b/src/tools/bunker_shot_gui/viewport_widgets.py
@@ -485,7 +485,7 @@ class CrossTierWidget(QWidget):
         self._artists.update(self._frame)
         self._canvas.draw_idle()
         moment = float(comparison.time_s[self._frame]) * 1e3
-        status = comparison.band.status_at(self._frame)
+        status = comparison.status_at(self._frame)
         self._readout.setText(
             f"{moment:.2f} ms - {status.value.replace('_', ' ').upper()} - "
             f"{comparison.licence_stamp()}"

--- a/tests/bunkershot3d/solvers/mpm/test_approach_distance.py
+++ b/tests/bunkershot3d/solvers/mpm/test_approach_distance.py
@@ -1,0 +1,123 @@
+"""The F1 approach must not blow up on a near-level descent (issue #8713).
+
+F1 has no instantaneous answer, so it builds a history: the section is
+reversed along its own velocity until it is clear of the bed, then driven
+back to the queried pose. Reversing along the velocity means dividing the
+required height by the velocity's vertical component -- and at the deepest
+sample of a real shot that component is essentially zero.
+
+Measured on the workbench's own 25 m/s greenside record: at the deepest
+sample the direction cosine on ``z`` is -0.0026, so a 24 mm climb needs a
+**9.5 m** run-in. The bed is then sized to cover it, and a 9.5 m bed at a
+6 mm cell is fifty thousand particles marched for twenty thousand steps --
+a query that looks ordinary and never returns. Nothing caught it but the
+``max_steps`` cap, and only after the bed had been allocated.
+
+The rule below is the one the level branch already implements, applied
+whenever the descending branch would be the longer of the two: run in
+horizontally from beyond the body's own length. Same modelling assumption,
+chosen by which one is actually shorter rather than by the sign of a
+number that passes through zero mid-shot.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from bunkershot3d.sand import PlayingCondition, playing_condition
+from bunkershot3d.solvers.elements import SurfaceElements
+from bunkershot3d.solvers.envelope import RefusalPolicy
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.solver import PlaneStrainMPMSolver
+from bunkershot3d.solvers.protocol import IntrusionState
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def material() -> SandContinuum:
+    return SandContinuum.from_sand_state(playing_condition(PlayingCondition.FIRM))
+
+
+@pytest.fixture(scope="module")
+def solver(material: SandContinuum) -> PlaneStrainMPMSolver:
+    return PlaneStrainMPMSolver(
+        material=material,
+        cell_size_m=0.006,
+        effective_width_m=0.030,
+        bed_depth_m=0.040,
+        run_in_lengths=0.3,
+        refusal_policy=RefusalPolicy.REPORT,
+        max_steps=200000,
+    )
+
+
+def submerged_state(descent_deg: float, *, speed_m_s: float = 20.0) -> IntrusionState:
+    """A 40 x 16 mm section 12 mm under the surface at a stated descent."""
+    corners = np.array(
+        [
+            [-0.020, 0.0, -0.020],
+            [0.020, 0.0, -0.020],
+            [0.020, 0.0, -0.004],
+            [-0.020, 0.0, -0.004],
+        ]
+    )
+    normals = np.tile([0.0, 0.0, -1.0], (corners.shape[0], 1))
+    areas = np.full(corners.shape[0], 4.0e-4)
+    angle = math.radians(descent_deg)
+    return IntrusionState(
+        SurfaceElements(corners, normals, areas),
+        (speed_m_s * math.cos(angle), 0.0, -speed_m_s * math.sin(angle)),
+        free_surface_height_m=0.0,
+    )
+
+
+class TestANearLevelDescentDoesNotDemandAMetreOfRunIn:
+    """The failure a deep sweep pose walks straight into."""
+
+    def test_the_approach_is_bounded_by_the_horizontal_run_in(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """0.15 deg of descent must not cost more than a level query does."""
+        level, _ = solver._approach(submerged_state(0.0))
+        shallow, shallow_distance = solver._approach(submerged_state(0.15))
+        level_distance = solver._approach(submerged_state(0.0))[1]
+        del level, shallow
+        # Unbounded, this is (0.012 + 0.020) / sin(0.15 deg) = 12 m.
+        assert shallow_distance < 2.0 * level_distance, (
+            f"{shallow_distance:.4g} m against a level run-in of {level_distance:.4g} m"
+        )
+        assert shallow_distance < 0.5
+
+    def test_a_steep_descent_still_backs_straight_out_of_the_bed(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """The guard must not take over where the descending branch is right."""
+        _, steep = solver._approach(submerged_state(60.0))
+        _, level = solver._approach(submerged_state(0.0))
+        assert steep < level
+
+    def test_the_step_count_stays_the_same_order_across_the_transition(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """No discontinuity as the descent passes through the switch."""
+        counts = [
+            solver._approach_steps(
+                submerged_state(angle),
+                solver._approach(submerged_state(angle))[1],
+                solver.time_step_s(submerged_state(angle)),
+            )
+            for angle in (0.05, 0.5, 5.0, 30.0)
+        ]
+        assert max(counts) < 10 * min(counts), counts
+
+    def test_a_shallow_descending_query_actually_runs(
+        self, solver: PlaneStrainMPMSolver
+    ) -> None:
+        """The observable: it returns, rather than allocating a 9 m bed."""
+        run = solver.run(submerged_state(0.15))
+        assert run.n_steps > 0
+        assert run.n_steps < 2000, run.n_steps

--- a/tests/bunkershot3d/solvers/mpm/test_divot_section.py
+++ b/tests/bunkershot3d/solvers/mpm/test_divot_section.py
@@ -1,0 +1,222 @@
+"""The F1 divot as a *section*, not only a depth (issue #8713).
+
+:meth:`~bunkershot3d.solvers.mpm.solver.MPMRun.divot_depth_m` answers how
+deep the free surface was pushed. The cross-tier comparison needs the other
+half of the same measurement -- how much sand was moved -- because F0's
+divot is reported as an area (``DivotMetrics.section_area_m2``) and a mass,
+and a depth alone cannot be compared against either.
+
+The empty-bin case is the whole reason this is a value object rather than a
+float: a bin the sand has left entirely has no surface height at all, so it
+cannot contribute a depth to an integral. Skipping it under-reports the
+area, and filling it in invents one. The count travels with the number so a
+caller can say which it is looking at.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bunkershot3d.sand import PlayingCondition, playing_condition
+from bunkershot3d.solvers.exceptions import SolverInputError
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.state import (
+    ParticleState,
+    SurfaceDepression,
+    settled_bed,
+    surface_depression,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def material() -> SandContinuum:
+    return SandContinuum.from_sand_state(playing_condition(PlayingCondition.FIRM))
+
+
+def flat_bed(material: SandContinuum) -> ParticleState:
+    """An undisturbed bed: the surface is exactly where it was seeded."""
+    return settled_bed(
+        material,
+        x_bounds_m=(0.0, 0.080),
+        free_surface_height_m=0.0,
+        depth_m=0.040,
+        cell_size_m=0.004,
+        particles_per_cell_axis=2,
+    )
+
+
+class TestAnUndisturbedBedHasNoDivot:
+    """The zero the measurement has to return before any other number counts."""
+
+    def test_the_section_area_is_zero(self, material: SandContinuum) -> None:
+        depression = surface_depression(
+            flat_bed(material),
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=16,
+        )
+        # The topmost particle sits half a particle spacing below the seeded
+        # surface, so the profile is a constant offset rather than exactly
+        # zero. What must be zero is the *variation*: a flat bed has no
+        # section, whatever datum it is measured from.
+        assert depression.section_area_m2 == pytest.approx(
+            depression.max_depth_m * 0.080, rel=1e-9
+        )
+
+    def test_no_bin_is_empty(self, material: SandContinuum) -> None:
+        depression = surface_depression(
+            flat_bed(material),
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=16,
+        )
+        assert depression.n_empty_bins == 0
+        assert depression.fully_resolved
+
+
+class TestAScoopedBedReportsWhatWasRemoved:
+    """A depression cut by hand, against its own closed-form area."""
+
+    def test_a_rectangular_scoop_gives_its_own_area(
+        self, material: SandContinuum
+    ) -> None:
+        """Remove every particle above -20 mm over the middle 40 mm.
+
+        The resulting section is a 40 mm x 20 mm rectangle, so the area is
+        8.0e-4 m^2 up to the half-spacing offset the seeding leaves on the
+        undisturbed shoulders.
+        """
+        particles = flat_bed(material)
+        x = particles.position_m[:, 0]
+        z = particles.position_m[:, 1]
+        keep = ~((x > 0.020) & (x < 0.060) & (z > -0.020))
+        scooped = ParticleState(
+            position_m=particles.position_m[keep],
+            velocity_m_s=particles.velocity_m_s[keep],
+            mass_kg=particles.mass_kg[keep],
+            initial_volume_m2=particles.initial_volume_m2[keep],
+            deformation_gradient=particles.deformation_gradient[keep],
+            affine=particles.affine[keep],
+        )
+        flat = surface_depression(
+            particles,
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=40,
+        )
+        cut = surface_depression(
+            scooped,
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=40,
+        )
+        removed = cut.section_area_m2 - flat.section_area_m2
+        # 40 mm wide, ~20 mm deep. The tolerance is the particle lattice: the
+        # scoop wall lands between particle rows, so the discrete cut is a
+        # spacing wider or narrower than the 40 mm the mask asked for.
+        assert removed == pytest.approx(8.0e-4, rel=0.12), (
+            f"{cut.summary()} against a flat {flat.summary()}"
+        )
+
+    def test_the_deepest_point_is_the_scoop_floor(
+        self, material: SandContinuum
+    ) -> None:
+        particles = flat_bed(material)
+        x = particles.position_m[:, 0]
+        z = particles.position_m[:, 1]
+        keep = ~((x > 0.020) & (x < 0.060) & (z > -0.020))
+        scooped = ParticleState(
+            position_m=particles.position_m[keep],
+            velocity_m_s=particles.velocity_m_s[keep],
+            mass_kg=particles.mass_kg[keep],
+            initial_volume_m2=particles.initial_volume_m2[keep],
+            deformation_gradient=particles.deformation_gradient[keep],
+            affine=particles.affine[keep],
+        )
+        cut = surface_depression(
+            scooped,
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=40,
+        )
+        assert cut.max_depth_m == pytest.approx(0.020, abs=0.002)
+
+
+class TestAnEvacuatedBinIsCountedRatherThanGuessed:
+    """The failure mode the value object exists to make visible."""
+
+    def test_an_emptied_column_is_counted(self, material: SandContinuum) -> None:
+        particles = flat_bed(material)
+        x = particles.position_m[:, 0]
+        keep = ~((x > 0.030) & (x < 0.050))
+        pierced = ParticleState(
+            position_m=particles.position_m[keep],
+            velocity_m_s=particles.velocity_m_s[keep],
+            mass_kg=particles.mass_kg[keep],
+            initial_volume_m2=particles.initial_volume_m2[keep],
+            deformation_gradient=particles.deformation_gradient[keep],
+            affine=particles.affine[keep],
+        )
+        depression = surface_depression(
+            pierced,
+            free_surface_height_m=0.0,
+            x_bounds_m=(0.0, 0.080),
+            n_bins=40,
+        )
+        assert depression.n_empty_bins > 0
+        assert not depression.fully_resolved
+        assert "bin" in depression.summary()
+
+    def test_a_window_with_no_particles_at_all_is_refused(
+        self, material: SandContinuum
+    ) -> None:
+        """Not a zero divot: nothing was measured, and zero would read as one."""
+        with pytest.raises(SolverInputError, match="no particle"):
+            surface_depression(
+                flat_bed(material),
+                free_surface_height_m=0.0,
+                x_bounds_m=(0.500, 0.580),
+                n_bins=8,
+            )
+
+
+class TestTheValueObjectRefusesNonsense:
+    """``raise``, never ``assert`` -- ``python -O`` must not switch these off."""
+
+    def test_a_negative_area_is_refused(self) -> None:
+        with pytest.raises(SolverInputError, match="non-negative"):
+            SurfaceDepression(
+                section_area_m2=-1.0,
+                max_depth_m=0.0,
+                n_bins=8,
+                n_empty_bins=0,
+                bed_width_m=0.08,
+            )
+
+    def test_more_empty_bins_than_bins_is_refused(self) -> None:
+        with pytest.raises(SolverInputError, match="empty"):
+            SurfaceDepression(
+                section_area_m2=0.0,
+                max_depth_m=0.0,
+                n_bins=8,
+                n_empty_bins=9,
+                bed_width_m=0.08,
+            )
+
+    def test_the_displaced_mass_needs_a_width_and_a_density(self) -> None:
+        depression = SurfaceDepression(
+            section_area_m2=8.0e-4,
+            max_depth_m=0.02,
+            n_bins=40,
+            n_empty_bins=0,
+            bed_width_m=0.08,
+        )
+        assert depression.displaced_mass_kg(
+            width_m=0.030, bulk_density_kg_m3=1550.0
+        ) == pytest.approx(8.0e-4 * 0.030 * 1550.0)
+        with pytest.raises(SolverInputError, match="width_m"):
+            depression.displaced_mass_kg(width_m=0.0, bulk_density_kg_m3=1550.0)
+        with pytest.raises(SolverInputError, match="bulk_density"):
+            depression.displaced_mass_kg(width_m=0.03, bulk_density_kg_m3=-1.0)

--- a/tests/tools/bunker_shot_gui/test_cross_tier_view.py
+++ b/tests/tools/bunker_shot_gui/test_cross_tier_view.py
@@ -1,0 +1,158 @@
+"""The cross-tier view inside the Qt workbench (issue #8713, epic #8699).
+
+The arithmetic and the drawing are covered headlessly in ``test_crosstier``
+and ``test_render_crosstier``. What is pinned here is what only exists once
+there is a window:
+
+* the view **follows** the transport the sole load field already owns, and
+  owns none of its own -- a second slider would let the panels drift apart,
+  which is the one thing linking them exists to prevent;
+* it is **empty until asked**, because a cross-tier check is minutes of F1
+  marching and must not be on the path of every shot;
+* clearing it stops nothing animating under a stale verdict.
+
+Qt is imported through ``pytest.importorskip`` for the same reason as
+``test_gui``: PyQt6 fails to load on some development machines.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt6", reason="the workbench shell needs a Qt binding")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from bunkershot3d.solvers import EnvelopeStatus  # noqa: E402
+from src.tools.bunker_shot_gui.crosstier import CrossTierComparison  # noqa: E402
+from src.tools.bunker_shot_gui.traces import ValidityBand  # noqa: E402
+from src.tools.bunker_shot_gui.viewport_widgets import (  # noqa: E402
+    CrossTierWidget,
+)
+from src.tools.bunker_shot_gui.widgets import (  # noqa: E402
+    FollowsFrame,
+    SoleLoadFieldWidget,
+)
+from tests.tools.bunker_shot_gui.test_crosstier import probe  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    """One offscreen QApplication for the module."""
+    application = QApplication.instance()
+    if application is None:
+        application = QApplication(sys.argv[:1])
+    return application
+
+
+def comparison() -> CrossTierComparison:
+    """A comparison over a synthetic 9-sample F0 record."""
+    time_s = np.linspace(0.0, 8.0e-3, 9)
+    force = np.zeros((9, 3))
+    force[:, 0] = -np.linspace(10.0, 50.0, 9)
+    force[:, 2] = np.linspace(10.0, 50.0, 9)
+    return CrossTierComparison(
+        shot_probes=(
+            probe(2, 2.0e-3, f0_force_n=20.0, f1_force_n=22.0),
+            probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=120.0),
+        ),
+        time_s=time_s,
+        f0_force_n=force,
+        f0_sole_depth_m=np.linspace(0.0, 0.012, 9),
+        f0_velocity_m_s=np.stack(
+            [
+                np.linspace(25.0, 21.0, 9),
+                np.zeros(9),
+                np.zeros(9),
+            ],
+            axis=1,
+        ),
+        f0_divot_section_area_m2=np.linspace(0.0, 6.0e-4, 9),
+        band=ValidityBand(
+            time_s=time_s, statuses=tuple([EnvelopeStatus.BEYOND_VALIDATION] * 9)
+        ),
+        head_mass_kg=0.300,
+        declared_width_m=0.030,
+        bulk_density_kg_m3=1550.0,
+        f1_cell_size_m=0.002,
+    )
+
+
+class TestTheViewOwnsNoTransport:
+    def test_it_is_accepted_where_a_follower_is_asked_for(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        """Structural, since ``FollowsFrame`` is not runtime-checkable."""
+        follower: FollowsFrame = CrossTierWidget("check")
+        assert callable(follower.set_frame)
+
+    def test_the_transport_actually_drives_it(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        """The link is wired, not merely accepted."""
+        field_view = SoleLoadFieldWidget("A")
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        field_view.link(view)
+        field_view.frame_changed.emit(3)
+        assert view.frame_index == 3
+
+    def test_it_owns_no_way_to_drive_the_transport_back(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        """Two views driving each other is what the narrow protocol prevents."""
+        view = CrossTierWidget("check")
+        assert not hasattr(view, "play")
+        assert not hasattr(view, "advance")
+
+    def test_a_frame_arriving_before_a_comparison_is_ignored(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        """The workbench clears views independently of the transport."""
+        CrossTierWidget("check").set_frame(3)
+
+    def test_a_frame_outside_the_record_is_refused(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        with pytest.raises(ValueError, match="outside"):
+            view.set_frame(99)
+
+
+class TestTheViewIsEmptyUntilAsked:
+    """A cross-tier check is minutes of F1 marching, not a per-shot view."""
+
+    def test_it_starts_with_nothing_and_says_so(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        view = CrossTierWidget("check")
+        assert not view.has_comparison
+        assert view.n_frames == 0
+        assert "not been run" in view.status_text.lower()
+
+    def test_loading_a_comparison_opens_on_the_peak_probe(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        assert view.has_comparison
+        assert view.frame_index == 6
+
+    def test_clearing_drops_it(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        view.clear()
+        assert not view.has_comparison
+        assert view.n_frames == 0
+
+
+class TestTheViewRestatesWhatItDoesNotLicense:
+    def test_the_readout_carries_the_licence_not_only_the_figure(
+        self,
+        qapp,  # type: ignore[no-untyped-def]
+    ) -> None:
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        assert "not validation" in view.status_text.lower()
+
+    def test_following_the_cursor_keeps_the_licence_on_screen(self, qapp) -> None:  # type: ignore[no-untyped-def]
+        view = CrossTierWidget("check")
+        view.set_comparison(comparison())
+        view.set_frame(2)
+        assert "not validation" in view.status_text.lower()
+        assert "2.00" in view.status_text

--- a/tests/tools/bunker_shot_gui/test_crosstier.py
+++ b/tests/tools/bunker_shot_gui/test_crosstier.py
@@ -1,0 +1,568 @@
+"""The cross-tier comparison, headless (issue #8713, epic #8699).
+
+Two things are being tested here and they are not the same thing.
+
+The **arithmetic** -- ratios, agreement classes, divergence spans, the
+inertial-share crossover, the licence statement -- is tested on hand-built
+value objects, because it has to be right for numbers nobody has run yet
+and because an MPM march inside a unit test would put a 30-second solve
+behind an assertion about a division.
+
+The **wiring** -- that F0's recorded pose really does reach F1 unchanged,
+and that the pair produces the divergence ADR-0033 measured -- is tested
+once, on a deliberately coarse bed, and is checked for *sign and shape*
+rather than pinned to a number the discretisation would move.
+
+What is deliberately not tested is agreement. ADR-0033 is explicit that
+consistency between two uncalibrated models is not validation, so a test
+asserting the two tiers agree would be asserting the one thing this view
+exists to refuse to claim.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bunkershot3d.solvers import EnvelopeStatus, FidelityTier
+from bunkershot3d.solvers.envelope import MAX_VALIDATED_SPEED_M_S
+from bunkershot3d.solvers.mpm.state import SurfaceDepression
+from bunkershot3d.solvers.mpm.verification import F0CrossCheck
+from src.tools.bunker_shot_gui.crosstier import (
+    DECLARED_AGREEMENT_BAND,
+    AgreementClass,
+    ComparedQuantity,
+    CrossTierComparison,
+    CrossTierProbe,
+    QuantityAgreement,
+    inertial_share_crossover,
+    licence_statement,
+)
+from src.tools.bunker_shot_gui.traces import ValidityBand
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------- fixtures
+
+
+def cross_check(
+    *,
+    speed_m_s: float,
+    f0_force_n: float,
+    f1_force_n: float,
+    f0_inertial_share: float,
+    f1_flux_share: float,
+    depth_m: float = 0.010,
+    f1_section_area_m2: float = 4.0e-4,
+    n_empty_bins: int = 0,
+) -> F0CrossCheck:
+    """One paired query, built from the shares rather than solved for them."""
+    direction = np.array([1.0, 0.0, -0.4])
+    direction = direction / np.linalg.norm(direction)
+    return F0CrossCheck(
+        speed_m_s=speed_m_s,
+        f0_force_n=f0_force_n * direction,
+        f1_force_n=f1_force_n * direction,
+        f0_depth_force_n=f0_force_n * (1.0 - f0_inertial_share) * direction,
+        f0_inertial_force_n=f0_force_n * f0_inertial_share * direction,
+        f1_stress_force_n=f1_force_n * (1.0 - f1_flux_share) * direction,
+        f1_flux_force_n=f1_force_n * f1_flux_share * direction,
+        submerged_depth_m=depth_m,
+        f0_max_depth_m=depth_m,
+        f1_max_depth_m=depth_m,
+        f1_divot=SurfaceDepression(
+            section_area_m2=f1_section_area_m2,
+            max_depth_m=depth_m,
+            n_bins=64,
+            n_empty_bins=n_empty_bins,
+            bed_width_m=0.30,
+        ),
+        effective_width_m=0.030,
+    )
+
+
+def probe(
+    frame: int,
+    time_s: float,
+    *,
+    speed_m_s: float = 12.0,
+    f0_force_n: float = 40.0,
+    f1_force_n: float = 60.0,
+    f0_inertial_share: float = 0.93,
+    f1_flux_share: float = 0.69,
+    f0_section_area_m2: float = 5.0e-4,
+    f1_section_area_m2: float = 4.0e-4,
+    depth_m: float = 0.010,
+    n_empty_bins: int = 0,
+) -> CrossTierProbe:
+    return CrossTierProbe(
+        frame=frame,
+        time_s=time_s,
+        check=cross_check(
+            speed_m_s=speed_m_s,
+            f0_force_n=f0_force_n,
+            f1_force_n=f1_force_n,
+            f0_inertial_share=f0_inertial_share,
+            f1_flux_share=f1_flux_share,
+            depth_m=depth_m,
+            f1_section_area_m2=f1_section_area_m2,
+            n_empty_bins=n_empty_bins,
+        ),
+        f0_divot_section_area_m2=f0_section_area_m2,
+        f0_sole_depth_m=depth_m,
+        declared_width_m=0.030,
+        bulk_density_kg_m3=1550.0,
+    )
+
+
+def comparison(probes: tuple[CrossTierProbe, ...]) -> CrossTierComparison:
+    """A comparison over a synthetic 9-sample F0 record."""
+    time_s = np.linspace(0.0, 8.0e-3, 9)
+    speed = np.linspace(25.0, 21.0, 9)
+    force = np.zeros((9, 3))
+    force[:, 0] = -np.linspace(10.0, 50.0, 9)
+    force[:, 2] = np.linspace(10.0, 50.0, 9)
+    return CrossTierComparison(
+        shot_probes=probes,
+        time_s=time_s,
+        f0_force_n=force,
+        f0_sole_depth_m=np.linspace(0.0, 0.012, 9),
+        f0_speed_m_s=speed,
+        f0_divot_section_area_m2=np.linspace(0.0, 6.0e-4, 9),
+        band=ValidityBand(
+            time_s=time_s,
+            statuses=tuple([EnvelopeStatus.BEYOND_VALIDATION] * 9),
+        ),
+        head_mass_kg=0.300,
+        declared_width_m=0.030,
+        bulk_density_kg_m3=1550.0,
+    )
+
+
+# ------------------------------------------------------------- agreement
+
+
+class TestQuantityAgreementIsARatioAndAVerdictOnIt:
+    """The number, and the declared band it is judged against."""
+
+    def test_the_ratio_is_f1_over_f0(self) -> None:
+        agreement = QuantityAgreement(
+            quantity=ComparedQuantity.WRENCH, f0_value=40.0, f1_value=60.0
+        )
+        assert agreement.ratio == pytest.approx(1.5)
+        assert agreement.relative_difference == pytest.approx(0.5)
+
+    def test_a_ratio_inside_the_band_is_consistent(self) -> None:
+        agreement = QuantityAgreement(
+            quantity=ComparedQuantity.SOLE_DEPTH, f0_value=0.0100, f1_value=0.0105
+        )
+        assert agreement.agreement is AgreementClass.CONSISTENT
+        assert not agreement.diverged
+
+    def test_a_ratio_outside_the_band_is_divergent(self) -> None:
+        agreement = QuantityAgreement(
+            quantity=ComparedQuantity.WRENCH, f0_value=166.0, f1_value=446.0
+        )
+        assert agreement.agreement is AgreementClass.DIVERGENT
+        assert agreement.diverged
+
+    def test_the_band_is_symmetric_in_the_ratio(self) -> None:
+        """2x and 0.5x are the same disagreement, so the band is on log ratio."""
+        up = QuantityAgreement(
+            quantity=ComparedQuantity.WRENCH, f0_value=10.0, f1_value=20.0
+        )
+        down = QuantityAgreement(
+            quantity=ComparedQuantity.WRENCH, f0_value=20.0, f1_value=10.0
+        )
+        assert up.log_ratio == pytest.approx(down.log_ratio)
+        assert up.agreement is down.agreement
+
+    def test_a_tier_that_produced_nothing_is_incomparable_not_agreeing(self) -> None:
+        """Two zeroes are not a match; they are an unanswered question."""
+        nothing = QuantityAgreement(
+            quantity=ComparedQuantity.DIVOT_SECTION, f0_value=0.0, f1_value=0.0
+        )
+        assert nothing.agreement is AgreementClass.INCOMPARABLE
+        one_sided = QuantityAgreement(
+            quantity=ComparedQuantity.DIVOT_SECTION, f0_value=0.0, f1_value=4.0e-4
+        )
+        assert one_sided.agreement is AgreementClass.INCOMPARABLE
+
+    def test_a_negative_magnitude_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            QuantityAgreement(
+                quantity=ComparedQuantity.WRENCH, f0_value=-1.0, f1_value=1.0
+            )
+
+    def test_a_band_of_zero_is_refused(self) -> None:
+        """A zero band would class every finite discretisation as divergent."""
+        with pytest.raises(ValueError, match="band"):
+            QuantityAgreement(
+                quantity=ComparedQuantity.WRENCH,
+                f0_value=1.0,
+                f1_value=1.0,
+                band=0.0,
+            )
+
+    def test_the_summary_names_the_quantity_its_unit_and_the_band(self) -> None:
+        agreement = QuantityAgreement(
+            quantity=ComparedQuantity.WRENCH, f0_value=40.0, f1_value=60.0
+        )
+        text = agreement.summary()
+        assert "N" in text
+        assert "1.5" in text
+        assert f"{DECLARED_AGREEMENT_BAND:g}" in text
+
+
+class TestEveryComparedQuantitySaysWhatEachTierMeansByIt:
+    """The two tiers use the same word for different measurements."""
+
+    def test_each_quantity_carries_a_unit_and_a_note(self) -> None:
+        for quantity in ComparedQuantity:
+            assert quantity.unit
+            assert quantity.label
+            assert len(quantity.note) > 30, quantity
+
+    def test_the_divot_note_says_the_two_divots_are_different_things(self) -> None:
+        note = ComparedQuantity.DIVOT_SECTION.note
+        assert "envelope" in note
+        assert "sand" in note
+
+    def test_the_speed_lost_note_says_f1_is_one_way_coupled(self) -> None:
+        assert "one-way" in ComparedQuantity.SPEED_LOST.note
+
+
+# ----------------------------------------------------------------- probes
+
+
+class TestAProbeIsOneInstantGivenToBothTiersUnchanged:
+    def test_it_reports_both_magnitudes_and_the_direction_cosine(self) -> None:
+        one = probe(4, 4.0e-3)
+        assert one.f0_force_magnitude_n == pytest.approx(40.0)
+        assert one.f1_force_magnitude_n == pytest.approx(60.0)
+        assert one.direction_agreement == pytest.approx(1.0)
+
+    def test_the_two_divot_masses_use_one_declared_width(self) -> None:
+        """Otherwise the mass comparison is confounded by two assumptions."""
+        one = probe(4, 4.0e-3, f0_section_area_m2=5.0e-4, f1_section_area_m2=4.0e-4)
+        assert one.f0_divot_mass_kg == pytest.approx(5.0e-4 * 0.030 * 1550.0)
+        assert one.f1_divot_mass_kg == pytest.approx(4.0e-4 * 0.030 * 1550.0)
+
+    def test_the_inertial_share_gap_is_f0_minus_f1(self) -> None:
+        one = probe(4, 4.0e-3, f0_inertial_share=0.93, f1_flux_share=0.69)
+        assert one.inertial_share_gap == pytest.approx(0.24, abs=1e-6)
+
+    def test_it_yields_an_agreement_per_instantaneous_quantity(self) -> None:
+        one = probe(4, 4.0e-3)
+        for quantity in (
+            ComparedQuantity.WRENCH,
+            ComparedQuantity.SOLE_DEPTH,
+            ComparedQuantity.DIVOT_SECTION,
+            ComparedQuantity.DIVOT_MASS,
+        ):
+            assert one.agreement(quantity).quantity is quantity
+
+    def test_speed_lost_is_refused_at_a_single_instant(self) -> None:
+        """It is a window integral; an instant cannot answer it."""
+        with pytest.raises(ValueError, match="window"):
+            probe(4, 4.0e-3).agreement(ComparedQuantity.SPEED_LOST)
+
+    def test_an_unresolved_divot_is_flagged_rather_than_quoted_quietly(self) -> None:
+        one = probe(4, 4.0e-3, n_empty_bins=3)
+        assert not one.divot_fully_resolved
+        assert "lower bound" in one.divot_caveat()
+
+
+# ------------------------------------------------------------ comparison
+
+
+class TestTheComparisonOverlaysThePairOnOneCursor:
+    def test_the_probes_index_into_the_f0_record(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        assert model.n_frames == 9
+        assert model.probe_frames == (2, 6)
+        assert model.probe_times_s == pytest.approx((2.0e-3, 6.0e-3))
+
+    def test_a_probe_outside_the_record_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="outside"):
+            comparison(
+                (probe(2, 2.0e-3), probe(99, 9.9e-3)),
+            )
+
+    def test_a_probe_whose_time_disagrees_with_its_frame_is_refused(self) -> None:
+        """A probe drawn at the wrong moment is worse than a missing one."""
+        with pytest.raises(ValueError, match="frame"):
+            comparison((probe(2, 7.0e-3),))
+
+    def test_a_comparison_with_no_probes_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            comparison(())
+
+    def test_the_shot_level_agreement_is_taken_at_f0s_peak_probe(self) -> None:
+        weak = probe(2, 2.0e-3, f0_force_n=10.0, f1_force_n=11.0)
+        strong = probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=120.0)
+        model = comparison((weak, strong))
+        assert model.peak_probe is strong
+        assert model.agreement(ComparedQuantity.WRENCH).ratio == pytest.approx(3.0)
+
+    def test_every_quantity_gets_an_agreement(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        covered = {item.quantity for item in model.agreements()}
+        assert covered == set(ComparedQuantity)
+
+
+class TestSpeedLostIsDerivedAndSaysSo:
+    """F1 is driven kinematically, so it loses no speed of its own."""
+
+    def test_f0s_speed_lost_is_read_off_its_own_record(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        # The synthetic record runs 25 -> 21 m/s over 9 samples, so the
+        # window between samples 2 and 6 is half of the 4 m/s total.
+        assert model.f0_speed_lost_m_s == pytest.approx(2.0)
+
+    def test_f1s_speed_lost_borrows_the_magnitude_and_keeps_f0s_direction(
+        self,
+    ) -> None:
+        """F0's own decrements, each weighted by the ``|F1|/|F0|`` ratio.
+
+        Integrating F1's force directly would assume the two resultants
+        point the same way, and the measured direction cosines say they do
+        not.
+        """
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=60.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=60.0),
+            )
+        )
+        assert model.f1_speed_lost_m_s == pytest.approx(1.5 * 2.0, rel=1e-9)
+
+    def test_a_ratio_that_varies_weights_where_the_deceleration_happened(
+        self,
+    ) -> None:
+        """Not simply the peak ratio times F0's loss."""
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=40.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=120.0),
+            )
+        )
+        # The record decelerates uniformly, so the ratio's mean over the
+        # four intervals -- 1.25, 1.75, 2.25, 2.75 at the interval starts --
+        # is what F0's 2.0 m/s loss is scaled by.
+        assert model.f1_speed_lost_m_s == pytest.approx(2.0 * 2.0, rel=1e-9)
+        assert model.f1_speed_lost_m_s < 3.0 * 2.0
+
+    def test_it_needs_two_probes_to_form_a_window(self) -> None:
+        model = comparison((probe(4, 4.0e-3),))
+        with pytest.raises(ValueError, match="window"):
+            _ = model.f1_speed_lost_m_s
+
+    def test_the_agreement_carries_the_one_way_coupling_note(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        agreement = model.agreement(ComparedQuantity.SPEED_LOST)
+        assert "one-way" in agreement.quantity.note
+
+
+class TestDivergenceIsMarkedRatherThanLeftForTheEye:
+    def test_a_divergent_stretch_becomes_a_span(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=42.0),
+                probe(4, 4.0e-3, f0_force_n=40.0, f1_force_n=120.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=130.0),
+            )
+        )
+        spans = model.divergence_spans(ComparedQuantity.WRENCH)
+        assert len(spans) == 1
+        assert spans[0].start_s == pytest.approx(4.0e-3)
+        assert spans[0].end_s == pytest.approx(6.0e-3)
+        assert spans[0].worst_ratio == pytest.approx(130.0 / 40.0)
+
+    def test_a_consistent_run_produces_no_spans(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=41.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=42.0),
+            )
+        )
+        assert model.divergence_spans(ComparedQuantity.WRENCH) == ()
+
+    def test_a_lone_divergent_probe_still_marks_a_span(self) -> None:
+        """A single instant of disagreement must not vanish for want of a pair."""
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=41.0),
+                probe(4, 4.0e-3, f0_force_n=40.0, f1_force_n=200.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=42.0),
+            )
+        )
+        spans = model.divergence_spans(ComparedQuantity.WRENCH)
+        assert len(spans) == 1
+        assert spans[0].start_s < 4.0e-3 < spans[0].end_s
+
+    def test_the_span_label_names_the_quantity_and_the_ratio(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=120.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=130.0),
+            )
+        )
+        label = model.divergence_spans(ComparedQuantity.WRENCH)[0].label
+        assert ComparedQuantity.WRENCH.label in label
+        assert "3.25x" in label
+
+
+# ------------------------------------------------------- the crossover
+
+
+class TestTheInertialShareCrossover:
+    """The sharpest single result: where F0's shortcut stops describing it."""
+
+    def test_a_bracketed_crossing_is_located_by_interpolation(self) -> None:
+        """ADR-0033's own numbers: F0 0.52 -> 0.93, F1 flat at 0.68 -> 0.69."""
+        probes = (
+            probe(0, 0.0, speed_m_s=5.0, f0_inertial_share=0.52, f1_flux_share=0.68),
+            probe(
+                4, 4.0e-3, speed_m_s=12.0, f0_inertial_share=0.93, f1_flux_share=0.69
+            ),
+        )
+        crossover = inertial_share_crossover(probes)
+        assert crossover is not None
+        # gap goes -0.16 -> +0.24, so the crossing sits at 0.16/0.40 of the way.
+        assert crossover.speed_m_s == pytest.approx(5.0 + 0.4 * 7.0, rel=1e-6)
+        assert 0.68 <= crossover.shared_share <= 0.69
+
+    def test_an_unbracketed_range_returns_nothing_rather_than_extrapolating(
+        self,
+    ) -> None:
+        probes = (
+            probe(0, 0.0, speed_m_s=20.0, f0_inertial_share=0.98, f1_flux_share=0.66),
+            probe(
+                4, 4.0e-3, speed_m_s=25.0, f0_inertial_share=0.99, f1_flux_share=0.65
+            ),
+        )
+        assert inertial_share_crossover(probes) is None
+
+    def test_one_probe_cannot_bracket_anything(self) -> None:
+        assert inertial_share_crossover((probe(0, 0.0),)) is None
+
+    def test_the_comparison_states_the_crossover_either_way(self) -> None:
+        above = comparison(
+            (
+                probe(
+                    2,
+                    2.0e-3,
+                    speed_m_s=25.0,
+                    f0_inertial_share=0.99,
+                    f1_flux_share=0.65,
+                ),
+                probe(
+                    6,
+                    6.0e-3,
+                    speed_m_s=21.0,
+                    f0_inertial_share=0.98,
+                    f1_flux_share=0.66,
+                ),
+            )
+        )
+        text = above.crossover_summary()
+        assert "above" in text.lower()
+        assert "0.9" in text
+
+    def test_the_summary_names_the_mechanism_not_only_the_number(self) -> None:
+        probes = (
+            probe(0, 0.0, speed_m_s=5.0, f0_inertial_share=0.52, f1_flux_share=0.68),
+            probe(
+                4, 4.0e-3, speed_m_s=12.0, f0_inertial_share=0.93, f1_flux_share=0.69
+            ),
+        )
+        crossover = inertial_share_crossover(probes)
+        assert crossover is not None
+        assert "yield" in crossover.summary()
+
+    def test_a_declared_speed_sweep_drives_the_crossover_when_present(self) -> None:
+        """The shot need not span the crossing; a sweep is a separate probe set."""
+        model = comparison((probe(2, 2.0e-3, speed_m_s=25.0), probe(6, 6.0e-3)))
+        swept = CrossTierComparison(
+            shot_probes=model.shot_probes,
+            time_s=model.time_s,
+            f0_force_n=model.f0_force_n,
+            f0_sole_depth_m=model.f0_sole_depth_m,
+            f0_speed_m_s=model.f0_speed_m_s,
+            f0_divot_section_area_m2=model.f0_divot_section_area_m2,
+            band=model.band,
+            head_mass_kg=model.head_mass_kg,
+            declared_width_m=model.declared_width_m,
+            bulk_density_kg_m3=model.bulk_density_kg_m3,
+            sweep_probes=(
+                probe(
+                    0, 0.0, speed_m_s=5.0, f0_inertial_share=0.52, f1_flux_share=0.68
+                ),
+                probe(
+                    0, 0.0, speed_m_s=12.0, f0_inertial_share=0.93, f1_flux_share=0.69
+                ),
+            ),
+        )
+        crossover = swept.crossover()
+        assert crossover is not None
+        assert 5.0 < crossover.speed_m_s < 12.0
+
+
+# ------------------------------------------------------------- the licence
+
+
+class TestTheViewStatesWhatAgreementDoesAndDoesNotLicense:
+    """The requirement of the issue, tested rather than assumed present."""
+
+    def test_it_says_consistency_is_not_validation(self) -> None:
+        text = licence_statement(speed_m_s=25.0)
+        assert "not validation" in text.lower()
+        assert "uncalibrated" in text.lower()
+
+    def test_it_quotes_the_nasa_std_7009b_validation_level_from_the_assessment(
+        self,
+    ) -> None:
+        text = licence_statement(speed_m_s=25.0)
+        assert "0 of 4" in text
+        assert "7009" in text
+
+    def test_it_quotes_the_published_speed_ceiling_from_the_envelope(self) -> None:
+        text = licence_statement(speed_m_s=25.0)
+        assert f"{MAX_VALIDATED_SPEED_M_S:g}" in text
+        assert "first sample" in text
+
+    def test_it_says_the_magnitude_rests_on_a_declared_width(self) -> None:
+        text = licence_statement(speed_m_s=25.0, effective_width_m=0.030)
+        assert "30" in text
+        assert "declared" in text.lower()
+
+    def test_it_says_what_disagreement_does_license(self) -> None:
+        """Falsification is the one thing the comparison can actually do."""
+        text = licence_statement(speed_m_s=25.0)
+        assert "falsif" in text.lower()
+
+    def test_the_comparison_carries_it_and_a_short_form_for_a_stamp(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        assert "not validation" in model.licence().lower()
+        stamp = model.licence_stamp()
+        assert len(stamp) < len(model.licence())
+        assert "not validation" in stamp.lower()
+
+    def test_the_summary_carries_the_licence_and_every_agreement(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        text = model.summary()
+        assert "not validation" in text.lower()
+        for quantity in ComparedQuantity:
+            assert quantity.label in text
+
+
+class TestTheComparisonInheritsRatherThanImprovesTheVerdict:
+    def test_the_worst_status_comes_from_the_f0_band(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        assert model.worst_status is EnvelopeStatus.BEYOND_VALIDATION
+
+    def test_the_pair_of_tiers_is_named(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        assert model.tiers == (FidelityTier.F0, FidelityTier.F1)

--- a/tests/tools/bunker_shot_gui/test_crosstier.py
+++ b/tests/tools/bunker_shot_gui/test_crosstier.py
@@ -56,18 +56,25 @@ def cross_check(
     depth_m: float = 0.010,
     f1_section_area_m2: float = 4.0e-4,
     n_empty_bins: int = 0,
+    f1_along_motion: bool = False,
 ) -> F0CrossCheck:
-    """One paired query, built from the shares rather than solved for them."""
-    direction = np.array([1.0, 0.0, -0.4])
+    """One paired query, built from the shares rather than solved for them.
+
+    The default resultant opposes a ``+x`` delivery and lifts, which is
+    what sand does. ``f1_along_motion`` turns F1's around so a test can
+    show that a force which does not oppose the motion does not brake.
+    """
+    direction = np.array([-1.0, 0.0, 0.4])
     direction = direction / np.linalg.norm(direction)
+    f1_direction = -direction if f1_along_motion else direction
     return F0CrossCheck(
         speed_m_s=speed_m_s,
         f0_force_n=f0_force_n * direction,
-        f1_force_n=f1_force_n * direction,
+        f1_force_n=f1_force_n * f1_direction,
         f0_depth_force_n=f0_force_n * (1.0 - f0_inertial_share) * direction,
         f0_inertial_force_n=f0_force_n * f0_inertial_share * direction,
-        f1_stress_force_n=f1_force_n * (1.0 - f1_flux_share) * direction,
-        f1_flux_force_n=f1_force_n * f1_flux_share * direction,
+        f1_stress_force_n=f1_force_n * (1.0 - f1_flux_share) * f1_direction,
+        f1_flux_force_n=f1_force_n * f1_flux_share * f1_direction,
         submerged_depth_m=depth_m,
         f0_max_depth_m=depth_m,
         f1_max_depth_m=depth_m,
@@ -95,6 +102,7 @@ def probe(
     f1_section_area_m2: float = 4.0e-4,
     depth_m: float = 0.010,
     n_empty_bins: int = 0,
+    f1_along_motion: bool = False,
 ) -> CrossTierProbe:
     return CrossTierProbe(
         frame=frame,
@@ -108,6 +116,7 @@ def probe(
             depth_m=depth_m,
             f1_section_area_m2=f1_section_area_m2,
             n_empty_bins=n_empty_bins,
+            f1_along_motion=f1_along_motion,
         ),
         f0_divot_section_area_m2=f0_section_area_m2,
         f0_sole_depth_m=depth_m,
@@ -128,7 +137,9 @@ def comparison(probes: tuple[CrossTierProbe, ...]) -> CrossTierComparison:
         time_s=time_s,
         f0_force_n=force,
         f0_sole_depth_m=np.linspace(0.0, 0.012, 9),
-        f0_speed_m_s=speed,
+        f0_velocity_m_s=np.stack(
+            [speed, np.zeros_like(speed), np.zeros_like(speed)], axis=1
+        ),
         f0_divot_section_area_m2=np.linspace(0.0, 6.0e-4, 9),
         band=ValidityBand(
             time_s=time_s,
@@ -137,6 +148,7 @@ def comparison(probes: tuple[CrossTierProbe, ...]) -> CrossTierComparison:
         head_mass_kg=0.300,
         declared_width_m=0.030,
         bulk_density_kg_m3=1550.0,
+        f1_cell_size_m=0.002,
     )
 
 
@@ -315,44 +327,53 @@ class TestTheComparisonOverlaysThePairOnOneCursor:
 class TestSpeedLostIsDerivedAndSaysSo:
     """F1 is driven kinematically, so it loses no speed of its own."""
 
-    def test_f0s_speed_lost_is_read_off_its_own_record(self) -> None:
+    def test_f0s_recorded_loss_is_read_off_its_own_record(self) -> None:
         model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
         # The synthetic record runs 25 -> 21 m/s over 9 samples, so the
         # window between samples 2 and 6 is half of the 4 m/s total.
-        assert model.f0_speed_lost_m_s == pytest.approx(2.0)
+        assert model.f0_recorded_speed_lost_m_s == pytest.approx(2.0)
 
-    def test_f1s_speed_lost_borrows_the_magnitude_and_keeps_f0s_direction(
-        self,
-    ) -> None:
-        """F0's own decrements, each weighted by the ``|F1|/|F0|`` ratio.
-
-        Integrating F1's force directly would assume the two resultants
-        point the same way, and the measured direction cosines say they do
-        not.
-        """
+    def test_both_tiers_are_integrated_on_the_same_quadrature(self) -> None:
+        """Comparing an exact number to a sampled one measures the sampling."""
         model = comparison(
             (
                 probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=60.0),
                 probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=60.0),
             )
         )
-        assert model.f1_speed_lost_m_s == pytest.approx(1.5 * 2.0, rel=1e-9)
+        # Both constant across the window, so the ratio is exactly the
+        # force ratio and the quadrature cancels.
+        assert model.f1_speed_lost_m_s / model.f0_speed_lost_m_s == pytest.approx(
+            1.5, rel=1e-9
+        )
+        # ... and neither equals the record's own 2.0 m/s, because the
+        # record is 53 samples of a curve and this is a two-point rule.
+        assert model.f0_speed_lost_m_s != pytest.approx(2.0, rel=1e-3)
 
-    def test_a_ratio_that_varies_weights_where_the_deceleration_happened(
-        self,
-    ) -> None:
-        """Not simply the peak ratio times F0's loss."""
-        model = comparison(
+    def test_a_force_that_does_not_oppose_the_motion_does_not_brake(self) -> None:
+        """The reason the projection is taken rather than the magnitude."""
+        opposing = comparison(
             (
-                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=40.0),
-                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=120.0),
+                probe(2, 2.0e-3, f1_force_n=60.0),
+                probe(6, 6.0e-3, f1_force_n=60.0),
             )
         )
-        # The record decelerates uniformly, so the ratio's mean over the
-        # four intervals -- 1.25, 1.75, 2.25, 2.75 at the interval starts --
-        # is what F0's 2.0 m/s loss is scaled by.
-        assert model.f1_speed_lost_m_s == pytest.approx(2.0 * 2.0, rel=1e-9)
-        assert model.f1_speed_lost_m_s < 3.0 * 2.0
+        along = comparison(
+            (
+                probe(2, 2.0e-3, f1_force_n=60.0),
+                probe(6, 6.0e-3, f1_force_n=60.0, f1_along_motion=True),
+            )
+        )
+        assert along.f1_speed_lost_m_s < opposing.f1_speed_lost_m_s
+        assert along.f1_speed_lost_m_s == pytest.approx(0.0, abs=1e-12)
+
+    def test_the_implied_speed_curve_leaves_from_f0s_own_speed(self) -> None:
+        model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
+        implied = model.implied_speed_m_s()
+        assert implied[2] == pytest.approx(float(model.f0_speed_m_s[2]))
+        assert np.isnan(implied[0])
+        assert np.isnan(implied[8])
+        assert implied[6] < implied[2]
 
     def test_it_needs_two_probes_to_form_a_window(self) -> None:
         model = comparison((probe(4, 4.0e-3),))
@@ -363,6 +384,40 @@ class TestSpeedLostIsDerivedAndSaysSo:
         model = comparison((probe(2, 2.0e-3), probe(6, 6.0e-3)))
         agreement = model.agreement(ComparedQuantity.SPEED_LOST)
         assert "one-way" in agreement.quantity.note
+
+
+class TestAGrazingProbeIsNamedRatherThanLeftToDominate:
+    """F0 reports zero when nothing leads, and the ratio then divides by that."""
+
+    def test_a_probe_far_below_the_peak_is_named(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=0.5, f1_force_n=50.0),
+                probe(6, 6.0e-3, f0_force_n=400.0, f1_force_n=150.0),
+            )
+        )
+        caveat = model.engagement_caveat()
+        assert "2.00 ms" in caveat
+        assert "8702" in caveat
+        assert "engagement criterion" in caveat
+
+    def test_a_fully_loaded_probe_set_says_nothing(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=300.0),
+                probe(6, 6.0e-3, f0_force_n=400.0),
+            )
+        )
+        assert model.engagement_caveat() == ""
+
+    def test_the_summary_carries_the_caveat(self) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=0.5, f1_force_n=50.0),
+                probe(6, 6.0e-3, f0_force_n=400.0, f1_force_n=150.0),
+            )
+        )
+        assert "engagement criterion" in model.summary()
 
 
 class TestDivergenceIsMarkedRatherThanLeftForTheEye:
@@ -490,12 +545,13 @@ class TestTheInertialShareCrossover:
             time_s=model.time_s,
             f0_force_n=model.f0_force_n,
             f0_sole_depth_m=model.f0_sole_depth_m,
-            f0_speed_m_s=model.f0_speed_m_s,
+            f0_velocity_m_s=model.f0_velocity_m_s,
             f0_divot_section_area_m2=model.f0_divot_section_area_m2,
             band=model.band,
             head_mass_kg=model.head_mass_kg,
             declared_width_m=model.declared_width_m,
             bulk_density_kg_m3=model.bulk_density_kg_m3,
+            f1_cell_size_m=model.f1_cell_size_m,
             sweep_probes=(
                 probe(
                     0, 0.0, speed_m_s=5.0, f0_inertial_share=0.52, f1_flux_share=0.68

--- a/tests/tools/bunker_shot_gui/test_crosstier_run.py
+++ b/tests/tools/bunker_shot_gui/test_crosstier_run.py
@@ -1,0 +1,232 @@
+"""Running both tiers on one F0 record (issue #8713, epic #8699).
+
+The arithmetic is covered in ``test_crosstier``. What is pinned here is
+the wiring: that the pose F0 recorded reaches F1 unchanged, that the pair
+produces the divergence ADR-0033 measured rather than an accidental
+agreement, and that the probes land where the comparison says they do.
+
+The F1 bed here is deliberately coarse -- a 6 mm cell on a 50 mm bed --
+because a single probe at ADR-0033's resolution costs tens of seconds and
+this suite runs on a 60-second timeout. Coarse changes the numbers, so
+nothing below is pinned to one: the assertions are on sign, direction and
+structure, which is what survives the discretisation. The quotable numbers
+are the ones ADR-0033 and SPEC record from a production-resolution run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bunkershot3d.solvers.drft import DRFTSolver, MaterialResponse
+from bunkershot3d.solvers.envelope import RefusalPolicy
+from bunkershot3d.solvers.mpm.constitutive import SandContinuum
+from bunkershot3d.solvers.mpm.solver import PlaneStrainMPMSolver
+from src.tools.bunker_shot_gui.bridge import (
+    compare_tiers,
+    entry_kinematics,
+    probe_frames,
+    validity_band,
+)
+from src.tools.bunker_shot_gui.crosstier import ComparedQuantity
+from src.tools.bunker_shot_gui.design import (
+    SandCondition,
+    SolverSetup,
+    SwingSetup,
+    WedgeDesign,
+)
+from src.tools.bunker_shot_gui.model import WorkbenchModel
+
+pytestmark = pytest.mark.unit
+
+COARSE = SolverSetup(
+    n_profile_points=12, n_stations=5, playability_points=2, target_carry_m=12.0
+)
+"""The cheapest head the workbench will loft; F1's cost dominates anyway."""
+
+
+@pytest.fixture(scope="module")
+def bench():  # type: ignore[no-untyped-def]
+    """One F0 shot and everything needed to put F1 beside it."""
+    model = WorkbenchModel(COARSE)
+    design = WedgeDesign(name="cross-tier")
+    geometry = design.geometry()
+    sand = SandCondition().sand_state()
+    swing = SwingSetup()
+    build = model.head_build(geometry)
+    kinematics = entry_kinematics(build, swing)
+    outcome = model.run_shot(geometry, sand, swing)
+    permissive = DRFTSolver(
+        material=MaterialResponse.from_sand_state(sand),
+        dynamic_terms_active=bool(swing.dynamic_terms_active),
+        refusal_policy=RefusalPolicy.REPORT,
+    )
+    return {
+        "model": model,
+        "geometry": geometry,
+        "sand": sand,
+        "swing": swing,
+        "build": build,
+        "kinematics": kinematics,
+        "outcome": outcome,
+        "f0": permissive,
+        "f1": PlaneStrainMPMSolver(
+            material=SandContinuum.from_sand_state(sand),
+            cell_size_m=0.006,
+            effective_width_m=geometry.sole_width_m,
+            bed_depth_m=0.050,
+            run_in_lengths=0.4,
+            refusal_policy=RefusalPolicy.REPORT,
+            max_steps=60000,
+        ),
+    }
+
+
+@pytest.fixture(scope="module")
+def comparison(bench):  # type: ignore[no-untyped-def]
+    outcome = bench["outcome"]
+    result = bench["model"].shot_result(
+        bench["geometry"], bench["sand"], bench["swing"]
+    )
+    band = validity_band(
+        bench["f0"], bench["build"], result, bench["kinematics"].orientation
+    )
+    assert band is not None
+    return compare_tiers(
+        f0_solver=bench["f0"],
+        f1_solver=bench["f1"],
+        build=bench["build"],
+        result=result,
+        kinematics=bench["kinematics"],
+        f0_divot_section_area_m2=outcome.scene.divot.section_area_m2,
+        band=band,
+        head_mass_kg=bench["geometry"].head_mass_kg,
+        bulk_density_kg_m3=bench["sand"].bulk_density_kg_m3,
+        n_probes=2,
+    )
+
+
+class TestProbeSelection:
+    """Which samples are worth the expense of an F1 march."""
+
+    def test_only_engaged_samples_are_probed(self, bench) -> None:  # type: ignore[no-untyped-def]
+        result = bench["model"].shot_result(
+            bench["geometry"], bench["sand"], bench["swing"]
+        )
+        frames = probe_frames(result, 3)
+        assert frames
+        for frame in frames:
+            assert result.active_areas_m2[frame] > 0.0
+
+    def test_the_peak_force_sample_is_always_probed(self, bench) -> None:  # type: ignore[no-untyped-def]
+        result = bench["model"].shot_result(
+            bench["geometry"], bench["sand"], bench["swing"]
+        )
+        peak = int(np.argmax(np.linalg.norm(result.forces_n, axis=1)))
+        assert peak in probe_frames(result, 2)
+
+    def test_a_non_positive_probe_count_is_refused(self, bench) -> None:  # type: ignore[no-untyped-def]
+        result = bench["model"].shot_result(
+            bench["geometry"], bench["sand"], bench["swing"]
+        )
+        with pytest.raises(ValueError, match="n_probes"):
+            probe_frames(result, 0)
+
+
+class TestTheRecordedPoseReachesF1Unchanged:
+    """The one row where a disagreement would be a wiring fault."""
+
+    def test_the_two_tiers_report_the_same_sole_depth(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        for probe in comparison.shot_probes:
+            agreement = probe.agreement(ComparedQuantity.SOLE_DEPTH)
+            assert agreement.ratio == pytest.approx(1.0, abs=1e-9), agreement.summary()
+
+    def test_f0s_probe_force_matches_the_force_the_march_recorded(
+        self,
+        comparison,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Rebuilding the state must reproduce the solve, not approximate it."""
+        for probe in comparison.shot_probes:
+            recorded = float(np.linalg.norm(comparison.f0_force_n[probe.frame]))
+            assert probe.f0_force_magnitude_n == pytest.approx(recorded, rel=1e-9)
+
+    def test_every_probe_sits_at_the_sample_it_names(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        for probe in comparison.shot_probes:
+            assert probe.time_s == pytest.approx(float(comparison.time_s[probe.frame]))
+
+
+class TestTheDivergenceIsReportedRatherThanSmoothed:
+    """Sign and structure, not numbers a coarse bed would move."""
+
+    def test_both_tiers_oppose_the_head(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        """The one physical claim a pair of uncalibrated models can support."""
+        for probe in comparison.shot_probes:
+            assert probe.check.f0_force_n[2] > 0.0, probe.check.summary()
+            assert probe.check.f1_force_n[2] > 0.0, probe.check.summary()
+
+    def test_f1_carries_a_divot_f0_cannot(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        """The reason ADR-0033 chose a continuum at all."""
+        assert comparison.peak_probe.f1_divot_section_area_m2 > 0.0
+
+    def test_f0_credits_more_of_its_force_to_inertia_at_greenside_speed(
+        self,
+        comparison,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """The mechanism, at the one speed a greenside shot actually runs at."""
+        peak = comparison.peak_probe
+        assert peak.speed_m_s > 10.0
+        assert peak.f0_inertial_fraction > peak.f1_flux_fraction, peak.check.summary()
+        assert peak.inertial_share_gap > 0.0
+
+    def test_the_wrench_agreement_is_reported_with_its_ratio(
+        self,
+        comparison,  # type: ignore[no-untyped-def]
+    ) -> None:
+        agreement = comparison.agreement(ComparedQuantity.WRENCH)
+        assert np.isfinite(agreement.ratio)
+        assert agreement.ratio > 0.0
+        assert "declared band" in agreement.summary()
+
+    def test_the_crossover_is_stated_either_way(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        text = comparison.crossover_summary()
+        assert "yield surface" in text
+
+    def test_the_summary_leads_with_the_licence(self, comparison) -> None:  # type: ignore[no-untyped-def]
+        text = comparison.summary()
+        assert text.startswith("What this comparison licenses: nothing about sand")
+        assert "not validation" in text.lower()
+        assert "8733" in text
+
+
+class TestTheDeclaredSpeedSweep:
+    """The crossover needs a range the shot itself does not span."""
+
+    def test_a_sweep_brackets_speeds_the_shot_never_reaches(self, bench) -> None:  # type: ignore[no-untyped-def]
+        outcome = bench["outcome"]
+        result = bench["model"].shot_result(
+            bench["geometry"], bench["sand"], bench["swing"]
+        )
+        band = validity_band(
+            bench["f0"], bench["build"], result, bench["kinematics"].orientation
+        )
+        assert band is not None
+        swept = compare_tiers(
+            f0_solver=bench["f0"],
+            f1_solver=bench["f1"],
+            build=bench["build"],
+            result=result,
+            kinematics=bench["kinematics"],
+            f0_divot_section_area_m2=outcome.scene.divot.section_area_m2,
+            band=band,
+            head_mass_kg=bench["geometry"].head_mass_kg,
+            bulk_density_kg_m3=bench["sand"].bulk_density_kg_m3,
+            n_probes=1,
+            # Fast on purpose. The approach is a fixed distance and the CFL
+            # step is set by the elastic wave speed, so a *slow* probe is the
+            # expensive one: the step count goes as ``(c_p + v) / v``, and a
+            # 4 m/s probe costs order thirty times a 25 m/s one.
+            sweep_speeds_m_s=(22.0, 30.0),
+        )
+        speeds = sorted(probe.speed_m_s for probe in swept.sweep_probes)
+        assert speeds == pytest.approx([22.0, 30.0])
+        assert swept.crossover_probes == swept.sweep_probes

--- a/tests/tools/bunker_shot_gui/test_render_crosstier.py
+++ b/tests/tools/bunker_shot_gui/test_render_crosstier.py
@@ -1,0 +1,254 @@
+"""Drawing the cross-tier comparison (issue #8713, epic #8699).
+
+Headless. Every assertion below is about a property the *picture* has to
+carry, not about pixels:
+
+* the F1 points are **not joined** -- there is no F1 history to join them
+  into, and a line between two independent marches would assert one;
+* every divergence is drawn as an explicit mark rather than left as a gap
+  the reader is expected to notice;
+* the licence is inside the figure, not in a caption a screenshot loses;
+* nothing autoscales while the cursor moves.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+from bunkershot3d.solvers import EnvelopeStatus  # noqa: E402
+from src.tools.bunker_shot_gui.crosstier import (  # noqa: E402
+    ComparedQuantity,
+    CrossTierComparison,
+    CrossTierProbe,
+)
+from src.tools.bunker_shot_gui.render_crosstier import (  # noqa: E402
+    CrossTierArtists,
+    cross_tier_still,
+    draw_cross_tier,
+)
+from src.tools.bunker_shot_gui.traces import ValidityBand  # noqa: E402
+from tests.tools.bunker_shot_gui.test_crosstier import probe  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def comparison(
+    probes: tuple[CrossTierProbe, ...] | None = None,
+    sweep: tuple[CrossTierProbe, ...] = (),
+) -> CrossTierComparison:
+    """A comparison over a synthetic 9-sample F0 record."""
+    time_s = np.linspace(0.0, 8.0e-3, 9)
+    force = np.zeros((9, 3))
+    force[:, 0] = -np.linspace(10.0, 50.0, 9)
+    force[:, 2] = np.linspace(10.0, 50.0, 9)
+    if probes is None:
+        probes = (
+            probe(2, 2.0e-3, f0_force_n=20.0, f1_force_n=22.0),
+            probe(4, 4.0e-3, f0_force_n=40.0, f1_force_n=110.0),
+            probe(6, 6.0e-3, f0_force_n=35.0, f1_force_n=95.0),
+        )
+    return CrossTierComparison(
+        shot_probes=probes,
+        time_s=time_s,
+        f0_force_n=force,
+        f0_sole_depth_m=np.linspace(0.0, 0.012, 9),
+        f0_speed_m_s=np.linspace(25.0, 21.0, 9),
+        f0_divot_section_area_m2=np.linspace(0.0, 6.0e-4, 9),
+        band=ValidityBand(
+            time_s=time_s, statuses=tuple([EnvelopeStatus.BEYOND_VALIDATION] * 9)
+        ),
+        head_mass_kg=0.300,
+        declared_width_m=0.030,
+        bulk_density_kg_m3=1550.0,
+        sweep_probes=sweep,
+    )
+
+
+@pytest.fixture
+def figure() -> Figure:
+    return Figure(figsize=(11.0, 8.0))
+
+
+class TestTheOverlayDrawsBothTiersWithoutInventingAnF1History:
+    def test_it_builds_one_panel_per_time_resolved_quantity(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        assert artists.n_panels == 4
+        assert len(figure.axes) >= 5
+
+    def test_the_f1_points_are_markers_and_never_a_line(self, figure: Figure) -> None:
+        """A line between two independent marches would assert a history."""
+        artists = draw_cross_tier(figure, comparison())
+        for series in artists.f1_series:
+            assert series.get_linestyle() == "None"
+            assert series.get_marker() not in ("", "None", None)
+
+    def test_the_f0_curve_covers_the_whole_record(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        model = artists.comparison
+        for line in artists.f0_series:
+            assert len(line.get_xdata()) == model.n_frames
+
+    def test_no_panel_autoscales(self, figure: Figure) -> None:
+        """A y-axis that re-ranged while scrubbing makes noise read as signal."""
+        artists = draw_cross_tier(figure, comparison())
+        for axes in artists.panels:
+            assert not axes.get_autoscalex_on()
+            assert not axes.get_autoscaley_on()
+
+    def test_the_time_axis_is_shared_and_labelled_in_milliseconds(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        assert "ms" in artists.panels[-1].get_xlabel()
+
+    def test_every_panel_names_its_unit(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        for axes, quantity in zip(
+            artists.panels, artists.panel_quantities, strict=True
+        ):
+            assert quantity.unit in axes.get_ylabel()
+
+
+class TestDivergenceIsMarkedNotLeftForTheEye:
+    def test_each_probe_carries_a_connector_between_the_two_tiers(
+        self, figure: Figure
+    ) -> None:
+        """The gap itself is drawn, so the disagreement is an object."""
+        artists = draw_cross_tier(figure, comparison())
+        assert artists.n_connectors == 3 * artists.n_panels
+
+    def test_a_divergent_probe_is_labelled_with_its_ratio(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        labels = [text.get_text() for text in artists.ratio_labels]
+        assert any("2.75x" in text for text in labels), labels
+
+    def test_a_divergent_stretch_is_shaded(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        assert artists.n_divergence_bands > 0
+
+    def test_a_consistent_comparison_shades_nothing(self, figure: Figure) -> None:
+        model = comparison(
+            (
+                probe(2, 2.0e-3, f0_force_n=40.0, f1_force_n=41.0),
+                probe(6, 6.0e-3, f0_force_n=40.0, f1_force_n=42.0),
+            )
+        )
+        artists = draw_cross_tier(figure, model)
+        assert artists.n_divergence_bands == 0
+
+
+class TestTheCrossoverPanel:
+    """The sharpest single result, given its own axes."""
+
+    def test_it_plots_both_shares_against_speed(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        axes = artists.crossover_axes
+        assert "m/s" in axes.get_xlabel()
+        assert "share" in axes.get_ylabel().lower()
+
+    def test_a_bracketed_crossing_is_marked_on_the_axes(self, figure: Figure) -> None:
+        model = comparison(
+            sweep=(
+                probe(
+                    0, 0.0, speed_m_s=5.0, f0_inertial_share=0.52, f1_flux_share=0.68
+                ),
+                probe(
+                    0, 0.0, speed_m_s=12.0, f0_inertial_share=0.93, f1_flux_share=0.69
+                ),
+                probe(
+                    0, 0.0, speed_m_s=25.0, f0_inertial_share=0.99, f1_flux_share=0.65
+                ),
+            )
+        )
+        artists = draw_cross_tier(figure, model)
+        assert artists.crossover_marked
+        assert "7.8" in artists.crossover_caption.get_text()
+
+    def test_an_unbracketed_range_says_so_rather_than_drawing_nothing(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        assert not artists.crossover_marked
+        assert "No crossing" in artists.crossover_caption.get_text()
+
+
+class TestTheFigureCarriesItsOwnCaveats:
+    def test_the_licence_is_inside_the_figure(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        text = artists.licence_text.get_text()
+        assert "not validation" in text.lower()
+        assert "uncalibrated" in text.lower()
+
+    def test_the_top_panel_is_stamped_with_the_verdict_and_the_tiers(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        stamp = artists.stamp.get_text()
+        assert "BEYOND VALIDATION" in stamp.upper()
+        assert "not validation" in stamp.lower()
+
+    def test_the_agreement_table_lists_every_compared_quantity(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        table = artists.agreement_text.get_text()
+        for quantity in ComparedQuantity:
+            assert quantity.label in table
+
+    def test_the_figure_says_the_f1_points_are_separate_marches(
+        self, figure: Figure
+    ) -> None:
+        """The #8733 caveat, in the picture rather than in the commit."""
+        artists = draw_cross_tier(figure, comparison())
+        assert "march" in artists.method_text.get_text().lower()
+
+
+class TestScrubbing:
+    def test_the_cursor_moves_on_every_panel(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        artists.update(6)
+        moment = 6.0e-3 * 1e3
+        for cursor in artists.cursors:
+            assert cursor.get_xdata()[0] == pytest.approx(moment)
+
+    def test_a_frame_outside_the_record_is_refused(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        with pytest.raises(ValueError, match="outside"):
+            artists.update(99)
+
+    def test_the_readout_states_the_moment_and_the_verdict(
+        self, figure: Figure
+    ) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        artists.update(4)
+        text = artists.readout.get_text()
+        assert "4.00" in text
+        assert "BEYOND VALIDATION" in text.upper()
+
+    def test_the_limits_do_not_move_when_the_cursor_does(self, figure: Figure) -> None:
+        artists = draw_cross_tier(figure, comparison())
+        before = [axes.get_ylim() for axes in artists.panels]
+        artists.update(8)
+        assert [axes.get_ylim() for axes in artists.panels] == before
+
+
+class TestTheStill:
+    def test_it_opens_on_the_peak_probe(self) -> None:
+        model = comparison()
+        drawn = cross_tier_still(model)
+        assert isinstance(drawn, Figure)
+
+    def test_a_still_can_be_rebuilt_from_its_own_artists(self) -> None:
+        model = comparison()
+        figure = Figure(figsize=(11.0, 8.0))
+        first = CrossTierArtists(figure, model)
+        second = CrossTierArtists(figure, model)
+        assert second.n_panels == first.n_panels

--- a/tests/tools/bunker_shot_gui/test_render_crosstier.py
+++ b/tests/tools/bunker_shot_gui/test_render_crosstier.py
@@ -58,7 +58,14 @@ def comparison(
         time_s=time_s,
         f0_force_n=force,
         f0_sole_depth_m=np.linspace(0.0, 0.012, 9),
-        f0_speed_m_s=np.linspace(25.0, 21.0, 9),
+        f0_velocity_m_s=np.stack(
+            [
+                np.linspace(25.0, 21.0, 9),
+                np.zeros(9),
+                np.zeros(9),
+            ],
+            axis=1,
+        ),
         f0_divot_section_area_m2=np.linspace(0.0, 6.0e-4, 9),
         band=ValidityBand(
             time_s=time_s, statuses=tuple([EnvelopeStatus.BEYOND_VALIDATION] * 9)
@@ -66,6 +73,7 @@ def comparison(
         head_mass_kg=0.300,
         declared_width_m=0.030,
         bulk_density_kg_m3=1550.0,
+        f1_cell_size_m=0.002,
         sweep_probes=sweep,
     )
 


### PR DESCRIPTION
Implements **B5** of epic #8699: the cross-tier comparison view, F0 against F1 on the quantities both produce, with the divergence marked rather than left for the eye.

## What it is

Three headless modules plus a Qt view, in the split #8618 established:

- **`agreement.py`** — the vocabulary. What is compared, in what unit, what each tier *means* by it, and the verdict on a ratio against a **declared** band of 0.25 on `|ln(F1/F0)|`. Declared, not derived: #8616 established there is no measurement of any of these quantities out of bunker sand, so there is no model error to calibrate a tolerance against, and the band travels with every result. It also owns `licence_statement`, computed from `vandv.credibility` and the solver's own envelope constants rather than quoted.
- **`crosstier.py`** — probes and the comparison. F1 has no shot history (#8733), so each F1 point is its own march to one recorded pose under a declared straight-line approach. The inertial-share crossover is located by interpolation and reported with its mechanism.
- **`render_crosstier.py`** — four stacked panels on the #8708 shared cursor, a labelled connector per probe so the gap is an object, divergent stretches shaded, the crossover on its own **speed** axis, and the licence inside the frame.
- **`CrossTierWidget`** — the fourth follower of the one transport `SoleLoadFieldWidget` owns, in its own tab, empty until asked from its own button.

Reused, not rebuilt: `cross_check_against_f0` from the F1 package, `stamp_axes`, `status_colour`, the `SoleLoadFieldWidget.link`/`FollowsFrame` transport, and the scene's own swept `DivotSection` rather than a second divot.

## The numbers, at the workbench's own design point

58 deg preset, 25 m/s, 20 mm declared effective width, F1 at dx = 3 mm on an 80 mm bed. **These are not ADR-0033's numbers, and that is the finding.**

| | test section (ADR-0033) | lofted wedge (here) |
|---|---|---|
| `\|F1\|/\|F0\|` at peak | 1.49–2.68 | **0.384** |
| direction cosine | 0.65–0.87 | **0.996** |
| F0 inertial share | 0.52 → 0.93 → 0.99 | 0.959 → 0.996 → 0.999 |
| F1 flux share | ~0.65–0.69 | 0.644 → 0.654 → 0.658 |

The published magnitude ratio **does not transfer** to a wedge — F1 reports about a third of F0's force, not twice it — while the two tiers agree about *where* the load points far better on real geometry than on the section the check was written for. The inertial-share result reproduces exactly, and the crossing sits **below** the whole greenside range: a shot entering at 25 m/s and leaving at 17.2 never decelerates through it, which is why the 5/12/25 m/s sweep is carried as its own declared experiment and labelled as one.

Agreement at the peak probe: force 0.384x (divergent), sole depth 1.00x (a control — both tiers get the same pose), divot section and mass 1.47x (divergent, and not like-for-like: F0's divot is the swept head envelope, F1's is moved sand), speed lost 8.82 vs 4.23 m/s against F0's own recorded 7.80 m/s over the same window.

## Defects found

1. **F1's approach distance was unbounded.** `_approach` divides the height to climb by the vertical direction cosine, which passes through zero at the deepest sample of every real shot — measured `-0.0026`, so a 24 mm climb asked for a **9.5 m** run-in, and `_build_bed` sized the bed to cover it. Caught only by `max_steps`, after the allocation. Now takes whichever clearance is shorter.
2. **F1's grid ceiling was an accident of the approach.** A descending body starts in the air and happens to raise it; a horizontal run-in does not, and the first ejected particle leaves the domain. Headroom is now stated in cells.
3. **`F0CrossCheck` compared two `max_depth_m` fields that do not mean the same thing.** F0 reports its deepest *engaged* element (the #8701 contact diagnostic); F1 reports the deepest submerged element. They coincide on a flat section and differ by **33x** on a lofted head. The check now carries the submerged depth off the shared query.
4. **The #8702 engagement artefact is named, not quietly reported.** F0 returns zero the moment no element is both submerged and leading-edge while the sole is still in the divot; the 51x and 295x ratios at the entry and exit probes are divisions by an engagement criterion.
5. **My own first speed-lost definition was wrong** and a real run caught it: ratio-weighted decrements reported 184.9 m/s off a 0.3 kg head. It is now each tier's resultant projected on the direction of travel, integrated on the same quadrature for both.

## What this does not license

Stated inside the figure, in the widget status line and in the report: consistency between two uncalibrated models is not validation. NASA-STD-7009B validation stays at **0 of 4**, the delivery point is **17x** past the 1.44 m/s published ceiling from its first sample and **63x** the stated Froude limit, and no F1 magnitude may be reproduced without its declared effective width. What the comparison *can* do is falsify.

Closes #8713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
