### PR TITLE
fix(ci): resolve npm ERESOLVE peer dependency in standalone sidekick packaging

### DIFF
--- a/.github/workflows/package-standalone-sidekick.yml
+++ b/.github/workflows/package-standalone-sidekick.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ui
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build frontend
         working-directory: ui


### PR DESCRIPTION
## Summary
Resolves peer dependency resolution conflicts (\
pm ERESOLVE\) during frontend dependency installation in the \Package Standalone Sidekick\ CI workflow.

- Adds \--legacy-peer-deps\ to the \
pm ci\ invocation in \.github/workflows/package-standalone-sidekick.yml\.
- Ensures clean standalone sidekick packaging runs without failing on peer dependency mismatches (such as between TypeScript and TypeScript-ESLint releases).

Closes #8772