### PR TITLE
fix(docker): make the modular builder slice self-sufficient (#8771)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -485,7 +485,7 @@ inventory and reopen adjudication until every new candidate is reviewed.
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
 
-| **Spec Version** | 1.0.548 |
+| **Spec Version** | 1.0.549 |
 | **Last Spec Update** | 2026-08-19 |
 
 ## 2. Purpose & Mission
@@ -517,39 +517,24 @@ UpstreamDrift is a multi-physics golf swing biomechanical simulation platform th
 
 ### Recent Spec Updates
 
-- **2026-08-19** - Git-ignored the test-run artefacts that have twice been
-  committed at the repository root (issue #8771). The autouse
-  `_prevent_repo_root_io` fixture chdirs every test into `tmp_path` so they are
-  not produced (#7935), but nothing stopped them being staged once they
-  existed: #8322 committed all nine (`base.csv`, `base.json`, `base.mat`, two
-  `.provenance.json` files, three `pytest_report*.txt` and a one-off patch
-  script) and #8747 had to delete them again while repairing the root-clutter
-  gate. The names are now ignored, anchored to the root so the tracked
-  `docs/research/.../base.csv` fixture is unaffected.
-- **2026-08-19** - Restored `optional-stack-check (3.11)` (issue #8771). The
-  lane failed on exactly three tests in `tests/unit/deployment/test_devices.py`,
-  each asserting `not dev.connect()` for the SpaceMouse, VR-controller and
-  haptic stubs, which raise `NotImplementedError` instead. #8322 made that
-  change and kept the tests. It also deleted the reasoning: before #8322 each
-  method returned `False` under a docstring explaining that "there is no
-  hardware driver behind this class, so the honest answer is always 'not
-  connected' (#7360)", and that the body it replaced had probed for an
-  optional backend and returned `False` on both arms, making the stub look
-  conditionally functional. Returning `False` is the contract the rest of the
-  subsystem keeps: `BaseInputDevice.connect` returns `False`, the ROS2 and UDP
-  controller stubs return `False` with tests asserting it, and
-  `test_base_input_device` asserts it of the base class directly - so the
-  three overrides were inconsistent with their own parent. #8322 additionally
-  rewrote two of the three test files that cover these stubs
-  (`tests/deployment/test_teleoperation.py` and
-  `tests/deployment/wave5_deployment/test_teleoperation.py`, six assertions)
-  from `assert not d.connect()` to `pytest.raises(NotImplementedError)`, and
-  missed the third - which is the whole reason `optional-stack-check` went red
-  while `unit-test-gate` did not. Before #8322 all three files asserted
-  `False`. The implementation bodies, their rationale and the six rewritten
-  assertions are all restored to their pre-#8322 text, so one contract holds
-  across the subsystem again; the `#8058` tracking reference is kept and no
-  test was skipped or deleted.
+- **2026-08-19** - Repaired all five `profile-size-matrix` Docker builds
+  (issue #8771). `Dockerfile.modular`'s builder stage copies a deliberate
+  minimal slice - `src/shared/python/__init__.py`, `engine_core/` and
+  `feature_registry/` - so resolving a profile does not invalidate the layer
+  cache on every source change. `scripts/docker/install_features.py` then did
+  `from src.shared.python.feature_registry.features import get_feature`, and
+  importing a submodule executes every parent package `__init__` first: once
+  `src/shared/python/__init__.py` grew an eager `from . import ai`, and `ai/`
+  is not in the slice, every modular image build died at `ImportError: cannot
+  import name 'ai' from partially initialized module`. The script now loads
+  `features.py` from its path with no parent package, which is what its own
+  comment always claimed ("read the features module in isolation") and what
+  makes the builder slice self-sufficient regardless of what any package
+  `__init__` later imports. `features.py` depends only on `dataclasses` and
+  `typing`. The module is registered in `sys.modules` before execution
+  because `@dataclass` resolves `cls.__module__` through it while processing
+  the class body. `src/shared/python/__init__.py` is a Tools-owned child copy
+  and is deliberately left untouched.
 
 - **2026-08-16** - Scoped BunkerShot3D's camber-clamped flag so it cannot
   understate substitution (`src/bunkershot3d/geometry/lofting.py`,
@@ -2975,6 +2960,7 @@ blocks Python package publication on the built-wheel smoke matrix.
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-19 | 1.0.549 | Repaired all five `profile-size-matrix` Docker builds. `scripts/docker/install_features.py` reached the feature registry through `from src.shared.python.feature_registry.features import ...`, which executes every parent package `__init__`; `Dockerfile.modular`'s builder stage deliberately copies only `__init__.py`, `engine_core/` and `feature_registry/` so profile resolution does not invalidate the layer cache, so an eager `from . import ai` in that `__init__` broke every modular build with `ImportError: cannot import name 'ai' from partially initialized module`. The script now loads `features.py` by path with no parent package - what its own comment always claimed - making the builder slice self-sufficient regardless of what any package `__init__` imports later; the module is registered in `sys.modules` before execution because `@dataclass` resolves `cls.__module__` through it. Verified against a reconstructed builder slice: all five profiles resolve with `src/shared/python/__init__.py` left exactly as it is on `main`, since it is a Tools-owned child copy (#8771). |
 | 2026-08-19 | 1.0.548 | Git-ignored the root-level test-run artefacts (`base.csv`, `base.json`, `base.mat`, `base.h5`, `base.*.provenance.json`, `pytest_report*.txt`, `golf_modeling_suite.db`). `_prevent_repo_root_io` stops tests producing them (#7935) but nothing stopped them being staged: #8322 committed nine such files at the root and #8747 deleted them again. Patterns are root-anchored, so the tracked `docs/research/proximal_distal_energy_transfer/data/wscg_two_hand_raw/base.csv` fixture is not affected; verified no tracked path is newly ignored (#8771). |
 | 2026-08-19 | 1.0.547 | Restored `optional-stack-check (3.11)`: the SpaceMouse, VR-controller and haptic `connect()` stubs in `src/deployment/teleoperation/devices.py` return `False` again instead of raising `NotImplementedError`. #8322 introduced the raise, kept the three tests asserting `not dev.connect()`, and deleted the #7360 docstring explaining why `False` is the honest answer for a stub with no hardware driver. `BaseInputDevice.connect`, the ROS2/UDP controller stubs and `test_base_input_device` all keep the `False` contract, so the overrides were inconsistent with their own parent class. #8322 also rewrote six assertions in `tests/deployment/test_teleoperation.py` and `tests/deployment/wave5_deployment/test_teleoperation.py` from `assert not d.connect()` to `pytest.raises(NotImplementedError)` while missing the third file - which is why `optional-stack-check` went red and `unit-test-gate` did not, and why the repo has since asserted both contracts at once. All of it is restored to the pre-#8322 text so a single contract holds again; the `#8058` reference is retained. 288 deployment tests pass, nothing skipped or deleted (#8771). |
 | 2026-08-18 | 1.0.543 | Added a "Load Private Corpus" button to the Launch Monitor Analytics Sessions tab and a matching File-menu action, backed by `MainWidget.load_private_corpus_sessions()`: one session per corpus source (261,666 shots across 27 sources in ~3 s), repeatable without duplicates, failing closed with a dialog when no authorized checkout or Parquet reader is available. Five regression tests cover the success, idempotence, fail-closed, and both UI-affordance paths over synthetic fixtures. Trends and Dispersion stay inert against corpus data pending capture-timestamp and lateral-carry extraction, tracked as data-authority issues #18/#19. |

--- a/scripts/docker/install_features.py
+++ b/scripts/docker/install_features.py
@@ -40,11 +40,13 @@ don't pull PyYAML into the builder.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import shlex
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 # ---------------------------------------------------------------------------
 # Minimal YAML loader.
@@ -153,19 +155,55 @@ def _resolve_profile_features(profiles: dict, name: str) -> list[str]:
 # Feature → install command via the registry.
 #
 # We import the registry directly so the *single* source of truth lives in
-# Python. To avoid running the registry's import-time DbC validator
-# (which would also import probes that need numpy etc.) we read the
-# features module in isolation by adding the repo to sys.path.
+# Python. To avoid running the registry's import-time DbC validator (which
+# would also import probes that need numpy etc.) we read the features module
+# in genuine isolation: loaded from its file, with no parent package.
+#
+# `from src.shared.python.feature_registry.features import ...` does not
+# achieve that, because importing a submodule executes every parent package's
+# `__init__` first. `Dockerfile.modular`'s builder stage deliberately copies
+# only `src/shared/python/__init__.py`, `engine_core/` and
+# `feature_registry/` so that resolving a profile does not invalidate the
+# layer cache on every source change - so any eager import that `__init__`
+# happens to grow, for a package outside that slice, breaks every modular
+# image build with `ImportError: cannot import name X from partially
+# initialized module`. That is exactly what happened here.
+#
+# Loading the file directly is safe: `features.py` imports only `dataclasses`
+# and `typing`, and it is what the paragraph above always claimed to do.
 # ---------------------------------------------------------------------------
+
+_FEATURES_RELATIVE_PATH = Path("src/shared/python/feature_registry/features.py")
+
+
+def _load_features_module(repo_root: Path) -> ModuleType:
+    """Load ``features.py`` from disk without importing its parent packages."""
+    features_path = repo_root / _FEATURES_RELATIVE_PATH
+    if not features_path.is_file():
+        raise SystemExit(f"[install_features] missing registry: {features_path}")
+
+    spec = importlib.util.spec_from_file_location(
+        "_install_features_registry", features_path
+    )
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"[install_features] cannot load registry: {features_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves `cls.__module__` through `sys.modules` while the
+    # class body is being processed, so the module has to be registered
+    # *before* it is executed, not after.
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
+    return module
 
 
 def _feature_install_argv(feature_name: str, repo_root: Path) -> list[list[str]]:
     """Return one or more argv lists describing how to install a feature."""
-    sys.path.insert(0, str(repo_root))
-    try:
-        from src.shared.python.feature_registry.features import get_feature
-    finally:
-        sys.path.pop(0)
+    get_feature = _load_features_module(repo_root).get_feature
 
     feature = get_feature(feature_name)
 


### PR DESCRIPTION
Part of #8771. Fixes all five `profile-size-matrix` checks — `slim`, `standard`, `biomech`, `research`, `full` — which are red on `main` and were not in the issue's original inventory.

**Reshaped** after CI: the first revision fixed the right bug in the wrong file. See "What changed and why" at the bottom.

## The failure

All five die at the same Docker build step, before any image is produced:

```
#18 [builder 12/22] RUN set -eux; ... install_features.py --profile "slim" --dry-run
#18 0.075 [install_features] resolved features: api, pendulum, mujoco
#18 0.075   File "/workspace/scripts/docker/install_features.py", line 166, in _feature_install_argv
#18 0.075     from src.shared.python.feature_registry.features import get_feature
#18 0.075   File "/workspace/src/shared/python/__init__.py", line 32, in <module>
#18 0.075     from . import ai as ai
#18 0.075 ImportError: cannot import name 'ai' from partially initialized module 'src.shared.python'
ERROR: failed to build: failed to solve
```

## Root cause

`Dockerfile.modular`'s builder stage copies a **deliberate minimal slice**:

```dockerfile
COPY src/__init__.py                        ./src/__init__.py
COPY src/shared/__init__.py                 ./src/shared/__init__.py
COPY src/shared/python/__init__.py          ./src/shared/python/__init__.py
COPY src/shared/python/engine_core/         ./src/shared/python/engine_core/
COPY src/shared/python/feature_registry/    ./src/shared/python/feature_registry/
RUN ... install_features.py --profile "$PROFILE" --dry-run
```

with the reason a few lines below: *"The full source tree is COPYd in the runtime stage so layer caches"* are not invalidated by every source change. Resolving which pip packages a profile needs must not require the whole repo.

`install_features.py` reached the registry through a **dotted import**, and importing a submodule executes every parent package's `__init__` first. So the slice was only ever self-sufficient by luck — it depended on `src/shared/python/__init__.py` importing nothing outside the slice. When that `__init__` grew an eager `from . import ai`, every modular image build broke. (The traceback's *"most likely due to a circular import"* is CPython guessing; the module is simply absent.)

## The fix

Load `features.py` from its path, with no parent package:

```python
spec = importlib.util.spec_from_file_location("_install_features_registry", features_path)
module = importlib.util.module_from_spec(spec)
sys.modules[spec.name] = module      # see below
spec.loader.exec_module(module)
```

This is what the comment above that code **always claimed** to do:

> To avoid running the registry's import-time DbC validator … we read the features module **in isolation** by adding the repo to sys.path.

Adding the repo to `sys.path` never achieved isolation — the dotted import still ran all three `__init__`s. Now it genuinely does, which makes the builder slice self-sufficient *regardless of what any package `__init__` imports in future*. `features.py` depends only on `dataclasses` and `typing`.

**One subtlety worth flagging for review:** the module must be registered in `sys.modules` *before* `exec_module`, because `@dataclass` resolves `cls.__module__` through `sys.modules` while processing the class body. Without it you get:

```
File "/usr/lib/python3.11/dataclasses.py", line 712, in _is_type
  ns = sys.modules.get(cls.__module__).__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

I hit exactly that on the first attempt. It is cleaned up on failure so a failed load leaves no half-initialised entry behind.

## Verification

Reconstructed the builder slice — exactly the paths the Dockerfile copies, nothing else — with `src/shared/python/__init__.py` left **exactly as it is on `main`**, eager import and all:

| | result |
| --- | --- |
| `origin/main` | `ImportError: cannot import name 'ai'`, exit 1 |
| this branch | all five profiles exit 0 |

```
slim     -> exit=0  (api, pendulum, mujoco)
standard -> exit=0  (… + pinocchio)
biomech  -> exit=0  (… + opensim, myosuite)
research -> exit=0  (… + drake, pose-mediapipe)
full     -> exit=0  (… + chrono)
```

Full-tree behaviour unchanged — `--profile slim/full` and `--features mujoco` resolve identically, and an unknown profile still fails loudly with the known list:

```
$ install_features.py --profile nonexistent --dry-run
unknown profile 'nonexistent'; known: biomech, full, gpu-training, research, slim, standard
```

```
tests/unit/repo_hygiene/test_tools_child_copy_contract.py   9 passed, 3 skipped
ruff check / ruff format --check                            clean
```

## What changed and why

The first revision restored the PEP 562 lazy `__getattr__` in `src/shared/python/__init__.py`. That was the right diagnosis and the wrong file — `unit-test-gate` caught it:

```
FAILED tests/unit/repo_hygiene/test_tools_child_copy_contract.py::test_current_branch_does_not_edit_tools_child_copies
  This branch directly modifies Tools-owned child copies in UpstreamDrift.
  Make each change in D-sorganization/Tools, merge or pin that canonical revision,
  and update only vendor/ud-tools here.
```

**And a vendor bump would not have fixed it either.** The builder stage copies `src/shared/python/__init__.py` from *this repo's own tree*, not from `vendor/ud-tools/` — so pinning a fixed Tools revision leaves the file the Dockerfile actually reads unchanged. I checked the `COPY` list specifically for this.

That leaves the fix having to live in UpstreamDrift-owned code, and `scripts/docker/` is exactly that. It is also the better fix: it removes the coupling permanently instead of restoring a property that has to be maintained by convention. The eager import in Tools remains a latent bug worth fixing upstream — nothing else currently depends on that `__init__` being lazy, but it is a trap — and it is no longer what breaks these builds.

Nothing currently *tests* that the builder slice is self-sufficient, which is why this broke silently for two and a half weeks. A cheap guard would be a unit test that reconstructs the slice from the `COPY` lines and runs the validator against it; I have not added one here, since it wants a home and a convention decision rather than being tacked onto a fix.

No admin merge or bypass requested.