### PR TITLE
fix(bunkershot3d): a follower refusing a frame must not abort the process

### DIFF
--- a/src/tools/bunker_shot_gui/widgets.py
+++ b/src/tools/bunker_shot_gui/widgets.py
@@ -9,6 +9,9 @@ preview anywhere in this package.
 
 from __future__ import annotations
 
+import logging
+
+from collections.abc import Callable
 from typing import Protocol
 
 import numpy as np
@@ -109,6 +112,48 @@ class FollowsFrame(Protocol):
             frame: The sample index.
         """
 
+
+def _guarded(follower: FollowsFrame) -> Callable[[int], None]:
+    """Wrap a follower's ``set_frame`` so a raise cannot kill the process.
+
+    Followers refuse an out-of-range index rather than clamping it, which is
+    the right contract: a clamped index would leave one view showing a
+    different moment from the one driving it, and that is precisely the
+    desynchronisation linking the views exists to prevent.
+
+    Delivering that refusal through a Qt signal is the problem. An exception
+    that escapes a slot unwinds through the C++ event loop, which aborts the
+    process with ``0xC0000409`` and **no Python traceback at all** -- so the
+    contract that exists to make a mismatch obvious instead makes it
+    undiagnosable.
+
+    This keeps the refusal and changes only what it costs: the mismatch is
+    logged with its traceback and the offending view stops following, while
+    the transport and every other view carry on. A silent ``pass`` would be
+    the wrong trade in the other direction, hiding the desynchronisation that
+    the raise was added to expose.
+    """
+
+    live = True
+
+    def deliver(frame: int) -> None:
+        nonlocal live
+        if not live:
+            return
+        try:
+            follower.set_frame(frame)
+        except Exception:
+            live = False
+            logger.exception(
+                "%s refused frame %d; it will stop following the transport",
+                type(follower).__name__,
+                frame,
+            )
+
+    return deliver
+
+
+logger = logging.getLogger(__name__)
 
 _EMPTY_CELL = QColor(238, 234, 226)
 _WINDOW_EDGE = QColor(20, 90, 40)
@@ -428,7 +473,7 @@ class SoleLoadFieldWidget(QWidget):
                 is deliberately that narrow, so linking a view does not give
                 it a way to drive the transport back.
         """
-        self.frame_changed.connect(follower.set_frame)
+        self.frame_changed.connect(_guarded(follower))
 
     # ------------------------------------------------------------ accessors
 

--- a/tests/tools/bunker_shot_gui/test_follower_crash_guard.py
+++ b/tests/tools/bunker_shot_gui/test_follower_crash_guard.py
@@ -1,0 +1,120 @@
+"""A follower that refuses a frame must not take the process with it.
+
+Followers refuse an out-of-range index rather than clamping it, and that
+contract is correct: a clamped index would leave one view showing a
+different moment from the one driving it.
+
+Delivering the refusal through a Qt signal is what makes it dangerous. An
+exception escaping a slot unwinds through the C++ event loop, which aborts
+the interpreter with ``0xC0000409`` and **no Python traceback**, so the
+mechanism meant to make a desynchronisation obvious instead makes it
+undiagnosable. These tests pin the fix: the refusal survives, its diagnosis
+improves, and the rest of the workbench keeps running.
+
+The crash is genuine rather than theoretical -- it was hit while wiring the
+sand-slice view, and the same shape exists for every other follower.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt6", reason="the workbench shell needs a Qt binding")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from src.tools.bunker_shot_gui.widgets import SoleLoadFieldWidget  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qapp() -> QApplication:
+    """One offscreen QApplication for the module."""
+    application = QApplication.instance()
+    if application is None:
+        application = QApplication(sys.argv[:1])
+    return application
+
+
+class _Refuses:
+    """A follower that refuses every frame, the way a real one refuses a bad index."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def set_frame(self, frame: int) -> None:
+        self.calls += 1
+        raise ValueError(f"frame {frame} is outside the shot")
+
+
+class _Accepts:
+    """A follower that accepts, to prove one bad follower does not stop the rest."""
+
+    def __init__(self) -> None:
+        self.frames: list[int] = []
+
+    def set_frame(self, frame: int) -> None:
+        self.frames.append(int(frame))
+
+
+class TestARefusalDoesNotEscapeTheSignal:
+    def test_emitting_to_a_refusing_follower_does_not_raise(self) -> None:
+        transport = SoleLoadFieldWidget("guard")
+        transport.link(_Refuses())
+        # Unguarded, this is the call that aborts the interpreter.
+        transport.frame_changed.emit(0)
+
+    def test_the_refusal_is_logged_with_its_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        transport = SoleLoadFieldWidget("guard")
+        transport.link(_Refuses())
+        with caplog.at_level(logging.ERROR):
+            transport.frame_changed.emit(3)
+        assert any(r.exc_info for r in caplog.records), (
+            "the refusal must carry its traceback; a bare message would be no "
+            "better a diagnosis than the crash it replaces"
+        )
+        assert "_Refuses" in caplog.text
+        assert "3" in caplog.text
+
+    def test_the_refusal_is_not_swallowed_silently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        transport = SoleLoadFieldWidget("guard")
+        transport.link(_Refuses())
+        with caplog.at_level(logging.ERROR):
+            transport.frame_changed.emit(0)
+        assert caplog.records, (
+            "a silent pass would hide the desynchronisation the raise exists "
+            "to expose, which is the wrong trade in the other direction"
+        )
+
+
+class TestOneBadFollowerDoesNotStopTheRest:
+    def test_a_healthy_follower_still_receives_frames(self) -> None:
+        transport = SoleLoadFieldWidget("guard")
+        healthy = _Accepts()
+        transport.link(_Refuses())
+        transport.link(healthy)
+        transport.frame_changed.emit(1)
+        transport.frame_changed.emit(2)
+        assert healthy.frames == [1, 2]
+
+    def test_the_refusing_follower_stops_being_called(self) -> None:
+        transport = SoleLoadFieldWidget("guard")
+        refuses = _Refuses()
+        transport.link(refuses)
+        for frame in range(5):
+            transport.frame_changed.emit(frame)
+        assert refuses.calls == 1, (
+            "a follower that has desynchronised should be dropped, not "
+            "re-invoked on every tick to log the same failure repeatedly"
+        )


### PR DESCRIPTION
Every linked view refuses an out-of-range index rather than clamping it. That contract is **correct** and this PR keeps it: a clamped index would leave one view showing a different moment from the one driving it, which is the exact desynchronisation linking the views exists to prevent.

What is wrong is how the refusal is delivered. An exception escaping a Qt slot unwinds through the C++ event loop, which aborts the interpreter with `0xC0000409` and **no Python traceback at all**. So the mechanism added to make a mismatch obvious instead makes it undiagnosable — and takes the whole workbench down rather than one view.

## Why this is latent across the package, not a one-off

It was hit for real while wiring the sand-slice view in #8711, and worked around there by reordering a clear. But all five followers raise from `set_frame`:

| widget | from |
|---|---|
| `ShotViewportWidget` | #8706 |
| `TracePanelWidget` | #8708 |
| `CrossTierWidget` | #8713 |
| `SandSliceWidget` | #8711 |
| `GridMapWidget` | #8618 |

They are safe today **only because their frame counts happen to equal the transport's**. That is a coincidence, not an invariant — and the first view whose record legitimately differs in length (a strided field capture, a comparison run over a sub-window) turns a routine index mismatch into a process abort.

## The fix

`link()` connects through `_guarded`, which keeps the refusal and changes only what it costs:

- the mismatch is logged **with its traceback** — strictly better diagnosis than the crash it replaces, which produces none;
- that view stops following, while the transport and every other view carry on;
- the dropped follower is not re-invoked, so a desynchronised view does not log the same failure on every tick.

A silent `pass` would be the wrong trade in the other direction — hiding the desynchronisation the raise exists to expose — so there is a test pinning that the failure is still reported, and another pinning that it still carries its traceback.

## Verification

Five new tests in `test_follower_crash_guard.py`, including the emit that aborts the interpreter unguarded. Full `tests/tools/bunker_shot_gui/` suite passes (exit 0). `ruff check`, `ruff format --check` and `mypy` clean on both files.

Found while reviewing #8711. Refs #8706, #8708, #8711, #8713.