### PR TITLE
Bind the Dispersion and Trends tabs to corpus data

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -485,7 +485,7 @@ inventory and reopen adjudication until every new candidate is reviewed.
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-| **Spec Version** | 1.0.543 |
+| **Spec Version** | 1.0.544 |
 | **Last Spec Update** | 2026-08-16 |
 
 ## 2. Purpose & Mission
@@ -871,6 +871,14 @@ study,vandv,provenance,units}`, with subpackages re-exported by name and a
   tabs remain inert for corpus data because the corpus carries no capture
   timestamp or lateral carry; both gaps are tracked as data-authority issues
   #18 and #19 and are recoverable from retained native fields.
+- **2026-08-19** - Bound the Launch Monitor Analytics Dispersion and Trends
+  tabs to corpus data. The data authority now extracts lateral carry, flight
+  time, and a capture date, and `launch_monitor.corpus` maps them onto the
+  canonical `lateral_carry` (m), `flight_time` (s), and `captured_at` fields.
+  Both tabs were previously inert against the corpus for want of a lateral
+  coordinate and a time column; they now run over 20,099 and 8,488 shots
+  respectively. Column selection is filtered against the dataset schema, so a
+  corpus pinned before those columns exist still loads.
 - **2026-08-18** - Connected Launch Monitor Analytics to the private shot
   corpus. `launch_monitor.corpus.load_private_corpus()` reads the data
   authority's source-partitioned Parquet corpus (261,666 shots across 27
@@ -2663,6 +2671,7 @@ overlapping fixture names in nested conftests.
 
 | Tool       | Version | Purpose                                                                            | Blocking? |
 | ---------- | ------- | ---------------------------------------------------------------------------------- | --------- |
+| 2026-08-19 | 1.0.544 | Mapped the data authority's new `lateral_carry_yd`, `flight_time_s`, and `captured_at` corpus columns onto the canonical `lateral_carry`/`flight_time`/`captured_at` fields in `launch_monitor.corpus`, making the Dispersion (20,099 shots) and Trends (8,488 shots) tabs runnable against corpus data for the first time. Column selection now filters against the dataset schema so an older pinned corpus still loads. |
 | 2026-08-18 | 1.0.544 | Bumped `vendor/ud-tools` to the heavy-hit epic merge (Tools #4562/#4568): the coupled ball-head-hands impact model quantifying hand/body influence (<1% ball-speed effect for physiological hands, rigid-shaft upper bound reported), the `swing_sim.body_chain/1` golfer-model interchange with runtime-free MJCF/URDF/.osim parsers (MuJoCo, Drake, Pinocchio, OpenSim), and the `golf_club.impact_coupling_report/1` counterfactual wire. Launcher-manifest smoke test green on the new pin. |
 | 2026-08-18 | 1.0.543 | Bumped `vendor/ud-tools` 6472d03 -> ac59066: Tools' Club Fitting Tester epic C1-C5 (Tools #4549/#4557) - shared mesh inertia tensor, shaft forward-dynamics delivery deltas, the `golf_club.fitting_document/1` OEM wire, the `swing_sim.delivery_trajectory/1` biomech interchange with Drake/MuJoCo/OpenSim export adapters, and the counterfactual fitting engine emitting `golf_club.fitting_report/1`. Launcher-manifest smoke test green on the new pin. |
 | 2026-08-16 | 1.0.539 | Made BunkerShot3D's F0 solver and W7 metrics compose without hand-padding (issues #8702, #8700, #8701 under epic #8699). `bunkershot3d.solvers.shot.simulate_shot` now records the whole strike rather than the contact: a free-flight lead-in (`ShotSettings.free_flight_lead_steps`, 3.5 steps) brackets the entry crossing, and the march integrates through the disengaged tail until the sole reference is back above the free surface, so both `depth = 0` crossings the divot metrics interpolate are inside the record. `StrikeTrace.from_shot` is the metrics-layer view of an in-memory shot, one sample per recorded sample with nothing synthesised. `ShotSettings.max_time_s` moves from 10 ms to 200 ms because a nominal bunker shot does not clear the sand until ~10.8 ms, and a window that ends first now raises `ShotTruncatedError` from the solver -- naming `max_time_s` and the time reached, and carrying the partial trace -- instead of surfacing as `divot_metrics` refusing to locate an exit; `require_exit=False` keeps deliberate fixed-window marches legal. `ShotResult.depths_m` was engaged-element depth documented as sole depth (non-monotone, and reading zero while the sole was millimetres under), and is split into `engaged_depths_m` and a geometric `sole_depths_m`. `src/tools/bunker_shot_gui/bridge.py` drops its private free-flight placement and ballistic zero-wrench coast-out and consumes the library composition instead. 19 new tests; no new dependencies. |

--- a/src/shared/python/launch_monitor/corpus.py
+++ b/src/shared/python/launch_monitor/corpus.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 
@@ -67,6 +68,74 @@ def corpus_dataset_path(root: str | Path | None = None) -> Path:
     return Path(resolved) / "data" / "authority" / "database" / "shot_corpus_parquet"
 
 
+def _selected_column_map(metrics: list[str] | None) -> dict[str, tuple[str, str]]:
+    """Narrow the corpus column map to an optional canonical-metric allowlist."""
+    if metrics is None:
+        return dict(CORPUS_COLUMN_MAP)
+    unknown = set(metrics) - {name for name, _ in CORPUS_COLUMN_MAP.values()}
+    if unknown:
+        raise ValueError(f"Unknown corpus metrics requested: {sorted(unknown)}")
+    return {
+        column: (name, unit)
+        for column, (name, unit) in CORPUS_COLUMN_MAP.items()
+        if name in metrics
+    }
+
+
+def _source_filter(
+    pyarrow_dataset: Any, dataset_dir: Path, sources: list[str] | None
+) -> Any:
+    """Build the partition filter for a ``source_id`` allowlist, if any."""
+    if sources is None:
+        return None
+    available = {
+        entry.name.split("=", 1)[1]
+        for entry in dataset_dir.iterdir()
+        if entry.is_dir() and entry.name.startswith("source_id=")
+    }
+    unknown = set(sources) - available
+    if unknown:
+        raise ValueError(f"Unknown corpus sources requested: {sorted(unknown)}")
+    return pyarrow_dataset.field("source_id").isin(sources)
+
+
+def _canonicalize_metrics(
+    frame: pd.DataFrame, selected_map: dict[str, tuple[str, str]]
+) -> pd.DataFrame:
+    """Convert native corpus columns to canonical units and metric names."""
+    from src.shared.python.launch_monitor.schema import METRICS
+
+    present = {
+        column: value
+        for column, value in selected_map.items()
+        if column in frame.columns
+    }
+    for column, (name, unit) in present.items():
+        frame[column] = _convert(frame[column], unit, METRICS[name].canonical_unit)
+    return frame.rename(columns={column: name for column, (name, _) in present.items()})
+
+
+def _apply_identity(frame: pd.DataFrame) -> pd.DataFrame:
+    """Derive ``shot_id`` and rename corpus identity columns to the schema."""
+    identity = (
+        frame["source_id"].astype(str)
+        + "\x1f"
+        + frame["file"].astype(str)
+        + "\x1f"
+        + frame["row_index"].astype(str)
+    )
+    frame["shot_id"] = identity.map(
+        lambda value: hashlib.sha256(value.encode()).hexdigest()[:20]
+    )
+    return frame.rename(
+        columns={
+            "source_id": "session_id",
+            "monitor": "monitor_vendor",
+            "row_index": "source_row",
+        }
+    ).drop(columns=["file"])
+
+
 def load_private_corpus(
     root: str | Path | None = None,
     sources: list[str] | None = None,
@@ -101,34 +170,13 @@ def load_private_corpus(
             "may predate the Parquet corpus - sync it to a newer commit"
         )
 
-    selected_map = dict(CORPUS_COLUMN_MAP)
-    if metrics is not None:
-        unknown = set(metrics) - {name for name, _ in CORPUS_COLUMN_MAP.values()}
-        if unknown:
-            raise ValueError(f"Unknown corpus metrics requested: {sorted(unknown)}")
-        selected_map = {
-            column: (name, unit)
-            for column, (name, unit) in CORPUS_COLUMN_MAP.items()
-            if name in metrics
-        }
-
+    selected_map = _selected_column_map(metrics)
     dataset = pyarrow_dataset.dataset(
         dataset_dir, format="parquet", partitioning="hive"
     )
+    # A corpus pinned before a column was introduced simply lacks it; select
+    # what the dataset actually has rather than failing the whole read.
     available_columns = set(dataset.schema.names)
-    filter_expression = None
-    if sources is not None:
-        available = {
-            entry.name.split("=", 1)[1]
-            for entry in dataset_dir.iterdir()
-            if entry.is_dir() and entry.name.startswith("source_id=")
-        }
-        unknown_sources = set(sources) - available
-        if unknown_sources:
-            raise ValueError(
-                f"Unknown corpus sources requested: {sorted(unknown_sources)}"
-            )
-        filter_expression = pyarrow_dataset.field("source_id").isin(sources)
     requested = [
         "source_id",
         "monitor",
@@ -140,39 +188,10 @@ def load_private_corpus(
     ]
     table = dataset.to_table(
         columns=[name for name in requested if name in available_columns],
-        filter=filter_expression,
-    )
-    frame = table.to_pandas()
-
-    from src.shared.python.launch_monitor.schema import METRICS
-
-    selected_map = {
-        column: value
-        for column, value in selected_map.items()
-        if column in available_columns
-    }
-    for column, (name, unit) in selected_map.items():
-        frame[column] = _convert(frame[column], unit, METRICS[name].canonical_unit)
-    frame = frame.rename(
-        columns={column: name for column, (name, _) in selected_map.items()}
+        filter=_source_filter(pyarrow_dataset, dataset_dir, sources),
     )
 
-    identity = (
-        frame["source_id"].astype(str)
-        + "\x1f"
-        + frame["file"].astype(str)
-        + "\x1f"
-        + frame["row_index"].astype(str)
-    )
-    frame["shot_id"] = identity.map(
-        lambda value: hashlib.sha256(value.encode()).hexdigest()[:20]
-    )
-    frame = frame.rename(
-        columns={
-            "source_id": "session_id",
-            "monitor": "monitor_vendor",
-            "row_index": "source_row",
-        }
-    ).drop(columns=["file"])
+    frame = _canonicalize_metrics(table.to_pandas(), selected_map)
+    frame = _apply_identity(frame)
     frame["observation_kind"] = "shot"
     return frame

--- a/src/shared/python/launch_monitor/corpus.py
+++ b/src/shared/python/launch_monitor/corpus.py
@@ -45,7 +45,14 @@ CORPUS_COLUMN_MAP: dict[str, tuple[str, str]] = {
     "carry_yd": ("carry_distance", "yd"),
     "total_yd": ("total_distance", "yd"),
     "descent_angle_deg": ("descent_angle", "deg"),
+    "lateral_carry_yd": ("lateral_carry", "yd"),
+    "flight_time_s": ("flight_time", "s"),
 }
+
+# Identity columns carried straight through when the corpus provides them.
+# captured_at is what the Trends analysis binds to; a corpus built before the
+# data authority added it simply lacks the column.
+OPTIONAL_IDENTITY_COLUMNS: tuple[str, ...] = ("captured_at",)
 
 
 def corpus_dataset_path(root: str | Path | None = None) -> Path:
@@ -108,6 +115,7 @@ def load_private_corpus(
     dataset = pyarrow_dataset.dataset(
         dataset_dir, format="parquet", partitioning="hive"
     )
+    available_columns = set(dataset.schema.names)
     filter_expression = None
     if sources is not None:
         available = {
@@ -121,14 +129,28 @@ def load_private_corpus(
                 f"Unknown corpus sources requested: {sorted(unknown_sources)}"
             )
         filter_expression = pyarrow_dataset.field("source_id").isin(sources)
+    requested = [
+        "source_id",
+        "monitor",
+        "club",
+        "file",
+        "row_index",
+        *OPTIONAL_IDENTITY_COLUMNS,
+        *selected_map,
+    ]
     table = dataset.to_table(
-        columns=["source_id", "monitor", "club", "file", "row_index", *selected_map],
+        columns=[name for name in requested if name in available_columns],
         filter=filter_expression,
     )
     frame = table.to_pandas()
 
     from src.shared.python.launch_monitor.schema import METRICS
 
+    selected_map = {
+        column: value
+        for column, value in selected_map.items()
+        if column in available_columns
+    }
     for column, (name, unit) in selected_map.items():
         frame[column] = _convert(frame[column], unit, METRICS[name].canonical_unit)
     frame = frame.rename(

--- a/tests/unit/launch_monitor/test_corpus.py
+++ b/tests/unit/launch_monitor/test_corpus.py
@@ -96,3 +96,58 @@ def test_missing_root_and_missing_dataset_fail_closed(
         corpus_dataset_path()
     with pytest.raises(FileNotFoundError, match="shot corpus dataset not found"):
         load_private_corpus(root=tmp_path / "empty")
+
+
+def test_lateral_flight_and_capture_columns_reach_canonical_schema(
+    tmp_path: Path,
+) -> None:
+    """The #18/#19 corpus columns convert into the canonical schema."""
+    checkout = tmp_path / "checkout"
+    dataset = checkout / "data" / "authority" / "database" / "shot_corpus_parquet"
+    partition = dataset / "source_id=synthetic_new"
+    partition.mkdir(parents=True)
+    rows = pd.DataFrame(
+        {
+            "monitor": ["TrackMan"],
+            "file": ["a.csv"],
+            "row_index": [0],
+            "club": ["Driver"],
+            "club_speed_mph": [100.0],
+            "ball_speed_mph": [150.0],
+            "smash_factor": [1.5],
+            "launch_angle_deg": [12.0],
+            "launch_direction_deg": [1.0],
+            "spin_rate_rpm": [2700.0],
+            "back_spin_rpm": [2600.0],
+            "side_spin_rpm": [300.0],
+            "spin_axis_deg": [4.0],
+            "attack_angle_deg": [-1.2],
+            "club_path_deg": [0.5],
+            "face_angle_deg": [0.2],
+            "carry_yd": [250.0],
+            "total_yd": [270.0],
+            "apex_native": [95.0],
+            "descent_angle_deg": [38.0],
+            "lateral_carry_yd": [-12.5],
+            "flight_time_s": [6.2],
+            "captured_at": ["2023-08-07T00:00:00"],
+            "native_json": ["{}"],
+        }
+    )
+    rows.to_parquet(partition / "part-0.parquet", index=False)
+
+    frame = load_private_corpus(root=checkout)
+
+    row = frame.iloc[0]
+    assert row["lateral_carry"] == pytest.approx(-12.5 * 0.9144)  # yards -> m
+    assert row["flight_time"] == pytest.approx(6.2)
+    assert row["captured_at"] == "2023-08-07T00:00:00"
+
+
+def test_corpus_predating_the_new_columns_still_loads(tmp_path: Path) -> None:
+    """An older pinned corpus lacks the columns; the loader must not fail."""
+    frame = load_private_corpus(root=_synthetic_checkout(tmp_path))
+
+    assert len(frame) == 2
+    assert "lateral_carry" not in frame.columns
+    assert "captured_at" not in frame.columns


### PR DESCRIPTION
## Summary

Two tabs of the Launch Monitor Analytics workbench have been inert against corpus data since the corpus was wired up in #8757/#8769 — **Dispersion** had no lateral coordinate to bind to, and **Trends** had no time column. The data authority has now extracted both (its issues #18 and #19); this is the consumer half.

- `lateral_carry_yd` → **`lateral_carry`** (yards → metres) and `flight_time_s` → **`flight_time`** join `CORPUS_COLUMN_MAP`.
- `captured_at` is carried through as an optional identity column — it is exactly what `analyze_trend` binds to.
- Column selection is filtered against the dataset's actual schema, so a corpus pinned before these columns existed still loads rather than failing the whole read on a missing name.

## Verified by actually running the tabs

Driven headless against an authorized checkout, not inferred from the data being present:

```
DISPERSION: Dispersion complete for 1 group(s).     20,099 shots, 95% ellipse
TRENDS:     Trend slope=-0.01793/day; 3 candidate change point(s).   8,488 shots
```

The dispersion ellipse renders with `center_forward` 136.8, `center_lateral` 0.56, `ellipse_major` 308.7 — a centred, plausibly-shaped distribution rather than a degenerate one.

Corpus-wide the new columns arrive as: `lateral_carry` 20,099 rows (median |10.0| m), `flight_time` 223,956 rows (max 9.67 s), `captured_at` 8,488 rows across 13 sources.

## One bug worth naming

`load_private_corpus` already used the local name `available` for the **set of source ids** inside the `sources is not None` branch. My first pass introduced a second `available` for column names, which the sources branch then clobbered — so the column filter matched nothing and returned an empty frame. Caught by the existing `test_source_and_metric_selection`; the column set is now `available_columns`. Worth flagging because the two sets are both plausibly called "available" and the collision is silent.

## Test plan

- [x] `pytest tests/unit/launch_monitor/` — all pass (2 new)
- [x] New tests cover canonical conversion of all three columns **and** that a corpus predating them still loads
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] Live workbench run producing the Dispersion ellipse and Trends slope quoted above
- [x] SPEC.md updated (1.0.544) per the spec-check policy

Depends on data-authority PR #20 for the columns to be present; degrades cleanly to today's behaviour until the lock file is bumped.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RRnmawXtzrcRJatcGNYVZ)_