### PR TITLE
fix(theme): export Colors, Sizes, Weights, and font getters from theme package (#8894)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4360,5 +4360,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - Vectorized batch swing optimizer effort sum-of-squares computation across environments via `np.einsum("nij,nij->n", controls, controls)` in `src/shared/python/optimization/batch_swing_optimizer.py` (#8958). (spec-exempt: micro-optimization)
 
 - (spec-exempt: micro-optimization) Replaced `np.sum(condition)` and `np.sum(np.isnan(arr))` with `np.count_nonzero` in python analytics and motion matching codebase for faster array evaluation.
-
 - Starting pose matcher: `on_clear_overrides_clicked` prompts for confirmation and unconditionally restores original mocap events state on confirm (#8889).
+- Theme package: export Colors, Sizes, Weights, and font getters from theme package root for clean imports (#8894).

--- a/src/shared/python/theme/__init__.py
+++ b/src/shared/python/theme/__init__.py
@@ -67,6 +67,7 @@ try:
         create_theme_menu,
         setup_themed_app,
     )
+    from .palette import Colors, ThemePalette, get_current_colors
     from .responsive import (
         TextWidthSpec,
         configure_form_layout_for_readability,
@@ -76,6 +77,13 @@ try:
         wrap_in_scroll_area,
     )
     from .theme_manager import ThemeManager, get_theme_manager
+    from .typography import (
+        Sizes,
+        Weights,
+        get_display_font,
+        get_mono_font,
+        get_qfont,
+    )
     from .zoom import (
         ApplicationZoomController,
         ZoomConfig,
@@ -114,6 +122,14 @@ except ImportError:
     ZoomTokenSet = None  # type: ignore[assignment, misc]
     install_application_zoom = None  # type: ignore[assignment]
     scale_px = None  # type: ignore[assignment]
+    Colors = None  # type: ignore[assignment, misc]
+    Sizes = None  # type: ignore[assignment, misc]
+    Weights = None  # type: ignore[assignment, misc]
+    get_qfont = None  # type: ignore[assignment]
+    get_display_font = None  # type: ignore[assignment]
+    get_mono_font = None  # type: ignore[assignment]
+    ThemePalette = None  # type: ignore[assignment, misc]
+    get_current_colors = None  # type: ignore[assignment]
 
 __all__ = [
     # Protocols (no PyQt6 dependency)
@@ -151,13 +167,21 @@ __all__ = [
     "ThemeListItem",
     "ThemeManagerDialog",
     "ThemePreviewWidget",
-    # Color utilities
+    # Color utilities & tokens
     "BUILTIN_THEMES",
     "CHART_COLORS",
+    "Colors",
     "SEMANTIC_COLOR_KEYS",
+    "Sizes",
     "THEME_COLOR_KEYS",
+    "ThemePalette",
+    "Weights",
+    "get_current_colors",
+    "get_display_font",
     "get_matplotlib_colors",
+    "get_mono_font",
     "get_qcolor",
+    "get_qfont",
     "get_rgba",
     "is_dark_theme",
     "is_valid_hex_color",

--- a/src/shared/python/theme/palette.py
+++ b/src/shared/python/theme/palette.py
@@ -56,7 +56,61 @@ class ThemePalette(dict):
         )
 
 
-__all__ = ["SEMANTIC_ALIASES", "ThemePalette"]
+class _ColorsMeta(type):
+    """Metaclass allowing Colors.TOKEN access to resolve dynamically from active theme."""
+
+    def __getattr__(cls, name: str) -> str:
+        colors = get_current_colors()
+        lower_name = name.lower()
+        if hasattr(colors, lower_name):
+            val = getattr(colors, lower_name)
+            if isinstance(val, str):
+                return val
+        if lower_name in colors:
+            return str(colors[lower_name])
+        fallbacks: dict[str, str] = {
+            "success": "#30D158",
+            "error": "#FF375F",
+            "warning": "#FF9F0A",
+            "info": "#0A84FF",
+            "primary": colors.get("accent", "#0A84FF"),
+            "primary_hover": colors.get("button_hover", "#409CFF"),
+            "bg_elevated": colors.get("group_bg", "#252526"),
+            "bg_base": colors.get("bg", "#1e1e1e"),
+            "border_default": colors.get("border", "#333333"),
+            "text_primary": colors.get("text", "#ffffff"),
+            "text_secondary": colors.get("text_secondary", "#aaaaaa"),
+            "text_tertiary": colors.get("label", "#888888"),
+        }
+        if lower_name in fallbacks:
+            return fallbacks[lower_name]
+        raise AttributeError(f"Colors has no color attribute {name!r}")
+
+
+class Colors(metaclass=_ColorsMeta):
+    """Semantic color token accessor resolving dynamically from active theme."""
+
+    SUCCESS: str = "#30D158"
+    ERROR: str = "#FF375F"
+    WARNING: str = "#FF9F0A"
+    INFO: str = "#0A84FF"
+    PRIMARY: str = "#0A84FF"
+    PRIMARY_HOVER: str = "#409CFF"
+    BG_ELEVATED: str = "#252526"
+    BG_BASE: str = "#1e1e1e"
+    BORDER_DEFAULT: str = "#333333"
+    TEXT_PRIMARY: str = "#ffffff"
+    TEXT_SECONDARY: str = "#aaaaaa"
+    TEXT_TERTIARY: str = "#888888"
+
+
+__all__ = [
+    "Colors",
+    "DARK_THEME",
+    "SEMANTIC_ALIASES",
+    "ThemePalette",
+    "get_current_colors",
+]
 
 
 def _builtin_dark_palette() -> ThemePalette:

--- a/tests/unit/shared/theme/test_shared_theme_exports.py
+++ b/tests/unit/shared/theme/test_shared_theme_exports.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_theme_package_exports() -> None:
+    from src.shared.python import theme
+
+    assert hasattr(theme, "Colors")
+    assert hasattr(theme, "Sizes")
+    assert hasattr(theme, "Weights")
+    assert hasattr(theme, "get_qfont")
+    assert hasattr(theme, "get_display_font")
+    assert hasattr(theme, "get_mono_font")
+    assert hasattr(theme, "ThemePalette")
+    assert hasattr(theme, "get_current_colors")
+
+    assert "Colors" in theme.__all__
+    assert "Sizes" in theme.__all__
+    assert "Weights" in theme.__all__
+    assert "get_qfont" in theme.__all__
+
+
+@pytest.mark.unit
+def test_colors_dynamic_tokens() -> None:
+    from src.shared.python.theme import Colors
+
+    assert isinstance(Colors.SUCCESS, str) and Colors.SUCCESS.startswith("#")
+    assert isinstance(Colors.ERROR, str) and Colors.ERROR.startswith("#")
+    assert isinstance(Colors.WARNING, str) and Colors.WARNING.startswith("#")
+    assert isinstance(Colors.INFO, str) and Colors.INFO.startswith("#")
+    assert isinstance(Colors.BG_ELEVATED, str) and Colors.BG_ELEVATED.startswith("#")
+    assert isinstance(Colors.BG_BASE, str) and Colors.BG_BASE.startswith("#")
+    assert isinstance(Colors.PRIMARY, str) and Colors.PRIMARY.startswith("#")
+    assert isinstance(Colors.PRIMARY_HOVER, str) and Colors.PRIMARY_HOVER.startswith(
+        "#"
+    )
+    assert isinstance(Colors.TEXT_PRIMARY, str) and Colors.TEXT_PRIMARY.startswith("#")
+    assert isinstance(Colors.TEXT_SECONDARY, str) and Colors.TEXT_SECONDARY.startswith(
+        "#"
+    )
+    assert isinstance(Colors.TEXT_TERTIARY, str) and Colors.TEXT_TERTIARY.startswith(
+        "#"
+    )
+
+
+@pytest.mark.unit
+def test_widgets_theme_available() -> None:
+    from src.shared.python.ui import (
+        loading_button,
+        preferences_dialog,
+        recent_models,
+        shortcuts_overlay,
+        toast,
+    )
+
+    assert toast.THEME_AVAILABLE, "toast.THEME_AVAILABLE must be True"
+    assert shortcuts_overlay.THEME_AVAILABLE, (
+        "shortcuts_overlay.THEME_AVAILABLE must be True"
+    )
+    assert recent_models.THEME_AVAILABLE, "recent_models.THEME_AVAILABLE must be True"
+    assert preferences_dialog.THEME_AVAILABLE, (
+        "preferences_dialog.THEME_AVAILABLE must be True"
+    )
+    assert loading_button.THEME_AVAILABLE, "loading_button.THEME_AVAILABLE must be True"


### PR DESCRIPTION
Closes #8894. Re-exports Colors, Sizes, Weights, get_qfont, get_display_font, and get_mono_font from theme package so shared widgets enable THEME_AVAILABLE instead of silent fallbacks.