### PR TITLE
fix(starting_pose_matcher): confirm and unconditionally restore events on clear overrides (#8889)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4360,3 +4360,5 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - Vectorized batch swing optimizer effort sum-of-squares computation across environments via `np.einsum("nij,nij->n", controls, controls)` in `src/shared/python/optimization/batch_swing_optimizer.py` (#8958). (spec-exempt: micro-optimization)
 
 - (spec-exempt: micro-optimization) Replaced `np.sum(condition)` and `np.sum(np.isnan(arr))` with `np.count_nonzero` in python analytics and motion matching codebase for faster array evaluation.
+
+- Starting pose matcher: `on_clear_overrides_clicked` prompts for confirmation and unconditionally restores original mocap events state on confirm (#8889).

--- a/src/tools/starting_pose_matcher/gui_main_widget.py
+++ b/src/tools/starting_pose_matcher/gui_main_widget.py
@@ -21,6 +21,7 @@ under the 1200-line budget enforced by
 
 from __future__ import annotations
 
+import copy
 import logging
 from pathlib import Path
 from typing import Any
@@ -118,6 +119,7 @@ class MainWidget(_RenderMixin, _BuildersMixin, _SessionMixin, QWidget):
         # Data
         self.df: pd.DataFrame | None = None
         self.events = MocapEvents()
+        self._events_original = copy.deepcopy(self.events)
         self._xlsx_path: str | None = None
 
         here = Path(__file__).parent
@@ -782,11 +784,27 @@ class MainWidget(_RenderMixin, _BuildersMixin, _SessionMixin, QWidget):
     def _clear_event_overrides(self) -> None:
         if not self.event_overrides:
             return
-        # Re-read events from the xlsx to undo overrides
-        if self._xlsx_path:
+        count = len(self.event_overrides)
+        reply = QMessageBox.question(
+            self,
+            "Clear Event Overrides",
+            f"Discard {count} manual event override{'s' if count != 1 else ''}?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+        # Unconditionally restore original events snapshot
+        if hasattr(self, "_events_original") and self._events_original is not None:
+            self.events = copy.deepcopy(self._events_original)
+        elif self._xlsx_path:
             self.events = read_event_header(
                 self._xlsx_path, self.sheet_combo.currentText()
             )
+            self._events_original = copy.deepcopy(self.events)
+        else:
+            self.events = MocapEvents()
+            self._events_original = copy.deepcopy(self.events)
         self.event_overrides = {}
         self.lbl_event_info.setText(self._events_summary())
         self._redraw()
@@ -955,6 +973,7 @@ class MainWidget(_RenderMixin, _BuildersMixin, _SessionMixin, QWidget):
         self.df = df
         self._xlsx_path = path
         self.events = read_event_header(path, sheet)
+        self._events_original = copy.deepcopy(self.events)
         # Re-apply any event-override that survived from the previous load
         for ev, sample in list(self.event_overrides.items()):
             setattr(self.events, f"{ev}_sample", float(sample))

--- a/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
+++ b/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
@@ -45,9 +45,12 @@ def test_clear_overrides_without_xlsx_restores_original_state_when_confirmed(
     """Issue #8889: Clear overrides without xlsx path must restore original events and ask confirmation."""
     widget = MainWidget()
     widget.df = pd.DataFrame(
-        {"time": [0.0, 0.01, 0.02, 0.03], "club_X": [0.1, 0.2, 0.3, 0.4]}
+        {"time": [0.0, 0.01, 0.02, 0.03, 0.04], "club_X": [0.1, 0.2, 0.3, 0.4, 0.5]}
     )
     widget._xlsx_path = None
+    original_events = MocapEvents(A_sample=1.0, T_sample=2.0, I_sample=3.0, F_sample=4.0)
+    widget._events_original = original_events
+    widget.events = MocapEvents(A_sample=1.0, T_sample=2.0, I_sample=3.0, F_sample=4.0)
     original_t_sample = widget.events.T_sample
     assert widget._events_original.T_sample == original_t_sample
 

--- a/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
+++ b/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
@@ -48,7 +48,9 @@ def test_clear_overrides_without_xlsx_restores_original_state_when_confirmed(
         {"time": [0.0, 0.01, 0.02, 0.03, 0.04], "club_X": [0.1, 0.2, 0.3, 0.4, 0.5]}
     )
     widget._xlsx_path = None
-    original_events = MocapEvents(A_sample=1.0, T_sample=2.0, I_sample=3.0, F_sample=4.0)
+    original_events = MocapEvents(
+        A_sample=1.0, T_sample=2.0, I_sample=3.0, F_sample=4.0
+    )
     widget._events_original = original_events
     widget.events = MocapEvents(A_sample=1.0, T_sample=2.0, I_sample=3.0, F_sample=4.0)
     original_t_sample = widget.events.T_sample

--- a/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
+++ b/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
@@ -45,7 +45,15 @@ def test_clear_overrides_without_xlsx_restores_original_state_when_confirmed(
     """Issue #8889: Clear overrides without xlsx path must restore original events and ask confirmation."""
     widget = MainWidget()
     widget.df = pd.DataFrame(
-        {"time": [0.0, 0.01, 0.02, 0.03, 0.04], "club_X": [0.1, 0.2, 0.3, 0.4, 0.5]}
+        {
+            "time": [0.0, 0.01, 0.02, 0.03, 0.04],
+            "mid_X": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "mid_Y": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "mid_Z": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "club_X": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "club_Y": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "club_Z": [0.0, 0.0, 0.0, 0.0, 0.0],
+        }
     )
     widget._xlsx_path = None
     original_events = MocapEvents(

--- a/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
+++ b/tests/unit/tools/starting_pose_matcher/test_clear_overrides_state.py
@@ -1,0 +1,86 @@
+"""Unit tests for Starting Pose Matcher 'Clear overrides' state restoration and confirmation (#8889)."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pandas as pd
+import pytest
+
+if "PySide6" in sys.modules:
+    pytest.skip(
+        "PySide6 already loaded — PyQt6 DLLs unavailable", allow_module_level=True
+    )
+
+try:
+    from PyQt6.QtWidgets import QApplication, QMessageBox
+
+    _HAVE_QT = True
+except Exception:
+    _HAVE_QT = False
+
+if not _HAVE_QT:
+    pytest.skip("PyQt6.QtWidgets unavailable", allow_module_level=True)
+
+from src.tools.starting_pose_matcher.core import MocapEvents
+from src.tools.starting_pose_matcher.gui_main_widget import MainWidget
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv[:1])
+    return app
+
+
+def test_clear_overrides_without_xlsx_restores_original_state_when_confirmed(
+    qapp, monkeypatch
+) -> None:
+    """Issue #8889: Clear overrides without xlsx path must restore original events and ask confirmation."""
+    widget = MainWidget()
+    widget.df = pd.DataFrame(
+        {"time": [0.0, 0.01, 0.02, 0.03], "club_X": [0.1, 0.2, 0.3, 0.4]}
+    )
+    widget._xlsx_path = None
+    original_t_sample = widget.events.T_sample
+    assert widget._events_original.T_sample == original_t_sample
+
+    # Manually set override for T
+    widget.current_frame = 2
+    widget.combo_set_event.setCurrentText("T - Top of Backswing")
+    widget._set_event_to_current_frame()
+
+    assert widget.event_overrides.get("T") == 3
+    assert widget.events.T_sample == 3.0
+
+    # User cancels dialog -> overrides must remain
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *args, **kwargs: QMessageBox.StandardButton.No,
+    )
+    widget._clear_event_overrides()
+    assert widget.event_overrides.get("T") == 3
+    assert widget.events.T_sample == 3.0
+
+    # User confirms dialog -> overrides cleared and original state restored
+    dialog_called = []
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *args, **kwargs: (
+            dialog_called.append(args) or QMessageBox.StandardButton.Yes
+        ),
+    )
+    widget._clear_event_overrides()
+
+    assert len(dialog_called) == 1
+    assert widget.event_overrides == {}
+    assert widget.events.T_sample == original_t_sample
+    assert widget.events.T_sample == widget._events_original.T_sample


### PR DESCRIPTION
Closes #8889. Adds confirmation dialog before clearing event overrides, snapshots pristine events at initialization and data load time, and restores original events unconditionally regardless of whether an xlsx path is configured.