### PR TITLE
🛡️ Sentinel: [MEDIUM] Add X-Launcher-CSRF-Token to CORS allow_headers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4146,3 +4146,4 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - `spec-exempt`: Replaced `np.sum(A * B)` with `np.vdot(A.ravel(), B.ravel())` in `src/bunkershot3d/study/surrogate.py` to optimize 2D array dot product without changing logic.
 
 - Replaced `np.concatenate` with in-place slice assignment in `TrajectoryFunnelBenchmark._policy_action` to optimize array construction in tight simulation loops. (spec-exempt: micro-optimization)
+- Security: Added `X-Launcher-CSRF-Token` to CORS `allow_headers` in `src/api/server.py` and `src/api/local_server.py` to fix CORS preflight rejections for the local launcher UI.

--- a/src/api/local_server.py
+++ b/src/api/local_server.py
@@ -203,7 +203,12 @@ def _configure_cors(app: FastAPI) -> None:
         # SECURITY (issue #6636 F3): match server.py hardening — do NOT use "*"
         # for methods/headers while credentials are enabled.
         allow_methods=["GET", "POST", "PUT", "DELETE"],
-        allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+        allow_headers=[
+            "Content-Type",
+            "Authorization",
+            "X-API-Key",
+            "X-Launcher-CSRF-Token",
+        ],
     )
 
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -302,7 +302,12 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     # SECURITY: Restrict headers - do NOT use "*"
-    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+    allow_headers=[
+        "Content-Type",
+        "Authorization",
+        "X-API-Key",
+        "X-Launcher-CSRF-Token",
+    ],
 )
 
 # Rate limiting


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The API server was rejecting valid CORS preflight requests from the UI because the `X-Launcher-CSRF-Token` header was not whitelisted in the CORS `allow_headers` configuration. 
🎯 Impact: Users would encounter CORS errors when trying to launch apps from the web UI to the desktop via the launcher manifest API, effectively breaking local launcher interactions for web clients.
🔧 Fix: Added `"X-Launcher-CSRF-Token"` to the `allow_headers` list in `CORSMiddleware` setup for both `src/api/server.py` and `src/api/local_server.py`.
✅ Verification: Verified fix locally by spinning up a fastAPI test client with the updated `allow_headers` logic and successfully performing a CORS pre-flight `OPTIONS` request sending the token. All linter checks and tests passed.

---
*PR created automatically by Jules for task [351803752289963287](https://jules.google.com/task/351803752289963287) started by @dieterolson*