### PR TITLE
fix(model_explorer): propagate load_model boolean success status to caller slots (#9041)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4377,3 +4377,4 @@ Per Issue #3474, 3D vector operations must use `math.hypot` instead of `np.linal
 - Starting pose matcher: `on_clear_overrides_clicked` prompts for confirmation and unconditionally restores original mocap events state on confirm (#8889).
 - Pose studio actions: initialize undo/redo QActions on MainWidget and guard action refresh against uninitialized state (#8879).
 - GUI exception handling: catch and log unexpected slot exceptions in terrain engine and model explorer GUI tools (#8890).
+- Model Explorer: propagate load_model boolean success status to caller slots and guard status bar updates against failed loads (#9041).

--- a/src/tools/model_explorer/gui.py
+++ b/src/tools/model_explorer/gui.py
@@ -222,19 +222,9 @@ class MainWidget(QWidget):
         )
 
         if file_path:
-            try:
-                self._load_urdf_file(Path(file_path))
+            if self.load_model(file_path):
                 self.status_bar.showMessage(f"Opened: {file_path}")
                 logger.info(f"URDF opened from: {file_path}")
-            except (
-                FileNotFoundError,
-                OSError,
-                RuntimeError,
-                TypeError,
-                ValueError,
-            ) as e:
-                logger.error(f"Error opening URDF: {e}")
-                QMessageBox.critical(self, "Error", f"Failed to open URDF: {e}")
 
     def load_from_library(self) -> None:  # noqa: C901
         """Load a URDF model from the bundled library."""
@@ -254,14 +244,15 @@ class MainWidget(QWidget):
 
                 if category == "golf_clubs":
                     urdf_path = library.generate_golf_club_urdf(model_key)
-                    if urdf_path:
-                        self._load_urdf_file(urdf_path)
+                    if urdf_path and self.load_model(urdf_path):
                         self.status_bar.showMessage(f"Loaded golf club: {model_key}")
                 elif category == "human":
                     urdf_path = library.get_human_model(model_key)
                     if urdf_path and urdf_path.exists():
-                        self._load_urdf_file(urdf_path)
-                        self.status_bar.showMessage(f"Loaded human model: {model_key}")
+                        if self.load_model(urdf_path):
+                            self.status_bar.showMessage(
+                                f"Loaded human model: {model_key}"
+                            )
                     else:
                         QMessageBox.information(
                             self,
@@ -288,10 +279,10 @@ class MainWidget(QWidget):
 
                             path = _project_root / raw_path
                         if path.exists():
-                            self._load_urdf_file(path)
-                            self.status_bar.showMessage(
-                                f"Loaded {category} model: {model_info['name']}"
-                            )
+                            if self.load_model(path):
+                                self.status_bar.showMessage(
+                                    f"Loaded {category} model: {model_info['name']}"
+                                )
                         else:
                             QMessageBox.warning(
                                 self, "Error", f"File not found: {path}"
@@ -319,19 +310,28 @@ class MainWidget(QWidget):
     def _on_library_model_selected(self, category: str, model_key: str) -> None:
         logger.info(f"Model selected from library: {category}/{model_key}")
 
-    def _load_urdf_file(self, file_path: Path) -> None:
-        """Load URDF file content and refresh the viewport."""
+    def load_model(self, file_path: str | Path) -> bool:
+        """Load URDF or OSIM model file content and refresh the viewport.
+
+        Args:
+            file_path: Path to the model file to load.
+
+        Returns:
+            True if model loading and rendering succeed, False otherwise.
+        """
+        path = Path(file_path)
         try:
-            if file_path.suffix.lower() == ".osim":
+            if path.suffix.lower() == ".osim":
                 from .osim_loader import OsimLoader
 
-                urdf_content = OsimLoader().to_urdf(file_path)
+                urdf_content = OsimLoader().to_urdf(path)
             else:
-                urdf_content = file_path.read_text(encoding="utf-8")
-            self.visualization_widget.update_visualization(urdf_content, str(file_path))
-            self.current_file_path = file_path
+                urdf_content = path.read_text(encoding="utf-8")
+            self.visualization_widget.update_visualization(urdf_content, str(path))
+            self.current_file_path = path
             self._update_window_title()
-            logger.info(f"URDF loaded: {file_path}")
+            logger.info(f"URDF loaded: {path}")
+            return True
         except (RuntimeError, TypeError, ValueError, OSError) as e:
             logger.exception("Error loading URDF file: %s", e)
             from PyQt6.QtWidgets import QMessageBox
@@ -339,8 +339,13 @@ class MainWidget(QWidget):
             QMessageBox.warning(
                 self,
                 "Model Load Error",
-                f"Failed to load model file '{file_path.name}':\n\n{e}",
+                f"Failed to load model file '{path.name}':\n\n{e}",
             )
+            return False
+
+    def _load_urdf_file(self, file_path: str | Path) -> bool:
+        """Backwards-compatible alias for load_model."""
+        return self.load_model(file_path)
 
     def save_urdf(self) -> None:
         if self.current_file_path:
@@ -490,10 +495,10 @@ class MainWidget(QWidget):
                 library = ModelLibrary()
                 urdf_path = library.get_human_model(str(default_model))
                 if urdf_path and urdf_path.exists():
-                    self._load_urdf_file(urdf_path)
-                    self.status_bar.showMessage(
-                        f"Loaded default model: {default_model}"
-                    )
+                    if self.load_model(urdf_path):
+                        self.status_bar.showMessage(
+                            f"Loaded default model: {default_model}"
+                        )
                 else:
                     logger.warning(f"Default model {default_model} not found")
         except ImportError as e:

--- a/src/tools/model_explorer/main_window.py
+++ b/src/tools/model_explorer/main_window.py
@@ -126,6 +126,12 @@ class URDFGeneratorWindow(QMainWindow):
     def load_from_library(self) -> None:
         self._main_widget.load_from_library()
 
+    def load_model(self, file_path: str | Path) -> bool:
+        return self._main_widget.load_model(file_path)
+
+    def _load_urdf_file(self, file_path: str | Path) -> bool:
+        return self._main_widget.load_model(file_path)
+
     def save_urdf(self) -> None:
         self._main_widget.save_urdf()
 

--- a/tests/tools/test_model_explorer_gui.py
+++ b/tests/tools/test_model_explorer_gui.py
@@ -1,0 +1,260 @@
+"""Unit tests for Model Explorer GUI model loading and error propagation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication, QMessageBox
+import pytest
+
+from src.tools.model_explorer.gui import MainWidget
+from src.tools.model_explorer.main_window import URDFGeneratorWindow
+
+pytestmark = [pytest.mark.unit, pytest.mark.ui]
+
+_APP: QApplication | None = None
+
+
+def _ensure_qapp() -> QApplication:
+    global _APP
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv[:1])
+    _APP = app
+    return app
+
+
+MINIMAL_VALID_URDF = """<?xml version="1.0"?>
+<robot name="test_robot">
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
+</robot>
+"""
+
+CORRUPTED_BINARY_DATA = b"\x80\xff\xfe\x00\x01\x02\x03\x04\xff\xff"
+CORRUPTED_OSIM_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
+<OpenSimDocument Version="40000">
+  <InvalidTag>
+"""
+
+
+@pytest.fixture
+def valid_urdf_file(tmp_path: Path) -> Path:
+    file = tmp_path / "valid_model.urdf"
+    file.write_text(MINIMAL_VALID_URDF, encoding="utf-8")
+    return file
+
+
+@pytest.fixture
+def corrupted_binary_file(tmp_path: Path) -> Path:
+    file = tmp_path / "corrupted_model.urdf"
+    file.write_bytes(CORRUPTED_BINARY_DATA)
+    return file
+
+
+@pytest.fixture
+def corrupted_osim_file(tmp_path: Path) -> Path:
+    file = tmp_path / "corrupted_model.osim"
+    file.write_text(CORRUPTED_OSIM_CONTENT, encoding="utf-8")
+    return file
+
+
+def test_load_model_success_with_valid_urdf(valid_urdf_file: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    success = widget.load_model(valid_urdf_file)
+
+    assert success is True
+    assert widget.current_file_path == valid_urdf_file
+
+
+def test_load_model_accepts_str_and_path(valid_urdf_file: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    assert widget.load_model(str(valid_urdf_file)) is True
+    assert widget.current_file_path == valid_urdf_file
+
+
+def test_load_model_returns_false_on_missing_file(tmp_path: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+    missing_file = tmp_path / "does_not_exist.urdf"
+
+    with patch.object(QMessageBox, "warning") as mock_warning:
+        success = widget.load_model(missing_file)
+
+    assert success is False
+    assert widget.current_file_path is None
+    mock_warning.assert_called_once()
+
+
+def test_load_model_returns_false_and_preserves_state_on_corrupted_binary_file(
+    valid_urdf_file: Path,
+    corrupted_binary_file: Path,
+) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    # Load valid model first to establish prior state
+    assert widget.load_model(valid_urdf_file) is True
+    assert widget.current_file_path == valid_urdf_file
+
+    with patch.object(QMessageBox, "warning") as mock_warning:
+        # Load corrupted file should fail without raising
+        success = widget.load_model(corrupted_binary_file)
+
+    # State preserved: current_file_path should still be valid_urdf_file
+    assert success is False
+    assert widget.current_file_path == valid_urdf_file
+    mock_warning.assert_called_once()
+
+
+def test_load_model_returns_false_and_preserves_state_on_corrupted_osim_file(
+    valid_urdf_file: Path,
+    corrupted_osim_file: Path,
+) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    # Load valid model first to establish prior state
+    assert widget.load_model(valid_urdf_file) is True
+    assert widget.current_file_path == valid_urdf_file
+
+    with patch.object(QMessageBox, "warning") as mock_warning:
+        # Load corrupted osim file should fail without raising
+        success = widget.load_model(corrupted_osim_file)
+
+    # State preserved: current_file_path should still be valid_urdf_file
+    assert success is False
+    assert widget.current_file_path == valid_urdf_file
+    mock_warning.assert_called_once()
+
+
+def test_load_model_returns_false_when_visualization_fails(
+    valid_urdf_file: Path,
+) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    with (
+        patch.object(
+            widget.visualization_widget,
+            "update_visualization",
+            side_effect=RuntimeError("OpenGL shader error"),
+        ),
+        patch.object(QMessageBox, "warning") as mock_warning,
+    ):
+        success = widget.load_model(valid_urdf_file)
+
+    assert success is False
+    assert widget.current_file_path is None
+    mock_warning.assert_called_once()
+
+
+def test_open_urdf_updates_status_bar_on_success(valid_urdf_file: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    with patch(
+        "PyQt6.QtWidgets.QFileDialog.getOpenFileName",
+        return_value=(str(valid_urdf_file), "URDF Files (*.urdf)"),
+    ):
+        widget.open_urdf()
+
+    assert widget.status_bar.currentMessage() == f"Opened: {valid_urdf_file}"
+    assert widget.current_file_path == valid_urdf_file
+
+
+def test_open_urdf_does_not_overwrite_status_bar_on_failure(tmp_path: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+    widget.status_bar.showMessage("Initial Status")
+    missing_file = tmp_path / "nonexistent.urdf"
+
+    with (
+        patch(
+            "PyQt6.QtWidgets.QFileDialog.getOpenFileName",
+            return_value=(str(missing_file), "URDF Files (*.urdf)"),
+        ),
+        patch.object(QMessageBox, "warning"),
+    ):
+        widget.open_urdf()
+
+    # Status bar should retain previous message and not show "Opened: ..."
+    assert widget.status_bar.currentMessage() == "Initial Status"
+    assert widget.current_file_path is None
+
+
+def test_load_from_library_does_not_overwrite_status_bar_on_load_failure() -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+    widget.status_bar.showMessage("Ready")
+
+    mock_dialog = MagicMock()
+    mock_dialog.exec.return_value = True
+    mock_dialog.get_selected_model.return_value = ("golf_clubs", "custom_driver")
+
+    with (
+        patch(
+            "src.tools.model_explorer.model_loader_dialog.ModelLoaderDialog",
+            return_value=mock_dialog,
+        ),
+        patch(
+            "src.tools.model_explorer.model_library.ModelLibrary.generate_golf_club_urdf",
+            return_value=Path("/invalid/path/club.urdf"),
+        ),
+        patch.object(widget, "load_model", return_value=False),
+        patch.object(QMessageBox, "warning"),
+    ):
+        widget.load_from_library()
+
+    assert widget.status_bar.currentMessage() == "Ready"
+
+
+def test_load_default_model_guards_status_bar_on_load_failure() -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+    widget.status_bar.showMessage("Ready")
+
+    with (
+        patch(
+            "src.tools.model_explorer.model_library.ModelLibrary.get_human_model",
+            return_value=Path("/invalid/model.urdf"),
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+        patch.object(widget, "load_model", return_value=False),
+    ):
+        widget.load_default_model()
+
+    assert widget.status_bar.currentMessage() == "Ready"
+
+
+def test_urdf_generator_window_delegates_load_model(valid_urdf_file: Path) -> None:
+    _ensure_qapp()
+    window = URDFGeneratorWindow()
+
+    assert window.load_model(valid_urdf_file) is True
+    assert window.current_file_path == valid_urdf_file
+
+    with patch.object(QMessageBox, "warning"):
+        assert window.load_model(Path("/invalid/file.urdf")) is False
+
+
+def test_load_urdf_file_backward_compatibility_alias(valid_urdf_file: Path) -> None:
+    _ensure_qapp()
+    widget = MainWidget()
+
+    assert widget._load_urdf_file(valid_urdf_file) is True
+    assert widget.current_file_path == valid_urdf_file


### PR DESCRIPTION
## Summary
- Update `load_model(self, file_path: str | Path) -> bool` on `MainWidget` to return `True` on success and `False` when model loading/rendering encounters exceptions.
- Guard status bar updates in callers (`open_urdf()`, `load_from_library()`, `load_default_model()`) to only report success when `load_model()` returns `True`.
- Add `load_model()` and `_load_urdf_file()` delegations on `URDFGeneratorWindow` for seamless API compatibility.
- Add comprehensive unit test suite in `tests/tools/test_model_explorer_gui.py` covering model loading success, failure modes (missing files, corrupted binary/osim files, visualization errors), status bar preservation, and delegation.
- Update `SPEC.md` changelog.

Resolves #9041, #9040, #9038, #9034, #9021, #9020.