### PR TITLE
CI: Auto-Approve Same-Repository Workflow Runs to End the PR Freeze

### DIFF
--- a/.github/workflows/approve-same-repo-runs.yml
+++ b/.github/workflows/approve-same-repo-runs.yml
@@ -1,0 +1,88 @@
+# approve-same-repo-runs.yml — unfreeze bot-updated pull requests
+#
+# PROBLEM (issue #8754): branch protection requires the `quality-gate` status
+# with `strict: true`, so armed auto-merge keeps every PR branch up to date
+# with main. Those branch updates are pushed as `github-actions[bot]`, and
+# GitHub requires manual approval for workflow runs whose triggering actor
+# has no commits in the repository's history — the bot never does, because
+# squash merges rewrite authorship. The repo already uses the weakest
+# available approval policy (`first_time_contributors_new_to_github`); there
+# is no setting that exempts the bot. Result: every advance of main pushed an
+# update to every open PR, spawned `action_required` runs nobody approved,
+# `quality-gate` never reported, and no PR could merge. 19 of the 30 most
+# recent runs were frozen this way, including the fix for the quality-gate
+# context collision itself (#8747).
+#
+# FIX: approve pending runs whose head repository is THIS repository. Fork
+# PRs are untouched — they keep exactly the approval gate GitHub applies
+# today, so the protection that matters for a public repo with self-hosted
+# capacity is preserved. Same-repo branches can only be pushed by users with
+# write access (or by GitHub's own branch-update machinery), which is the
+# same trust boundary that lets those actors trigger workflows directly.
+#
+# Scheduled runs execute from the default branch without approval, so this
+# workflow cannot freeze itself.
+
+name: Approve Same-Repo Workflow Runs
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+concurrency:
+  group: approve-same-repo-runs
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ${{ !github.event.repository.private && vars.CI_RUNNER_MODE != 'local' && 'ubuntu-latest' || 'd-sorg-fleet-docker' }}
+    timeout-minutes: 10
+    steps:
+      - name: Approve pending runs whose head is this repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Only pull_request runs from branches in this repository. Fork PRs
+          # (head_repository != this repo) are deliberately excluded and keep
+          # their manual-approval requirement.
+          ids=$(gh api "repos/$REPO/actions/runs?status=action_required&per_page=100" \
+            --jq ".workflow_runs[]
+                  | select(.event == \"pull_request\")
+                  | select(.head_repository.full_name == \"$REPO\")
+                  | .id")
+
+          if [ -z "$ids" ]; then
+            echo "No pending same-repository runs."
+            exit 0
+          fi
+
+          approved=0
+          failed=0
+          for id in $ids; do
+            if gh api -X POST "repos/$REPO/actions/runs/$id/approve" >/dev/null; then
+              approved=$((approved + 1))
+              echo "approved run $id"
+            else
+              # A run can legitimately vanish between listing and approval
+              # (superseded SHA cancelled by a concurrency group). Warn, do
+              # not fail the sweep for it.
+              failed=$((failed + 1))
+              echo "::warning::could not approve run $id"
+            fi
+          done
+
+          echo "approved=$approved failed=$failed" >> "$GITHUB_STEP_SUMMARY"
+
+          # If everything failed, the token lacks permission and the workflow
+          # is not doing its job — fail loudly rather than rot silently.
+          if [ "$approved" -eq 0 ] && [ "$failed" -gt 0 ]; then
+            echo "::error::all $failed approval attempts failed — check token permissions"
+            exit 1
+          fi


### PR DESCRIPTION
No pull request in this repository can currently merge. This PR implements the fix for #8754, with the mechanism now confirmed by data rather than the theory the issue opened with.

## The mechanism, corrected

My original issue text guessed at the approval *setting*. Wrong — the repo already uses GitHub's **weakest** policy (`first_time_contributors_new_to_github`), verified via API. The real loop is three individually-reasonable features composing into a deadlock:

| Piece | Behaviour |
|---|---|
| Branch protection | requires `quality-gate`, `strict: true` (branches must be up to date) |
| Armed auto-merge | keeps every PR branch updated with main — pushed as **`github-actions[bot]`** |
| Squash merges | rewrite authorship, so the bot has **zero commits** in main's history |

A triggering actor with no commits in the repository is a "first-time contributor," so **every bot branch-update spawns `action_required` runs** — under any policy, because there is nothing weaker to set. Every advance of main re-updates every open PR, the new runs sit unapproved, `quality-gate` never reports, and every PR shows `BLOCKED` with **zero checks** — indistinguishable from slow CI.

Verified on a frozen run: `event: pull_request`, `actor: github-actions[bot]`, `triggering_actor: github-actions[bot]`, `head_repo: D-sorganization/UpstreamDrift` (not a fork). 16 of the 30 most recent runs are frozen this way right now, **including #8747 — the fix for the `quality-gate` context collision that the 26/26 merge audit went through.**

## The fix

A scheduled workflow (`*/5`) that approves pending runs whose **head repository is this repository**, and nothing else:

- **Fork PRs are untouched** — they keep exactly the approval gate they have today, which is the boundary that matters for a public repo with self-hosted capacity.
- Same-repo branches can only be pushed by write-access users or GitHub's own branch-update machinery — the same trust boundary that already lets those actors trigger workflows directly. Approving their runs grants nothing new.
- Scheduled runs execute from the default branch without approval, so **the approver cannot freeze itself**.
- If every approval attempt fails (token/permission rot), the job fails loudly instead of silently.

## Why not the alternatives

- **A weaker approval setting** — does not exist; already at the floor.
- **Re-identify the branch-update automation** so pushes come from the owner — the updates come from GitHub's auto-merge machinery itself, not a workflow I can edit.
- **Drop `strict: true`** — removes the trigger but weakens protection in a repo whose gates were just shown to be hollow (26/26). Wrong direction.
- **Merge queue** — the genuinely correct structural end-state: it replaces update-every-branch-on-every-main-advance entirely and removes the quadratic CI load. But it's a process change for the whole agent fleet and would jam immediately while main's aggregate is red. Recorded in #8754 as the owner-decision follow-up.

## After merge

I will `workflow_dispatch` it once to sweep the current backlog instead of waiting for cron, then verify the four frozen PRs (#8747, #8690–92) get real check runs.

Fixes #8754

🤖 Generated with [Claude Code](https://claude.com/claude-code)
