### PR TITLE
Fix: Sync Launcher Handler Tests With Long-Standing Production Behavior

### DIFF
--- a/tests/launchers/test_launcher_model_handlers.py
+++ b/tests/launchers/test_launcher_model_handlers.py
@@ -45,6 +45,7 @@ def test_module_handler() -> None:
         module_name="my_module",
         cwd=Path("/repo"),
         extra_python_paths=(),
+        keep_terminal_open=True,
     )
 
 
@@ -71,6 +72,7 @@ def test_script_handler() -> None:
         script_path=Path("/repo") / "script.py",
         cwd=Path("/repo") / "dir",
         extra_python_paths=(),
+        keep_terminal_open=True,
     )
 
 
@@ -370,7 +372,7 @@ class TestProviderExerciseHandler:
         ],
     )
     def test_launch_routes_provider_directory_to_matching_engine_dashboard(
-        self, model_type: str, engine: str
+        self, model_type: str, engine: str, tmp_path: Path
     ) -> None:
         """Provider directories launch a contained exercise dashboard, never a directory."""
 
@@ -380,24 +382,31 @@ class TestProviderExerciseHandler:
             path = "src/provider_models/exercises/bench_press"
             type = model_type
 
+        # The handler validates that the exercise path resolves to a real
+        # directory before launching, so the test repo must actually contain
+        # it - a bare fake path exercises only the rejection branch.
+        exercise_dir = (
+            tmp_path / "src" / "provider_models" / "exercises" / "bench_press"
+        )
+        exercise_dir.mkdir(parents=True)
+
         manager = MagicMock()
         manager.get_subprocess_env.return_value = {}
         manager.launch_script.return_value = "process"
 
-        result = ProviderExerciseHandler().launch(
-            ProviderModel(), Path("/repo"), manager
-        )
+        result = ProviderExerciseHandler().launch(ProviderModel(), tmp_path, manager)
 
         assert result is True
         manager.launch_script.assert_called_once_with(
             name="Bench Press",
-            script_path=Path("/repo") / "src" / "launchers" / "exercise_dashboard.py",
-            cwd=Path("/repo"),
+            script_path=tmp_path / "src" / "launchers" / "exercise_dashboard.py",
+            cwd=tmp_path,
             env={
                 "BIOMECH_EXERCISE": "bench_press",
                 "BIOMECH_ENGINE": engine,
             },
             extra_python_paths=(),
+            keep_terminal_open=True,
         )
         manager.launch_module.assert_not_called()
 


### PR DESCRIPTION
Production has passed `keep_terminal_open=True` since the #6955-era consolidations and the provider handler validates real directories; the tests still asserted the old signature with fake paths. This is one of the standing reds inside the honest `quality-gate` aggregate (visible across the 26/26 audit on #8747) — expectation drift that merged unnoticed through the context collision.

Fixes: three call expectations gain `keep_terminal_open=True`; the provider-routing params build a real exercise directory under `tmp_path` so the directory guard passes legitimately instead of only ever exercising the rejection branch.

Verified locally: file goes from 10 failing tests to 0.

Part of #8754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)