### PR TITLE
fix(pose_studio): initialize undo/redo QActions on MainWidget and guard refresh (#8879)

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,6 +1,6 @@
 # Agent Handoff — UpstreamDrift
 
-Last updated: 2026-08-23
+Last updated: 2026-08-24
 
 This file records current operational state, not history. Git and GitHub retain
 history. Epic #8557 is the single proximal-to-distal completion authority.
@@ -12,42 +12,39 @@ history. Epic #8557 is the single proximal-to-distal completion authority.
   projection. Tools owns reusable consumers; do not copy its solver or UI
   implementations into this repository or `vendor/ud-tools`.
 - UpstreamDrift remote `main` is
-  `9e220712025564caf0ac5201a0ddcf69dd98299e`, the protected squash merge of
-  PR #9018. Issue #8724 is closed with exact-head CI, optional-stack CI, and
-  remote-main ancestry verified.
+  `228b9a5df130ac46954dd2c9431d795525003c58`. The normalized-claim authority
+  from PR #9018 remains an ancestor; issue #8724 is closed.
 - The current computational publication is 239 pages with SHA-256
   `be85b7b62bba060a26ce3fea8355aa8b01dcf8c1b1ccf09304450898a4e5e78b`,
   194 URI links, and 247 outline entries. All pages render and were inspected.
   Archival qualification remains false because the PDF is untagged and retains
   Type 3 and unembedded font resources.
 
-## Active Articulated Uncertainty Campaign (#8752)
+## Active Structural Campaign and Recovery Boundary (#8800)
 
-- ControlTower worktree:
-  `C:\Users\diete\Repositories\UpstreamDrift-worktrees\goal-8752-uncertainty`,
-  running the exact scientific launch revision
-  `13146cdcece879e7156e06e2dca6626c1a54e045`.
-- Container `upstreamdrift-8752-campaign` uses eight workers within a reversible
-  four-core CPU cap. Its workspace and campaign records are bind-mounted from
-  the ControlTower C: drive, and restart policy is `on-failure`. Do not start a
-  duplicate or modify its frozen source.
-- At 13:34 PDT, 18 of 19 registered corners were terminal and retained,
-  including declared failed-retained outcomes. The final
-  `ground_free_moment_damping_scale-high` corner had atomically completed
-  branch 38/72 of its ground atlas. `status.json` remained `running`.
-- Status and logs:
-  `C:\Users\diete\Campaigns\UpstreamDrift-8752`. Remote inspection uses the
-  pinned Tailscale SSH route into `ControlTower-SSD`; a separate Codex session
-  on ControlTower is unnecessary. Loss of this task or Tailscale connectivity
-  does not stop the container.
-- Runtime: Ubuntu 22.04, Python 3.10.12, NumPy 2.2.4, SciPy 1.15.2, MuJoCo
-  3.8.0, and Pinocchio 3.8.0. The cross-CPU canary preserves registered
-  discrete decisions and gates at `rtol=2e-8`, `atol=1e-9`.
-- At terminal status, audit every expected branch, retained failure, and
-  digest. Then integrate `fix/8752-atomic-campaign-checkpoint`. The constitutive
-  subcampaign precedes execution of #8800; #8800 still blocks final closure of
-  #8752 and #8668. Regenerate claims, figures, paper, and release only after
-  both authorities pass.
+- ControlTower prepared clean source commit
+  `1bd4d57da7bd257b76b42b3cc19524b283b5f748`, image
+  `sha256:b40d91fe2326c5fae288e4a853377fb164aa0a6ba1de62cb28aba15d65500a1e`,
+  plan file SHA-256
+  `2bddb125492e907acc827e1dbf4cb43b9724e73087679cbf4113bcf96824b120`,
+  and plan-contract SHA-256
+  `c5cfba35ecafa96054ef8cc872f2e91a9f7855db0b93cfa491f9b18ee3db80f4`.
+- The campaign used two workers and two CPUs. Shaft is complete at 48/48
+  atomic checkpoints; ground has 45/48. The 93 checkpoint files and completed
+  shaft artifacts remain on the ControlTower C: drive under
+  `C:\Users\diete\Campaigns\UpstreamDrift-8800-1bd4d57da`.
+- Status remains `running`, has no retained execution failures, and explicitly
+  reports `release_evidence=false`. Partial checkpoints are resume evidence,
+  not scientific release evidence.
+- WSL cannot currently mount
+  `F:\WSL\ControlTower-SSD\ext4.vhdx`; Windows reported the file corrupted and
+  unreadable (`0x80070570`). Both WSL distributions are stopped. Tailscale SSH
+  to ControlTower remains available.
+- Do not retry WSL, run CHKDSK, repair or mount the VHDX, restart Windows
+  services, create a replacement campaign, or alter frozen source or plans
+  without an explicit recovery and recoverability decision. Preserve the VHDX
+  and C: checkpoints. After recovery, verify identities and resume only the
+  three missing ground branches before complete-set and digest qualification.
 
 ## Normalized Claim Adjudication (#8724)
 
@@ -85,13 +82,16 @@ history. Epic #8557 is the single proximal-to-distal completion authority.
 
 ## Other Active Dependencies
 
-- The current constitutive subcampaign is the active #8752 slice. #8800 then
-  propagates height, body-mass, and joint-limit bounds through both headline
-  atlases and blocks the final #8752/#8668 audit.
+- #8800 propagates height, body-mass, and joint-limit bounds through both
+  headline atlases and blocks the final #8752/#8668 audit.
 - #8443, #8448, #8449, #8450, #8595, #8668, #8684, and #8796 remain open.
   Verify each issue's exact acceptance evidence before changing state.
-- Tools #4142 remains open for requirement-level R10–R15 qualification and
-  immutable UpstreamDrift consumption. Tools #4430 is complete.
+- Tools PR #4669 is open at exact head
+  `36f4b1add2bc72cea87bd9f87d36b232db76d50b` with squash auto-merge requested;
+  do not pin it before protected merge. Its final suite exposed an
+  UpstreamDrift provider-mode test isolation defect, corrected in protected
+  PR #9022. Tools #4142 remains open until immutable UpstreamDrift consumption
+  and R10–R15 qualification are complete.
 - AffineDrift #3930 remains downstream of the qualified UpstreamDrift release;
   do not project a moving or partial campaign.
 - #8963 architecture debt remains separate from the frozen campaign source.

--- a/SPEC.md
+++ b/SPEC.md
@@ -4362,3 +4362,4 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - (spec-exempt: micro-optimization) Replaced `np.sum(condition)` and `np.sum(np.isnan(arr))` with `np.count_nonzero` in python analytics and motion matching codebase for faster array evaluation.
 
 - Starting pose matcher: `on_clear_overrides_clicked` prompts for confirmation and unconditionally restores original mocap events state on confirm (#8889).
+- Pose studio actions: initialize undo/redo QActions on MainWidget and guard action refresh against uninitialized state (#8879).

--- a/src/tools/pose_studio/gui.py
+++ b/src/tools/pose_studio/gui.py
@@ -106,6 +106,17 @@ class MainWidget(QtWidgets.QWidget):
         self.btn_redo.setToolTip("Redo the last undone edit (Ctrl+Shift+Z).")
         self.btn_redo.clicked.connect(self._on_redo)
 
+        # Actions for keyboard shortcuts and menu bar (created on MainWidget so embedded mode has working shortcuts)
+        self.act_undo = QtGui.QAction("&Undo", self)
+        self.act_undo.setShortcut(QtGui.QKeySequence("Ctrl+Z"))
+        self.act_undo.triggered.connect(self._on_undo)
+        self.addAction(self.act_undo)
+
+        self.act_redo = QtGui.QAction("&Redo", self)
+        self.act_redo.setShortcut(QtGui.QKeySequence("Ctrl+Shift+Z"))
+        self.act_redo.triggered.connect(self._on_redo)
+        self.addAction(self.act_redo)
+
     def _build_layout(self) -> None:
         outer = QtWidgets.QVBoxLayout(self)
         outer.setContentsMargins(8, 8, 8, 8)
@@ -212,8 +223,10 @@ class MainWidget(QtWidgets.QWidget):
     def _refresh_undo_redo_actions(self) -> None:
         self.btn_undo.setEnabled(self._history.can_undo)
         self.btn_redo.setEnabled(self._history.can_redo)
-        self.act_undo.setEnabled(self._history.can_undo)
-        self.act_redo.setEnabled(self._history.can_redo)
+        if hasattr(self, "act_undo") and self.act_undo is not None:
+            self.act_undo.setEnabled(self._history.can_undo)
+        if hasattr(self, "act_redo") and self.act_redo is not None:
+            self.act_redo.setEnabled(self._history.can_redo)
 
     def create_menu_bar(self, parent: QtWidgets.QMainWindow) -> QtGui.QMenuBar:
         """Create and return a menu bar for the given parent window.
@@ -252,13 +265,7 @@ class MainWidget(QtWidgets.QWidget):
         file_menu.addAction(act_quit)
 
         # Edit menu.
-        self.act_undo = QtGui.QAction("&Undo", parent)
-        self.act_undo.setShortcut(QtGui.QKeySequence("Ctrl+Z"))
-        self.act_undo.triggered.connect(self._on_undo)
         edit_menu.addAction(self.act_undo)
-        self.act_redo = QtGui.QAction("&Redo", parent)
-        self.act_redo.setShortcut(QtGui.QKeySequence("Ctrl+Shift+Z"))
-        self.act_redo.triggered.connect(self._on_redo)
         edit_menu.addAction(self.act_redo)
 
         # Pose Library menu.
@@ -310,6 +317,14 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
     def main_widget(self) -> MainWidget:
         """Return the embedded MainWidget."""
         return self._main_widget
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate attribute lookups to the inner MainWidget for backwards compatibility."""
+        if "_main_widget" in self.__dict__:
+            return getattr(self._main_widget, name)
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
 
 
 class _EmbedAdapter:

--- a/src/tools/pose_studio/gui.py
+++ b/src/tools/pose_studio/gui.py
@@ -228,7 +228,7 @@ class MainWidget(QtWidgets.QWidget):
         if hasattr(self, "act_redo") and self.act_redo is not None:
             self.act_redo.setEnabled(self._history.can_redo)
 
-    def create_menu_bar(self, parent: QtWidgets.QMainWindow) -> QtGui.QMenuBar:
+    def create_menu_bar(self, parent: QtWidgets.QMainWindow) -> QtWidgets.QMenuBar:
         """Create and return a menu bar for the given parent window.
 
         Args:
@@ -325,6 +325,13 @@ class PoseStudioWindow(QtWidgets.QMainWindow):
         raise AttributeError(
             f"'{type(self).__name__}' object has no attribute '{name}'"
         )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Delegate attribute assignments to the inner MainWidget for backwards compatibility."""
+        if "_main_widget" in self.__dict__ and hasattr(self._main_widget, name):
+            setattr(self._main_widget, name, value)
+        else:
+            super().__setattr__(name, value)
 
 
 class _EmbedAdapter:

--- a/src/tools/pose_studio/widgets/view_3d.py
+++ b/src/tools/pose_studio/widgets/view_3d.py
@@ -155,8 +155,7 @@ class View3D(QtWidgets.QWidget):
             try:
                 self._service.set_pose(pose) if pose else None
                 transforms = self._service.get_link_transforms()
-                self._render_from_transforms(transforms)
-                self._canvas.draw_idle()
+                self.update_from_service_transforms(transforms)
                 return
             except (NotImplementedError, RuntimeError, ValueError) as exc:
                 # Fall back to canonical forward kinematics if service fails.

--- a/tests/shared_contracts/test_tools_vendoring.py
+++ b/tests/shared_contracts/test_tools_vendoring.py
@@ -77,18 +77,30 @@ def _configure_tools_mode(
     root_conftest = _load_root_conftest()
     local_path = _local_tools_path()
     vendored_path = _vendored_tools_path()
+    vendored_root = _repo_root() / "vendor/ud-tools"
+    vendored_parent_paths = {
+        str((vendored_root / "src").resolve()),
+        str((vendored_root / "src/python/src").resolve()),
+    }
     real_exists = root_conftest.os.path.exists
 
     def _fake_exists(path: object) -> bool:
-        return str(path) in {local_path, vendored_path} or real_exists(path)
+        controlled_paths = {local_path, vendored_path, *vendored_parent_paths}
+        return str(path) in controlled_paths or real_exists(path)
 
+    monkeypatch.delenv("TOOLS_REPO_PATH", raising=False)
     monkeypatch.setattr(root_conftest.os.path, "exists", _fake_exists)
     if alias_contracts:
-        canonical_module = ModuleType("src.shared.python.contracts")
+        canonical_name = (
+            "shared.python.contracts"
+            if mode == "vendored"
+            else "src.shared.python.contracts"
+        )
+        canonical_module = ModuleType(canonical_name)
         real_import_module = importlib.import_module
 
         def _fake_import_module(name: str, package: str | None = None) -> ModuleType:
-            if name == "src.shared.python.contracts":
+            if name == canonical_name:
                 sys.modules[name] = canonical_module
                 return canonical_module
             return real_import_module(name, package)

--- a/tests/unit/tools/pose_studio/test_gui.py
+++ b/tests/unit/tools/pose_studio/test_gui.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from src.tools.pose_studio.gui import PoseStudioWindow, main
+from src.tools.pose_studio.gui import MainWidget, PoseStudioWindow, _EmbedAdapter, main
 from src.tools.pose_studio.core import EngineStatus
 from src.shared.python.pose_interchange.canonical import (
     canonical_zero_pose,
@@ -19,9 +19,26 @@ def test_gui_initialization(mock_qapp) -> None:
     # Test fallback to "drake" if unknown engine is provided
     win = PoseStudioWindow(initial_engine="unknown_engine")
     assert win is not None
+    assert win.main_widget is not None
+    assert win.main_widget._engine_controller.engine_name == "drake"
     assert win._engine_controller.engine_name == "drake"
+    assert win.act_undo is not None
+    assert win.act_redo is not None
 
-    # Check that it doesn't crash on applying initial pose
+
+@patch("src.tools.pose_studio.gui.QtWidgets.QApplication")
+def test_embed_adapter_create_and_edit_pose(mock_qapp) -> None:
+    adapter = _EmbedAdapter()
+    widget = adapter.create_main_widget(parent=None)
+    assert isinstance(widget, MainWidget)
+    assert widget.act_undo is not None
+    assert widget.act_redo is not None
+
+    # Test editing an angle without crash
+    joint = REFERENCE_GOLFER_FIELDS[0]
+    widget._on_angle_edited(joint, 30.0)
+    assert widget._engine_controller.pose.joint_angles_deg[joint] == 30.0
+    assert widget.act_undo.isEnabled()
 
 
 @patch("src.tools.pose_studio.gui.QtWidgets.QApplication")

--- a/tests/unit/tools/pose_studio/test_gui.py
+++ b/tests/unit/tools/pose_studio/test_gui.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.ui]
 
 from src.tools.pose_studio.gui import MainWidget, PoseStudioWindow, _EmbedAdapter, main
 from src.tools.pose_studio.core import EngineStatus


### PR DESCRIPTION
Closes #8879. Initializes undo/redo QActions on MainWidget and attaches them to widget for embedded use, guards _refresh_undo_redo_actions, and adds tests for standalone and embedded workflows.