### PR TITLE
fix(spec): collapse the duplicated Identity rows an earlier merge left

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -871,11 +871,8 @@ inventory and reopen adjudication until every new candidate is reviewed.
 | **Primary Language(s)** | Python 3.11+, Rust, TypeScript                     |
 | **License**             | MIT                                                |
 | **Current Version**     | 2.1.1                                              |
-| **Spec Version**        | 1.0.624                                            |
+| **Spec Version**        | 1.0.629                                            |
 | **Last Spec Update**    | 2026-08-28                                         |
-| **Spec Version**        | 1.0.626                                            |
-| **Last Spec Update**    | 2026-08-28                                         |
-| **Last Spec Update**    | 2026-08-27                                         |
 
 ## 2. Purpose & Mission
 


### PR DESCRIPTION
`SPEC.md`'s Identity table on `main` carries **two** `Spec Version` rows and **three** `Last Spec Update` rows:

```
| **Spec Version**     | 1.0.624    |
| **Last Spec Update** | 2026-08-28 |
| **Spec Version**     | 1.0.626    |   <- duplicate
| **Last Spec Update** | 2026-08-28 |   <- duplicate
| **Last Spec Update** | 2026-08-27 |   <- orphaned third
```

That is the residue of a union-style resolution of a hot-prepend conflict — both sides' rows kept where only one belongs. **None of the surviving values matches the newest changelog entry (1.0.629)**, so the field that states the spec's version disagrees with the spec.

## Why this is not cosmetic

It is self-propagating. Every branch that merges `main` inherits the duplicates, and each subsequent `SPEC.md` conflict unions them again. Two concurrent BunkerShot3D branches were observed carrying **six and seven** rows, and both had to repair the same damage locally before they could land. Left alone the count grows monotonically and re-breaks the next merge.

## The fix

Collapsed to a single pair, derived from the newest changelog row (1.0.629, dated 2026-08-28) rather than from whichever duplicate happened to survive — so the table is sourced from the log instead of guessed.

```
| **Spec Version**        | 1.0.629    |
| **Last Spec Update**    | 2026-08-28 |
```

Verified after the edit: exactly one `Spec Version` row and one `Last Spec Update` row remain, and both agree with the newest changelog entry. Prettier-formatted. One file, +1/−4.

Found while merging two stacked PRs (#9181, #9184) against `main`.