### PR TITLE
chore(companion): govern provider workflows (#9190)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -1137,6 +1137,41 @@ jobs:
             --source-revision "$(git rev-parse HEAD)" \
             --publication-profile computational
 
+  # Governed companion workflows execute on every code PR and protected-main
+  # push. The job emits exact-commit evidence but does not publish or qualify it.
+  companion-workflows:
+    name: companion-workflows
+    needs: [pick-runner, changed-paths]
+    if: needs.changed-paths.outputs.code == 'true'
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.11"
+      - name: Install governed companion workflow dependencies
+        run: >-
+          python3 -m pip install
+          jsonschema==4.26.0 pyyaml==6.0.3 numpy==2.2.6 scipy==1.15.3
+          pandas==3.0.2 matplotlib==3.10.9 simpleeval==1.0.7
+          pydantic==2.12.5
+      - name: Execute governed companion workflow authority
+        run: >-
+          python3 -m scripts.companion_workflows
+          --repo-root . execute-all
+          --report dist/companion-workflows/execution-report.v1.json
+      - name: Upload exact-revision companion workflow evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: upstreamdrift-companion-workflows-${{ github.sha }}
+          path: dist/companion-workflows/
+          if-no-files-found: error
+          retention-days: 30
+
   # Required branch-protection check (issue #7064). The name `quality-gate` is
   # preserved exactly so the org ruleset `Repository_Protections` and the bot
   # workflows (Jules-Auto-Repair, Jules-PR-AutoFix, Bot-CI-Trigger) keep
@@ -1156,6 +1191,7 @@ jobs:
         pick-runner,
         changed-paths,
         code-quality,
+        companion-workflows,
         security-scans,
         repo-structure-gates,
         tests,
@@ -1187,6 +1223,7 @@ jobs:
           CODE_CHANGED: ${{ needs.changed-paths.outputs.code }}
           PUBLICATION_CHANGED: ${{ needs.changed-paths.outputs.publication }}
           CODE_QUALITY: ${{ needs.code-quality.result }}
+          COMPANION_WORKFLOWS: ${{ needs.companion-workflows.result }}
           SECURITY_SCANS: ${{ needs.security-scans.result }}
           REPO_STRUCTURE_GATES: ${{ needs.repo-structure-gates.result }}
           TESTS: ${{ needs.tests.result }}
@@ -1198,6 +1235,7 @@ jobs:
           failed=0
 
           gates="code-quality:$CODE_QUALITY"
+          gates="$gates companion-workflows:$COMPANION_WORKFLOWS"
           gates="$gates security-scans:$SECURITY_SCANS"
           gates="$gates repo-structure-gates:$REPO_STRUCTURE_GATES"
           gates="$gates tests:$TESTS"

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -110,6 +110,8 @@ contract, recovery constraints, and next commands are in
 
 - Foundation #9180 merged as `1af18489e8755933a0d189aa8edafe787fa94d0f`;
   publication #9214 merged as `a8073c42edc811522c5d5709744f55c5cbd0fa8e`.
+- Governed companion workflows (#9190) define the 15-record registry, public
+  executor, and CI execution evidence across 10 success and 4 failure fixtures.
 - #9222 has exact tree `c468c0db`, but its protected-main run was cancelled with
   no jobs or artifacts. #9192 remains open pending post-#9236 exact bytes,
   acquisition identity, and attestations; #9174 remains open.

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,6 +51,20 @@ Failure to establish that working directory is negative publication evidence:
 no artifact or attestation may be accepted, and #9192 remains open until a new
 protected-main run publishes and verifies the exact protected commit bytes.
 
+## Deterministic Companion Workflow Authority (#9190)
+
+ADR-0043 amendment establishes UpstreamDrift as the workflow-execution authority
+for the 15 registered companion workflows. Ten success workflows cover
+installation, launch resolution, simulation, import/export, catalog export,
+counterfactual mechanics, reports, and plotting; four deterministic failure
+fixtures cover unsupported dependency, bad input, unavailable engine, and stale
+version; one native OpenSim GUI workflow is explicitly unavailable until
+native-engine UI and screenshot authority exist. All workflows execute through
+`scripts.companion_workflows` using `shell=False` arguments and emit structured
+execution records with exact command strings, exits, durations, and outputs.
+CI job `companion-workflows` runs all available records and verifies execution
+evidence against schema `upstreamdrift-companion-v1.schema.json`.
+
 ## Ball-Sand Interaction: What Reaches the Ball (#8712)
 
 Issue #8712 resolves the sand arriving at the ball inside the F1 plane-strain

--- a/docs/adr/0043-companion-manifest-provider-authority.md
+++ b/docs/adr/0043-companion-manifest-provider-authority.md
@@ -3,7 +3,7 @@
 - Status: Accepted
 - Date: 2026-08-28
 - Decision Makers: UpstreamDrift maintainers and AffineDrift companion owners
-- Related Issues/PRs: UpstreamDrift #9174, #9192, #9064, #9070;
+- Related Issues/PRs: UpstreamDrift #9174, #9190, #9192, #9064, #9070;
   AffineDrift #4010, #4030
 
 ## Context
@@ -45,17 +45,18 @@ the schema does not use current counts as `const`, `minItems`, or `maxItems`.
 
 ### Source Ownership
 
-| Fact                               | Editable Authority                        | Companion Treatment                                 |
-| ---------------------------------- | ----------------------------------------- | --------------------------------------------------- |
-| Native model and launch metadata   | `src/config/models.yaml`                  | Local-only normalized program record                |
-| Web launcher metadata              | `src/config/launcher_manifest.json`       | Merged by stable program ID, with source provenance |
-| Shell parity, gaps, and exemptions | `src/config/feature_parity.json`          | Feature record with parity kept separate            |
-| Package and Python compatibility   | `pyproject.toml` plus supported CI matrix | Exact package version/specifier and tested minors   |
-| Engine support tier                | UpstreamDrift support policy              | `supported`, `extended`, or `experimental` only     |
-| Tools provider revision            | `vendor/ud-tools` Git gitlink             | Exact immutable 40-character commit                 |
-| Equations/calculations/uncertainty | #9070 calculation manifest                | Link later; never copy or redefine                  |
-| Design-manual content/approval     | #9064 governed QMD authority              | Link later; never infer approval                    |
-| Scientific qualification           | Qualification evidence authority          | Conservative explicit state; inclusion grants none  |
+| Fact                               | Editable Authority                           | Companion Treatment                                   |
+| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| Native model and launch metadata   | `src/config/models.yaml`                     | Local-only normalized program record                  |
+| Web launcher metadata              | `src/config/launcher_manifest.json`          | Merged by stable program ID, with source provenance   |
+| Shell parity, gaps, and exemptions | `src/config/feature_parity.json`             | Feature record with parity kept separate              |
+| Package and Python compatibility   | `pyproject.toml` plus supported CI matrix    | Exact package version/specifier and tested minors     |
+| Engine support tier                | UpstreamDrift support policy                 | `supported`, `extended`, or `experimental` only       |
+| Tools provider revision            | `vendor/ud-tools` Git gitlink                | Exact immutable 40-character commit                   |
+| Equations/calculations/uncertainty | #9070 calculation manifest                   | Link later; never copy or redefine                    |
+| Design-manual content/approval     | #9064 governed QMD authority                 | Link later; never infer approval                      |
+| Scientific qualification           | Qualification evidence authority             | Conservative explicit state; inclusion grants none    |
+| Governed workflow declarations     | `scripts/config/companion_workflows.v1.json` | Hashed records executed only by the provider boundary |
 
 The export keeps these independent dimensions:
 
@@ -90,9 +91,15 @@ inputs.
 Postconditions require unique, deterministically sorted program and feature
 IDs, exact input hashes, exact provider pins, resolvable feature/program
 references, a strict-schema-valid document, and a detached digest over the
-rendered bytes. Publication remains `draft` while capability evidence,
-workflow/document inventories, screenshot qualification, and immutable
-release acquisition are incomplete.
+rendered bytes. The workflow registry adds its referenced committed fixtures to
+the hashed input set. Its executor accepts only declared Python modules, argv
+arrays, allowlisted environment values, repository-relative working directories
+and outputs, and uses `shell=False`. It verifies exact exit codes, declared
+artifact types and digests, rejects undeclared outputs, and refuses source
+commit mismatch. Unavailable records have no executor, argv, exit code, or
+artifacts and cannot be run. Publication remains `draft` while capability
+evidence, documentation, screenshot qualification, and protected completion
+evidence are incomplete.
 
 ### Provider and Consumer Boundary
 
@@ -140,9 +147,9 @@ depend on AffineDrift.
   without schema churn; DbC rejects ambiguous publication inputs.
 - Negative: a clean committed checkout is required to generate an authoritative
   artifact, so local drafts cannot be presented as publishable output.
-- Negative: this foundation emits empty documentation, workflow, and screenshot
-  inventories. Those empty arrays are explicit negative evidence, not #9174
-  completion or a publishable companion.
+- Negative: documentation and screenshot inventories remain incomplete. The
+  governed workflows prove only their declared deterministic software paths;
+  they do not establish native GUI/engine availability or scientific validity.
 
 ### Foundation Boundary and Remaining Provider Ownership
 
@@ -165,6 +172,24 @@ by four linked children:
 The local ignored files produced by #9180 validate deterministic generation;
 they have no durable release acquisition URL and must not be represented as a
 released provider artifact. No ad hoc tag or release is part of this slice.
+
+### Governed Workflow Authority
+
+Issue #9190 establishes one strict workflow registry and one public executor.
+Ten successful records cover installation, headless launch resolution,
+simulation and analysis, import/export, program export, counterfactual, report,
+and plot paths. Four failure records deterministically represent unsupported
+dependency, bad input, unavailable engine, and stale-version behavior with
+distinct non-zero exits. The optional native OpenSim GUI record is explicitly
+unavailable and structurally non-executable until its prerequisite and evidence
+authority exist.
+
+Every code pull request and protected-main push runs all fourteen available
+records and uploads exact-commit evidence for 30 days. This job is an aggregate
+quality-gate dependency, not a publication channel. Local development may skip
+the self-referential catalog-export record only through the private test API
+while the tree is dirty; the public CLI and CI always require a clean exact
+commit and execute the complete available registry.
 
 ### Protected Publication and Acquisition
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,10 @@ canonical-core app-shell registry reuse of the embeddable-tool contract.
   one shared bundle command, ephemeral protected-main evidence, draft-first
   immutable release acquisition, attestation, and non-fabricated schema
   compatibility history.
+- **2026-08-30:** ADR-0043 adds the #9190 structured-workflow authority:
+  a hashed repository registry, one fail-closed public executor, exact-commit
+  CI evidence, and an explicit boundary against scientific or native-engine
+  qualification.
 - **2026-08-16:** ADR-0033 amends ADR-0032's fidelity-tier table: F1 is
   narrowed from "reduced-order / 2-D plane-strain continuum" to a 2-D
   plane-strain **MPM** solver and becomes the sand-field visualization tier,

--- a/docs/api/contracts/upstreamdrift-companion-v1.schema.json
+++ b/docs/api/contracts/upstreamdrift-companion-v1.schema.json
@@ -646,10 +646,156 @@
         }
       }
     },
+    "workflowEnvironment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inherit", "fixed", "python_paths"],
+      "properties": {
+        "inherit": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$"
+          },
+          "uniqueItems": true
+        },
+        "fixed": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "MPLBACKEND": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "PYTHONHASHSEED": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "PYTHONPATH": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "PYTHONDONTWRITEBYTECODE": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "PYTHONUTF8": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        },
+        "python_paths": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "const": "."
+              },
+              {
+                "$ref": "#/$defs/repoPath"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "workflowArtifactVerification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "minimum_bytes"],
+      "properties": {
+        "method": {
+          "enum": [
+            "csv-header",
+            "json-object",
+            "non-empty",
+            "png-signature",
+            "sha256-sidecar"
+          ]
+        },
+        "minimum_bytes": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "required_columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "workflowArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "type", "required", "verification"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/repoPath"
+        },
+        "type": {
+          "enum": ["csv", "json", "markdown", "png", "sha256"]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "verification": {
+          "$ref": "#/$defs/workflowArtifactVerification"
+        }
+      }
+    },
+    "workflowDeterminism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixture_kind",
+        "fixture_paths",
+        "absolute_tolerance",
+        "relative_tolerance"
+      ],
+      "properties": {
+        "fixture_kind": {
+          "enum": ["inline", "repository"]
+        },
+        "fixture_paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/repoPath"
+          },
+          "uniqueItems": true
+        },
+        "absolute_tolerance": {
+          "type": "number",
+          "minimum": 0
+        },
+        "relative_tolerance": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
     "workflow": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "title", "command", "documentation_ids"],
+      "required": [
+        "id",
+        "title",
+        "kind",
+        "executor",
+        "argv",
+        "cwd",
+        "environment",
+        "expected_exit_code",
+        "expected_artifacts",
+        "documentation_paths",
+        "program_ids",
+        "prerequisites",
+        "support_tier",
+        "availability",
+        "determinism",
+        "verification_method",
+        "scientific_limitations",
+        "source_commit"
+      ],
       "properties": {
         "id": {
           "$ref": "#/$defs/identifier"
@@ -657,17 +803,147 @@
         "title": {
           "$ref": "#/$defs/nonEmptyString"
         },
-        "command": {
-          "$ref": "#/$defs/command"
+        "kind": {
+          "enum": ["workflow", "failure-fixture"]
         },
-        "documentation_ids": {
+        "failure_class": {
+          "enum": [
+            "bad-input",
+            "stale-version",
+            "unavailable-engine",
+            "unsupported-dependency"
+          ]
+        },
+        "executor": {
+          "enum": ["python-module", null]
+        },
+        "argv": {
           "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "cwd": {
+          "anyOf": [
+            {
+              "const": "."
+            },
+            {
+              "$ref": "#/$defs/repoPath"
+            }
+          ]
+        },
+        "environment": {
+          "$ref": "#/$defs/workflowEnvironment"
+        },
+        "expected_exit_code": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 255
+        },
+        "expected_artifacts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workflowArtifact"
+          }
+        },
+        "documentation_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/repoPath"
+          },
+          "uniqueItems": true
+        },
+        "program_ids": {
+          "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/identifier"
           },
           "uniqueItems": true
+        },
+        "prerequisites": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "support_tier": {
+          "enum": ["supported", "extended", "experimental", "not_applicable"]
+        },
+        "availability": {
+          "$ref": "#/$defs/availability"
+        },
+        "determinism": {
+          "$ref": "#/$defs/workflowDeterminism"
+        },
+        "verification_method": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "scientific_limitations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "uniqueItems": true
+        },
+        "source_commit": {
+          "$ref": "#/$defs/commit"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "failure-fixture"
+              }
+            }
+          },
+          "then": {
+            "required": ["failure_class"],
+            "properties": {
+              "expected_exit_code": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "availability": {
+                "properties": {
+                  "state": {
+                    "const": "unavailable"
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "executor": {
+                "const": null
+              },
+              "argv": {
+                "maxItems": 0
+              },
+              "expected_exit_code": {
+                "const": null
+              },
+              "expected_artifacts": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
     },
     "screenshot": {
       "type": "object",
@@ -699,7 +975,9 @@
         "local_model_records",
         "program_records",
         "feature_records",
-        "feature_surface_paths"
+        "feature_surface_paths",
+        "workflow_records",
+        "executable_workflow_records"
       ],
       "properties": {
         "raw_launcher_records": {
@@ -719,6 +997,14 @@
           "minimum": 0
         },
         "feature_surface_paths": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workflow_records": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "executable_workflow_records": {
           "type": "integer",
           "minimum": 0
         }

--- a/docs/operations/companion-publication.md
+++ b/docs/operations/companion-publication.md
@@ -4,6 +4,30 @@ UpstreamDrift is the provider authority for the AffineDrift companion catalog.
 This runbook covers delivery evidence only; it does not qualify a program,
 workflow, screenshot, calculation, or engineering conclusion.
 
+## Governed Workflow Evidence
+
+From a clean exact-commit checkout, execute the provider-owned workflow
+registry with:
+
+```text
+python3 -m scripts.companion_workflows --repo-root . execute-all --report dist/companion-workflows/execution-report.v1.json
+```
+
+The strict registry is `scripts/config/companion_workflows.v1.json`; it and all
+referenced fixtures are hashed catalog inputs. Ten successful workflows cover
+installation, launch resolution, simulation/analysis, import/export, program
+export, counterfactual, report, and plot evidence. Four deterministic failure
+fixtures must return their declared non-zero exits. The native OpenSim GUI
+record is explicitly unavailable and cannot be executed.
+
+The executor passes no shell string, rejects undeclared environment and
+outputs, restricts paths to the repository, verifies artifact types and
+digests, and refuses a stale source commit. CI runs every available record on
+code pull requests and protected `main`, then uploads a commit-named 30-day
+artifact. This is test evidence only. It is not a durable acquisition channel,
+does not demonstrate native GUI interaction, and grants no scientific,
+operational, engine, participant, or coaching qualification.
+
 ## One Generator, Two Delivery Channels
 
 Both channels call the same public builder and verifier:

--- a/scripts/companion_catalog.py
+++ b/scripts/companion_catalog.py
@@ -18,14 +18,16 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
+from scripts import companion_workflows
 from src.shared.python.config.model_registry import ModelConfig, ModelRegistry
 
 SCHEMA_ID = "https://upstreamdrift.dev/schemas/upstreamdrift-companion-v1.schema.json"
 SCHEMA_VERSION = "1.0.0"
-GENERATOR_VERSION = "1.0.0"
+GENERATOR_VERSION = "1.1.0"
 DEFAULT_OUTPUT = Path("dist/companion/upstreamdrift-companion.v1.json")
 INPUT_PATHS = (
     Path("pyproject.toml"),
+    companion_workflows.REGISTRY_PATH,
     Path("src/config/feature_parity.json"),
     Path("src/config/launcher_manifest.json"),
     Path("src/config/models.yaml"),
@@ -152,8 +154,10 @@ def _read_input(repo_root: Path, relative: Path, *, require_committed: bool) -> 
         capture_output=True,
         shell=False,
     )
-    if committed.returncode != 0:
+    if committed.returncode != 0 and require_committed:
         raise CatalogAuthorityError(f"input is not tracked at HEAD: {normalized}")
+    if committed.returncode != 0:
+        return path.read_bytes()
     if diff.returncode == 0:
         # Hash and parse committed blob bytes so checkout line-ending policy
         # cannot change the manifest on Windows versus Linux.
@@ -390,7 +394,7 @@ def _source_provenance(
         },
         "inputs": [
             {"path": relative.as_posix(), "sha256": _sha256(payloads[relative])}
-            for relative in INPUT_PATHS
+            for relative in sorted(payloads, key=lambda path: path.as_posix())
         ],
     }
 
@@ -402,8 +406,7 @@ def _catalog_payload(
     payloads: Mapping[Path, bytes],
     source: Mapping[str, Any],
     tools_commit: str,
-    programs: Sequence[Mapping[str, Any]],
-    features: Sequence[Mapping[str, Any]],
+    inventories: Mapping[str, Sequence[Mapping[str, Any]]],
     summary: Mapping[str, int],
 ) -> dict[str, Any]:
     """Assemble the strict schema shape from already validated facts."""
@@ -445,6 +448,12 @@ def _catalog_payload(
             "version": None,
             "discovery_mode": "local-only",
         },
+        {
+            "id": "workflow_registry",
+            "path": companion_workflows.REGISTRY_PATH.as_posix(),
+            "version": companion_workflows.REGISTRY_VERSION,
+            "discovery_mode": "local-only",
+        },
     ]
     engines = [
         {
@@ -465,7 +474,7 @@ def _catalog_payload(
             "state": "draft",
             "blockers": [
                 "Engine capability claims require qualification evidence.",
-                "Workflow and screenshot inventories are scheduled for later slices.",
+                "Documentation and screenshot inventories require their governed provider slices.",
             ],
         },
         "source": dict(source),
@@ -480,10 +489,10 @@ def _catalog_payload(
             },
         },
         "engines": engines,
-        "programs": list(programs),
-        "features": list(features),
+        "programs": list(inventories["programs"]),
+        "features": list(inventories["features"]),
         "documentation": [],
-        "workflows": [],
+        "workflows": list(inventories["workflows"]),
         "screenshots": [],
         "summary": dict(summary),
     }
@@ -523,6 +532,18 @@ def build_catalog(repo_root: Path, *, require_clean: bool = True) -> dict[str, A
     models = registry.get_all_models()
     features, feature_ids_by_program, surface_count = _features(parity["features"])
     programs = _merge_programs(launcher["tiles"], models, feature_ids_by_program)
+    source_commit = _git_commit(root)
+    workflows = companion_workflows.parse_registry(
+        payloads[companion_workflows.REGISTRY_PATH],
+        repo_root=root,
+        source_commit=source_commit,
+        program_ids={program["id"] for program in programs},
+    )
+    for fixture_path in companion_workflows.referenced_fixture_paths(workflows):
+        payloads.setdefault(
+            fixture_path,
+            _read_input(root, fixture_path, require_committed=require_clean),
+        )
     source = _source_provenance(root, payloads)
     tools_commit = _tools_gitlink(root)
     summary = {
@@ -531,6 +552,10 @@ def build_catalog(repo_root: Path, *, require_clean: bool = True) -> dict[str, A
         "program_records": len(programs),
         "feature_records": len(features),
         "feature_surface_paths": surface_count,
+        "workflow_records": len(workflows),
+        "executable_workflow_records": sum(
+            workflow["availability"]["state"] == "available" for workflow in workflows
+        ),
     }
     return _catalog_payload(
         launcher=launcher,
@@ -538,8 +563,11 @@ def build_catalog(repo_root: Path, *, require_clean: bool = True) -> dict[str, A
         payloads=payloads,
         source=source,
         tools_commit=tools_commit,
-        programs=programs,
-        features=features,
+        inventories={
+            "programs": programs,
+            "features": features,
+            "workflows": workflows,
+        },
         summary=summary,
     )
 

--- a/scripts/companion_workflow_tasks.py
+++ b/scripts/companion_workflow_tasks.py
@@ -1,0 +1,448 @@
+"""Deterministic, headless tasks exercised by the companion workflow authority.
+
+These tasks are small adapters over existing UpstreamDrift public surfaces. They
+produce reviewable evidence artifacts; they do not create a second scientific
+calculation authority or claim that optional GUI/engine runtimes are qualified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    root = Path.cwd().resolve()
+    if not (root / "pyproject.toml").is_file():
+        raise ValueError("companion workflow tasks must run from the repository root")
+    return root
+
+
+def _output_path(root: Path, raw: str) -> Path:
+    from scripts.companion_catalog import validate_repo_relative
+
+    relative = validate_repo_relative(Path(raw))
+    destination = root.joinpath(*relative.parts).resolve()
+    try:
+        destination.relative_to(root)
+    except ValueError as exc:  # pragma: no cover - defense after lexical validation
+        raise ValueError(f"output escapes repository root: {raw}") from exc
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    return destination
+
+
+def _source_commit(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        shell=False,
+    )
+    commit = completed.stdout.strip().lower()
+    if completed.returncode != 0 or len(commit) != 40:
+        raise RuntimeError("workflow task could not resolve an exact source commit")
+    return commit
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _rounded(values: Sequence[float]) -> list[float]:
+    return [round(float(value), 12) for value in values]
+
+
+def _reference_simulation() -> Any:
+    import numpy as np
+
+    from src.shared.python.pendulum_simulator.physics import PendulumParams
+    from src.shared.python.pendulum_simulator.simulation import run_simulation
+
+    params = PendulumParams(
+        m1=5.0,
+        m2=0.3,
+        L1=0.65,
+        L2=1.1,
+        mClub=0.2,
+        b1=0.05,
+        b2=0.02,
+    )
+    state = np.array([math.radians(-35.0), math.radians(70.0), 0.2, -0.1])
+    return run_simulation(
+        params,
+        state,
+        0.05,
+        lambda _time: (12.0, -3.0),
+        dt=0.01,
+    )
+
+
+def _installation_verification(root: Path, output: Path) -> int:
+    from scripts.ci.verify_installation import check_python_version
+    from src.shared.python.config.model_registry import ModelRegistry
+
+    python_ok, _message = check_python_version()
+    registry = ModelRegistry(
+        config_path=root / "src/config/models.yaml",
+        strict=True,
+        discovery_mode="local-only",
+    )
+    _write_json(
+        output,
+        {
+            "check_scope": "provider workflow core imports and local registry",
+            "model_records": len(registry.get_all_models()),
+            "python_major_minor": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "python_supported": python_ok,
+            "source_commit": _source_commit(root),
+            "status": "passed" if python_ok else "failed",
+        },
+    )
+    return 0 if python_ok else 10
+
+
+def _model_launch_resolution(root: Path, output: Path) -> int:
+    from src.shared.python.config.model_registry import ModelRegistry
+
+    registry = ModelRegistry(
+        config_path=root / "src/config/models.yaml",
+        strict=True,
+        discovery_mode="local-only",
+    )
+    model = registry.get_model("model_explorer")
+    if model is None or model.path is None:
+        raise RuntimeError("model_explorer launch record is missing")
+    entry_point = root / model.path
+    if not entry_point.is_file():
+        raise RuntimeError(f"model_explorer entry point is missing: {model.path}")
+    _write_json(
+        output,
+        {
+            "entry_point": model.path,
+            "launch_argv": ["python3", model.path],
+            "launch_mode": "headless-resolution-only",
+            "program_id": model.id,
+            "source_commit": _source_commit(root),
+            "status": "resolved",
+        },
+    )
+    return 0
+
+
+def _reference_simulation_task(root: Path, output: Path) -> int:
+    result = _reference_simulation()
+    _write_json(
+        output,
+        {
+            "coordinate_order": ["theta1", "phi", "dtheta1", "dphi"],
+            "final_state": _rounded(result.states[-1]),
+            "frame": "planar pendulum model frame",
+            "n_steps": result.n_steps,
+            "source_commit": _source_commit(root),
+            "time_end_s": round(float(result.t[-1]), 12),
+            "units": ["rad", "rad", "rad/s", "rad/s"],
+        },
+    )
+    return 0
+
+
+def _reference_analysis(root: Path, output: Path) -> int:
+    result = _reference_simulation()
+    tip_speeds = [
+        result.joint_velocities_at(i)["tip_speed"] for i in range(result.n_steps)
+    ]
+    initial_energy = result.energy_at(0)
+    final_energy = result.energy_at(result.n_steps - 1)
+    _write_json(
+        output,
+        {
+            "energy_change_j": round(
+                float(final_energy["total"] - initial_energy["total"]), 12
+            ),
+            "estimands": ["maximum tip speed", "total mechanical energy change"],
+            "max_tip_speed_m_s": round(float(max(tip_speeds)), 12),
+            "n_steps": result.n_steps,
+            "source_commit": _source_commit(root),
+        },
+    )
+    return 0
+
+
+def _launch_monitor_roundtrip(root: Path, output: Path, csv_output: Path) -> int:
+    from src.shared.python.launch_monitor import import_session
+
+    fixture = root / "tests/fixtures/launch_monitor/trackman.csv"
+    session = import_session(fixture)
+    canonical_columns = [
+        column
+        for column in (
+            "shot_id",
+            "club_speed",
+            "ball_speed",
+            "launch_angle",
+            "spin_rate",
+            "carry_distance",
+        )
+        if column in session.shots.columns
+    ]
+    if len(canonical_columns) < 5:
+        raise RuntimeError("TrackMan fixture did not map the canonical metrics")
+    session.shots.loc[:, canonical_columns].to_csv(
+        csv_output,
+        index=False,
+        lineterminator="\n",
+    )
+    _write_json(
+        output,
+        {
+            "canonical_columns": canonical_columns,
+            "export_path": csv_output.relative_to(root).as_posix(),
+            "profile_id": session.manifest.profile_id,
+            "row_count": int(len(session.shots)),
+            "source_commit": _source_commit(root),
+            "source_fixture": "tests/fixtures/launch_monitor/trackman.csv",
+            "source_sha256": session.manifest.file_sha256,
+        },
+    )
+    return 0
+
+
+def _program_catalog_export(root: Path, output: Path) -> int:
+    from scripts import companion_catalog
+
+    catalog = companion_catalog.build_catalog(root, require_clean=False)
+    selected_ids = {"model_explorer", "pendulum_simulator", "pose_studio"}
+    records = [
+        {
+            "availability": program["availability"],
+            "entry_point": program["entry_point"],
+            "id": program["id"],
+            "name": program["name"],
+        }
+        for program in catalog["programs"]
+        if program["id"] in selected_ids
+    ]
+    if len(records) != len(selected_ids):
+        raise RuntimeError("program catalog slice is incomplete")
+    _write_json(
+        output,
+        {
+            "programs": records,
+            "source_commit": catalog["source"]["commit"],
+        },
+    )
+    return 0
+
+
+def _zero_torque_counterfactual(root: Path, output: Path) -> int:
+    import numpy as np
+
+    from src.shared.python.pendulum_simulator.counterfactual import (
+        zero_torque_joint_forces_double,
+    )
+    from src.shared.python.pendulum_simulator.physics import PendulumParams
+
+    state = np.array([0.3, -0.2, 0.5, -0.3])
+    params = PendulumParams(m1=5.0, m2=0.3, L1=0.65, L2=1.1, mClub=0.2)
+    forces = zero_torque_joint_forces_double(state, params)
+    _write_json(
+        output,
+        {
+            "counterfactual": "instantaneous zero applied driving torque",
+            "forces_n": {
+                name: _rounded(value) for name, value in sorted(forces.items())
+            },
+            "source_commit": _source_commit(root),
+            "state_order": ["theta1", "phi", "dtheta1", "dphi"],
+        },
+    )
+    return 0
+
+
+def _reference_report(root: Path, output: Path) -> int:
+    result = _reference_simulation()
+    tip_speeds = [
+        result.joint_velocities_at(i)["tip_speed"] for i in range(result.n_steps)
+    ]
+    commit = _source_commit(root)
+    output.write_text(
+        "\n".join(
+            [
+                "# Governed Reference Simulation Report",
+                "",
+                f"- Source commit: `{commit}`",
+                f"- Samples: {result.n_steps}",
+                f"- Maximum tip speed: {max(tip_speeds):.9f} m/s",
+                "- Scope: deterministic software workflow evidence only",
+                "- Limitation: this short synthetic trace is not a golfer validation dataset",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+    return 0
+
+
+def _reference_plot(root: Path, output: Path) -> int:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib.figure import Figure
+
+    result = _reference_simulation()
+    tip_speeds = [
+        result.joint_velocities_at(i)["tip_speed"] for i in range(result.n_steps)
+    ]
+    figure = Figure(figsize=(6.4, 3.6), dpi=100, layout="constrained")
+    axes = figure.subplots()
+    axes.plot(result.t, tip_speeds, color="#4c78a8", linewidth=2)
+    axes.set_title("Reference Double-Pendulum Tip Speed")
+    axes.set_xlabel("Time (s)")
+    axes.set_ylabel("Tip Speed (m/s)")
+    axes.grid(alpha=0.25)
+    figure.savefig(
+        output,
+        format="png",
+        metadata={"Software": "UpstreamDrift", "SourceCommit": _source_commit(root)},
+    )
+    return 0
+
+
+def _failure_evidence(
+    root: Path,
+    output: Path,
+    *,
+    failure_class: str,
+    error_type: str,
+    detail: str,
+) -> None:
+    _write_json(
+        output,
+        {
+            "detail": detail,
+            "error_type": error_type,
+            "failure_class": failure_class,
+            "source_commit": _source_commit(root),
+            "status": "expected-failure",
+        },
+    )
+
+
+def _unsupported_dependency(root: Path, output: Path) -> int:
+    dependency = "upstreamdrift_companion_missing_dependency_fixture_v1"
+    if importlib.util.find_spec(dependency) is not None:  # pragma: no cover
+        raise RuntimeError("reserved missing-dependency fixture unexpectedly exists")
+    _failure_evidence(
+        root,
+        output,
+        failure_class="unsupported-dependency",
+        error_type="ModuleNotFoundError",
+        detail=f"Required fixture dependency is unavailable: {dependency}",
+    )
+    return 20
+
+
+def _bad_input(root: Path, output: Path) -> int:
+    from src.shared.python.pendulum_simulator.physics import PendulumParams
+
+    try:
+        PendulumParams(m1=0.0, m2=0.3, L1=0.65, L2=1.1)
+    except ValueError as exc:
+        _failure_evidence(
+            root,
+            output,
+            failure_class="bad-input",
+            error_type=type(exc).__name__,
+            detail=str(exc),
+        )
+        return 21
+    raise RuntimeError("bad-input fixture did not fail closed")  # pragma: no cover
+
+
+def _unavailable_engine(root: Path, output: Path) -> int:
+    engine_id = "companion-missing-engine-fixture"
+    _failure_evidence(
+        root,
+        output,
+        failure_class="unavailable-engine",
+        error_type="EngineUnavailableError",
+        detail=f"Deterministic fixture engine is unavailable: {engine_id}",
+    )
+    return 22
+
+
+def _stale_version(root: Path, output: Path) -> int:
+    from scripts import companion_publication
+
+    policy = companion_publication.load_compatibility_policy(root)
+    stale = dict(policy)
+    stale["current"] = "0.0.0"
+    try:
+        companion_publication.validate_compatibility_policy(root, stale)
+    except companion_publication.PublicationContractError as exc:
+        _failure_evidence(
+            root,
+            output,
+            failure_class="stale-version",
+            error_type=type(exc).__name__,
+            detail=str(exc),
+        )
+        return 23
+    raise RuntimeError("stale-version fixture did not fail closed")  # pragma: no cover
+
+
+_TASKS: dict[str, Callable[[Path, Path], int]] = {
+    "installation-verification": _installation_verification,
+    "model-launch-resolution": _model_launch_resolution,
+    "reference-simulation": _reference_simulation_task,
+    "reference-analysis": _reference_analysis,
+    "program-catalog-export": _program_catalog_export,
+    "zero-torque-counterfactual": _zero_torque_counterfactual,
+    "reference-report": _reference_report,
+    "reference-plot": _reference_plot,
+    "unsupported-dependency": _unsupported_dependency,
+    "bad-input": _bad_input,
+    "unavailable-engine": _unavailable_engine,
+    "stale-version": _stale_version,
+}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("task", choices=sorted((*_TASKS, "launch-monitor-roundtrip")))
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--csv-output")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one deterministic task and return its governed exit code."""
+    args = _parser().parse_args(argv)
+    root = _repo_root()
+    output = _output_path(root, args.output)
+    if args.task == "launch-monitor-roundtrip":
+        if not args.csv_output:
+            raise ValueError("launch-monitor-roundtrip requires --csv-output")
+        csv_output = _output_path(root, args.csv_output)
+        return _launch_monitor_roundtrip(root, output, csv_output)
+    if args.csv_output:
+        raise ValueError("--csv-output is only valid for launch-monitor-roundtrip")
+    return _TASKS[args.task](root, output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/companion_workflows.py
+++ b/scripts/companion_workflows.py
@@ -1,0 +1,868 @@
+"""Validate and execute the governed UpstreamDrift companion workflows.
+
+The registry is data; this module is the sole execution boundary. Commands are
+always argv-based Python modules, receive only declared environment keys, run
+with ``shell=False``, and may change only their declared artifact files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence, Set
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+
+import jsonschema
+
+REGISTRY_PATH = Path("scripts/config/companion_workflows.v1.json")
+DEFAULT_REPORT = Path("dist/companion-workflows/execution-report.v1.json")
+REGISTRY_ID = "upstreamdrift-companion-workflows"
+REGISTRY_VERSION = "1.0.0"
+_IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_MODULE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
+_ENVIRONMENT_KEY = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_FORBIDDEN_ARGUMENT = re.compile(r"[;&|<>`$(){}\[\]!*?~\r\n]")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_ALLOWED_INHERITED_ENV = frozenset(
+    {
+        "COMSPEC",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "USERPROFILE",
+        "WINDIR",
+    }
+)
+_ALLOWED_FIXED_ENV = frozenset(
+    {
+        "MPLBACKEND",
+        "PYTHONHASHSEED",
+        "PYTHONPATH",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTHONUTF8",
+    }
+)
+_ALLOWED_MODULES = frozenset(
+    {"scripts.companion_catalog", "scripts.companion_workflow_tasks"}
+)
+_FAILURE_CLASSES = frozenset(
+    {"bad-input", "stale-version", "unavailable-engine", "unsupported-dependency"}
+)
+_ARTIFACT_TYPES = frozenset({"csv", "json", "markdown", "png", "sha256"})
+_VERIFICATION_METHODS = frozenset(
+    {"csv-header", "json-object", "non-empty", "png-signature", "sha256-sidecar"}
+)
+_SUPPORT_TIERS = frozenset({"experimental", "extended", "not_applicable", "supported"})
+_OUTPUT_PREFIX = PurePosixPath("dist/companion-workflows/artifacts")
+_RECORD_REQUIRED_KEYS = frozenset(
+    {
+        "id",
+        "title",
+        "kind",
+        "executor",
+        "argv",
+        "cwd",
+        "environment",
+        "expected_exit_code",
+        "expected_artifacts",
+        "documentation_paths",
+        "program_ids",
+        "prerequisites",
+        "support_tier",
+        "availability",
+        "determinism",
+        "verification_method",
+        "scientific_limitations",
+    }
+)
+
+
+class WorkflowContractError(ValueError):
+    """Raised when workflow registry data violates its fail-closed contract."""
+
+
+class WorkflowExecutionError(RuntimeError):
+    """Raised when a command or its artifact evidence violates its contract."""
+
+
+def _exact_keys(
+    value: Mapping[str, Any], *, required: Set[str], optional: Set[str], label: str
+) -> None:
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing or unknown:
+        raise WorkflowContractError(
+            f"{label} has unknown or missing keys; missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+
+
+def _non_empty_string(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorkflowContractError(f"{label} must be a non-empty string")
+    return value
+
+
+def _repo_relative(value: Any, *, label: str, allow_root: bool = False) -> str:
+    text = _non_empty_string(value, label=label).replace("\\", "/")
+    if allow_root and text == ".":
+        return text
+    candidate = PurePosixPath(text)
+    if (
+        candidate.is_absolute()
+        or PureWindowsPath(text).is_absolute()
+        or ".." in candidate.parts
+        or candidate.parts in ((), (".",))
+    ):
+        raise WorkflowContractError(f"{label} must be a contained repo-relative path")
+    return candidate.as_posix()
+
+
+def _safe_argument(value: Any, *, index: int) -> str:
+    text = _non_empty_string(value, label=f"argv[{index}]")
+    if _FORBIDDEN_ARGUMENT.search(text):
+        raise WorkflowContractError(f"argv[{index}] contains a shell metacharacter")
+    if text.startswith(("http://", "https://")):
+        raise WorkflowContractError(
+            f"argv[{index}] contains a mutable external reference"
+        )
+    candidate = PurePosixPath(text.replace("\\", "/"))
+    if candidate.is_absolute() or PureWindowsPath(text).is_absolute():
+        raise WorkflowContractError(f"argv[{index}] must not be absolute")
+    if ".." in candidate.parts:
+        raise WorkflowContractError(f"argv[{index}] contains path traversal")
+    return text
+
+
+def _string_list(value: Any, *, label: str, non_empty: bool = False) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise WorkflowContractError(f"{label} must be an array of strings")
+    if non_empty and not value:
+        raise WorkflowContractError(f"{label} must not be empty")
+    if len(value) != len(set(value)):
+        raise WorkflowContractError(f"{label} contains duplicate values")
+    return list(value)
+
+
+def _validate_environment(raw: Any, *, repo_root: Path) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("environment must be an object")
+    _exact_keys(
+        raw,
+        required={"inherit", "fixed", "python_paths"},
+        optional=set(),
+        label="environment",
+    )
+    inherited = _string_list(raw["inherit"], label="environment.inherit")
+    fixed_raw = raw["fixed"]
+    if not isinstance(fixed_raw, Mapping):
+        raise WorkflowContractError("environment.fixed must be an object")
+    fixed: dict[str, str] = {}
+    for key, value in fixed_raw.items():
+        if not isinstance(key, str) or not _ENVIRONMENT_KEY.fullmatch(key):
+            raise WorkflowContractError(f"invalid fixed environment key: {key!r}")
+        fixed[key] = _non_empty_string(value, label=f"environment.fixed.{key}")
+    invalid_inherited = set(inherited) - _ALLOWED_INHERITED_ENV
+    invalid_fixed = set(fixed) - _ALLOWED_FIXED_ENV
+    overlap = set(inherited) & set(fixed)
+    if invalid_inherited or invalid_fixed or overlap:
+        raise WorkflowContractError(
+            "environment keys are not safely declared; "
+            f"invalid inherited={sorted(invalid_inherited)}, "
+            f"invalid fixed={sorted(invalid_fixed)}, overlap={sorted(overlap)}"
+        )
+    python_paths = [
+        _repo_relative(path, label="environment python path", allow_root=True)
+        for path in _string_list(raw["python_paths"], label="environment.python_paths")
+    ]
+    for path in python_paths:
+        candidate = repo_root if path == "." else repo_root / path
+        if not candidate.is_dir():
+            raise WorkflowContractError(
+                f"environment python path does not exist: {path}"
+            )
+    return {
+        "inherit": sorted(inherited),
+        "fixed": dict(sorted(fixed.items())),
+        "python_paths": python_paths,
+    }
+
+
+def _validate_verification(raw: Any, *, artifact_type: str) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("artifact verification must be an object")
+    _exact_keys(
+        raw,
+        required={"method", "minimum_bytes"},
+        optional={"required_columns"},
+        label="artifact verification",
+    )
+    method = _non_empty_string(raw["method"], label="artifact verification method")
+    if method not in _VERIFICATION_METHODS:
+        raise WorkflowContractError(
+            f"unsupported artifact verification method: {method}"
+        )
+    minimum_bytes = raw["minimum_bytes"]
+    if (
+        not isinstance(minimum_bytes, int)
+        or isinstance(minimum_bytes, bool)
+        or minimum_bytes < 1
+    ):
+        raise WorkflowContractError("artifact minimum_bytes must be a positive integer")
+    required_columns = _string_list(
+        raw.get("required_columns", []), label="artifact required_columns"
+    )
+    if method == "csv-header" and not required_columns:
+        raise WorkflowContractError("csv-header verification requires columns")
+    if method != "csv-header" and required_columns:
+        raise WorkflowContractError("required_columns is only valid for csv-header")
+    expected_method = {
+        "csv": "csv-header",
+        "json": "json-object",
+        "markdown": "non-empty",
+        "png": "png-signature",
+        "sha256": "sha256-sidecar",
+    }[artifact_type]
+    if method != expected_method:
+        raise WorkflowContractError(
+            f"artifact type {artifact_type} requires verification method {expected_method}"
+        )
+    result: dict[str, Any] = {"method": method, "minimum_bytes": minimum_bytes}
+    if required_columns:
+        result["required_columns"] = required_columns
+    return result
+
+
+def _validate_artifacts(raw: Any, *, executable: bool) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise WorkflowContractError("expected_artifacts must be an array")
+    artifacts: list[dict[str, Any]] = []
+    paths: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise WorkflowContractError(
+                f"expected_artifacts[{index}] must be an object"
+            )
+        _exact_keys(
+            item,
+            required={"path", "type", "required", "verification"},
+            optional=set(),
+            label=f"expected_artifacts[{index}]",
+        )
+        path = _repo_relative(item["path"], label="artifact path")
+        candidate = PurePosixPath(path)
+        if candidate != _OUTPUT_PREFIX and _OUTPUT_PREFIX not in candidate.parents:
+            raise WorkflowContractError(
+                f"artifact path must be below {_OUTPUT_PREFIX.as_posix()}"
+            )
+        artifact_type = _non_empty_string(item["type"], label="artifact type")
+        if artifact_type not in _ARTIFACT_TYPES:
+            raise WorkflowContractError(f"unsupported artifact type: {artifact_type}")
+        required = item["required"]
+        if not isinstance(required, bool):
+            raise WorkflowContractError("artifact required must be boolean")
+        if path in paths:
+            raise WorkflowContractError(f"duplicate artifact path: {path}")
+        paths.add(path)
+        artifacts.append(
+            {
+                "path": path,
+                "type": artifact_type,
+                "required": required,
+                "verification": _validate_verification(
+                    item["verification"], artifact_type=artifact_type
+                ),
+            }
+        )
+    if executable and not artifacts:
+        raise WorkflowContractError("executable workflows require expected artifacts")
+    return sorted(artifacts, key=lambda item: item["path"])
+
+
+def _validate_determinism(raw: Any, *, repo_root: Path) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("determinism must be an object")
+    _exact_keys(
+        raw,
+        required={
+            "fixture_kind",
+            "fixture_paths",
+            "absolute_tolerance",
+            "relative_tolerance",
+        },
+        optional=set(),
+        label="determinism",
+    )
+    fixture_kind = _non_empty_string(raw["fixture_kind"], label="fixture_kind")
+    if fixture_kind not in {"inline", "repository"}:
+        raise WorkflowContractError("fixture_kind must be inline or repository")
+    fixture_paths = [
+        _repo_relative(path, label="fixture path")
+        for path in _string_list(raw["fixture_paths"], label="fixture_paths")
+    ]
+    if fixture_kind == "repository" and not fixture_paths:
+        raise WorkflowContractError("repository fixtures require fixture_paths")
+    if fixture_kind == "inline" and fixture_paths:
+        raise WorkflowContractError("inline fixtures cannot declare fixture_paths")
+    for path in fixture_paths:
+        if not (repo_root / path).is_file():
+            raise WorkflowContractError(f"fixture path does not exist: {path}")
+    tolerances: dict[str, float] = {}
+    for key in ("absolute_tolerance", "relative_tolerance"):
+        value = raw[key]
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value < 0:
+            raise WorkflowContractError(f"{key} must be a non-negative number")
+        tolerances[key] = float(value)
+    return {
+        "fixture_kind": fixture_kind,
+        "fixture_paths": sorted(fixture_paths),
+        **tolerances,
+    }
+
+
+def _validate_identity(raw: Mapping[str, Any]) -> tuple[str, str]:
+    workflow_id = _non_empty_string(raw["id"], label="workflow id")
+    if not _IDENTIFIER.fullmatch(workflow_id):
+        raise WorkflowContractError(f"invalid workflow id: {workflow_id}")
+    kind = _non_empty_string(raw["kind"], label="workflow kind")
+    if kind not in {"failure-fixture", "workflow"}:
+        raise WorkflowContractError(f"unsupported workflow kind: {kind}")
+    return workflow_id, kind
+
+
+def _validate_availability(
+    raw: Any,
+) -> tuple[str, str | None, bool]:
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("availability must be an object")
+    _exact_keys(raw, required={"state", "reason"}, optional=set(), label="availability")
+    state = _non_empty_string(raw["state"], label="availability state")
+    if state not in {"available", "unavailable"}:
+        raise WorkflowContractError(
+            "workflow availability must be available or unavailable"
+        )
+    reason = raw["reason"]
+    if state == "available" and reason is not None:
+        raise WorkflowContractError("available workflow reason must be null")
+    if state == "unavailable":
+        reason = _non_empty_string(reason, label="unavailable reason")
+    return state, reason, state == "available"
+
+
+def _validate_execution(
+    raw: Mapping[str, Any], *, kind: str, executable: bool
+) -> tuple[str | None, list[str], int | None, str | None]:
+    executor = raw["executor"]
+    argv_raw = raw["argv"]
+    if not isinstance(argv_raw, list):
+        raise WorkflowContractError("argv must be an array")
+    argv = [_safe_argument(value, index=index) for index, value in enumerate(argv_raw)]
+    if executable:
+        if executor != "python-module":
+            raise WorkflowContractError(f"unsupported executor: {executor}")
+        if not argv or not _MODULE.fullmatch(argv[0]):
+            raise WorkflowContractError(
+                "python-module argv must begin with a module name"
+            )
+        if argv[0] not in _ALLOWED_MODULES:
+            raise WorkflowContractError(
+                f"python module is not an approved workflow boundary: {argv[0]}"
+            )
+    elif executor is not None or argv:
+        raise WorkflowContractError(
+            "unavailable workflow must not expose an executor or argv"
+        )
+    expected_exit = raw["expected_exit_code"]
+    if executable and (
+        not isinstance(expected_exit, int)
+        or isinstance(expected_exit, bool)
+        or not 0 <= expected_exit <= 255
+    ):
+        raise WorkflowContractError(
+            "expected_exit_code must be an integer from 0 to 255"
+        )
+    if not executable and expected_exit is not None:
+        raise WorkflowContractError(
+            "unavailable workflow expected_exit_code must be null"
+        )
+    failure_class = raw.get("failure_class")
+    if kind == "failure-fixture":
+        if failure_class not in _FAILURE_CLASSES:
+            raise WorkflowContractError(
+                f"invalid failure fixture class: {failure_class}"
+            )
+        if not executable or expected_exit == 0:
+            raise WorkflowContractError(
+                "failure fixtures must execute with a nonzero exit"
+            )
+    elif failure_class is not None:
+        raise WorkflowContractError("ordinary workflows cannot declare failure_class")
+    elif executable and expected_exit != 0:
+        raise WorkflowContractError("ordinary workflows must expect exit code zero")
+    return executor, argv, expected_exit, failure_class
+
+
+def _validate_references(
+    raw: Mapping[str, Any], *, repo_root: Path, program_ids: Set[str]
+) -> tuple[str, list[str], list[str], str]:
+    cwd = _repo_relative(raw["cwd"], label="cwd", allow_root=True)
+    cwd_path = repo_root if cwd == "." else repo_root / cwd
+    if not cwd_path.is_dir():
+        raise WorkflowContractError(f"workflow cwd does not exist: {cwd}")
+    documentation_paths = [
+        _repo_relative(path, label="documentation path")
+        for path in _string_list(
+            raw["documentation_paths"], label="documentation_paths", non_empty=True
+        )
+    ]
+    for path in documentation_paths:
+        if not (repo_root / path).is_file():
+            raise WorkflowContractError(f"documentation path does not exist: {path}")
+    referenced_programs = _string_list(
+        raw["program_ids"], label="program_ids", non_empty=True
+    )
+    dangling = set(referenced_programs) - program_ids
+    if dangling:
+        raise WorkflowContractError(
+            f"workflow has dangling program IDs: {sorted(dangling)}"
+        )
+    support_tier = _non_empty_string(raw["support_tier"], label="support_tier")
+    if support_tier not in _SUPPORT_TIERS:
+        raise WorkflowContractError(f"unsupported support tier: {support_tier}")
+    return cwd, sorted(documentation_paths), sorted(referenced_programs), support_tier
+
+
+def _validate_record(
+    raw: Any, *, repo_root: Path, source_commit: str, program_ids: Set[str]
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("workflow record must be an object")
+    _exact_keys(
+        raw,
+        required=_RECORD_REQUIRED_KEYS,
+        optional={"failure_class"},
+        label="workflow record",
+    )
+    workflow_id, kind = _validate_identity(raw)
+    state, reason, executable = _validate_availability(raw["availability"])
+    executor, argv, expected_exit, failure_class = _validate_execution(
+        raw, kind=kind, executable=executable
+    )
+    cwd, documentation_paths, referenced_programs, support_tier = _validate_references(
+        raw, repo_root=repo_root, program_ids=program_ids
+    )
+    record: dict[str, Any] = {
+        "id": workflow_id,
+        "title": _non_empty_string(raw["title"], label="workflow title"),
+        "kind": kind,
+        "executor": executor,
+        "argv": argv,
+        "cwd": cwd,
+        "environment": _validate_environment(raw["environment"], repo_root=repo_root),
+        "expected_exit_code": expected_exit,
+        "expected_artifacts": _validate_artifacts(
+            raw["expected_artifacts"], executable=executable
+        ),
+        "documentation_paths": documentation_paths,
+        "program_ids": referenced_programs,
+        "prerequisites": sorted(
+            _string_list(raw["prerequisites"], label="prerequisites", non_empty=True)
+        ),
+        "support_tier": support_tier,
+        "availability": {"state": state, "reason": reason},
+        "determinism": _validate_determinism(raw["determinism"], repo_root=repo_root),
+        "verification_method": _non_empty_string(
+            raw["verification_method"], label="verification_method"
+        ),
+        "scientific_limitations": sorted(
+            _string_list(
+                raw["scientific_limitations"],
+                label="scientific_limitations",
+                non_empty=True,
+            )
+        ),
+        "source_commit": source_commit,
+    }
+    if failure_class is not None:
+        record["failure_class"] = failure_class
+    return record
+
+
+def parse_registry(
+    payload: bytes,
+    *,
+    repo_root: Path,
+    source_commit: str,
+    program_ids: Set[str],
+) -> list[dict[str, Any]]:
+    """Parse strict registry bytes into source-commit-bound manifest records.
+
+    Postcondition: records are unique and sorted by stable workflow ID.
+    """
+    if not _COMMIT.fullmatch(source_commit):
+        raise WorkflowContractError("source commit must be an exact lowercase commit")
+    try:
+        raw = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise WorkflowContractError(
+            f"workflow registry is not canonical JSON: {exc}"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise WorkflowContractError("workflow registry must be an object")
+    _exact_keys(
+        raw,
+        required={"registry_id", "version", "workflows"},
+        optional=set(),
+        label="workflow registry",
+    )
+    if raw["registry_id"] != REGISTRY_ID or raw["version"] != REGISTRY_VERSION:
+        raise WorkflowContractError("workflow registry identity or version is stale")
+    workflows_raw = raw["workflows"]
+    if not isinstance(workflows_raw, list) or not workflows_raw:
+        raise WorkflowContractError("workflow registry must contain records")
+    records = [
+        _validate_record(
+            item,
+            repo_root=repo_root,
+            source_commit=source_commit,
+            program_ids=program_ids,
+        )
+        for item in workflows_raw
+    ]
+    ids = [record["id"] for record in records]
+    if len(ids) != len(set(ids)):
+        raise WorkflowContractError("workflow registry contains duplicate IDs")
+    failure_classes = [
+        record["failure_class"]
+        for record in records
+        if record["kind"] == "failure-fixture"
+    ]
+    if set(failure_classes) != _FAILURE_CLASSES or len(failure_classes) != 4:
+        raise WorkflowContractError(
+            "workflow registry must contain exactly one fixture for each failure class"
+        )
+    available_successes = [
+        record
+        for record in records
+        if record["kind"] == "workflow"
+        and record["availability"]["state"] == "available"
+    ]
+    if len(available_successes) < 10:
+        raise WorkflowContractError(
+            "workflow registry requires at least ten executable workflows"
+        )
+    if not any(record["availability"]["state"] == "unavailable" for record in records):
+        raise WorkflowContractError(
+            "workflow registry requires an explicit unavailable record"
+        )
+    return sorted(records, key=lambda record: record["id"])
+
+
+def referenced_fixture_paths(records: Iterable[Mapping[str, Any]]) -> tuple[Path, ...]:
+    """Return unique repository fixture inputs in canonical order."""
+    paths = {
+        Path(path)
+        for record in records
+        for path in record["determinism"]["fixture_paths"]
+    }
+    return tuple(sorted(paths, key=lambda path: path.as_posix()))
+
+
+def _snapshot_files(scan_root: Path, *, repo_root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    if not scan_root.exists():
+        return snapshot
+    for directory, names, files in os.walk(scan_root):
+        names[:] = [name for name in names if name != ".git"]
+        base = Path(directory)
+        for name in files:
+            path = base / name
+            relative = path.relative_to(repo_root).as_posix()
+            snapshot[relative] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return snapshot
+
+
+def _execution_scope(repo_root: Path, declared_paths: Set[str]) -> Path:
+    prefix = "dist/companion-workflows/"
+    if declared_paths and all(path.startswith(prefix) for path in declared_paths):
+        return repo_root / "dist/companion-workflows"
+    return repo_root
+
+
+def _artifact_path(repo_root: Path, raw: str) -> Path:
+    path = (repo_root / raw).resolve()
+    try:
+        path.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise WorkflowExecutionError(
+            f"artifact path escapes repository: {raw}"
+        ) from exc
+    return path
+
+
+def _verify_artifact(
+    repo_root: Path, artifact: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    path = _artifact_path(repo_root, artifact["path"])
+    if not path.is_file():
+        if artifact["required"]:
+            raise WorkflowExecutionError(
+                f"required artifact is missing: {artifact['path']}"
+            )
+        return None
+    payload = path.read_bytes()
+    verification = artifact["verification"]
+    if len(payload) < verification["minimum_bytes"]:
+        raise WorkflowExecutionError(
+            f"artifact is smaller than declared: {artifact['path']}"
+        )
+    method = verification["method"]
+    if method == "json-object":
+        try:
+            decoded = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WorkflowExecutionError(
+                f"artifact is not valid JSON: {artifact['path']}"
+            ) from exc
+        if not isinstance(decoded, Mapping):
+            raise WorkflowExecutionError(
+                f"JSON artifact must be an object: {artifact['path']}"
+            )
+    elif method == "csv-header":
+        text = payload.decode("utf-8")
+        header = next(iter(csv.reader(text.splitlines())), [])
+        missing = set(verification["required_columns"]) - set(header)
+        if missing:
+            raise WorkflowExecutionError(
+                f"CSV artifact lacks declared columns {sorted(missing)}: {artifact['path']}"
+            )
+    elif method == "png-signature":
+        if not payload.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise WorkflowExecutionError(
+                f"artifact lacks PNG signature: {artifact['path']}"
+            )
+    elif method == "sha256-sidecar":
+        fields = payload.decode("ascii").strip().split()
+        target = path.with_suffix("")
+        if len(fields) != 2 or fields[1] != target.name or not target.is_file():
+            raise WorkflowExecutionError(f"invalid SHA-256 sidecar: {artifact['path']}")
+        if fields[0] != hashlib.sha256(target.read_bytes()).hexdigest():
+            raise WorkflowExecutionError(
+                f"SHA-256 sidecar mismatch: {artifact['path']}"
+            )
+    return {
+        "path": artifact["path"],
+        "type": artifact["type"],
+        "bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "verification_method": method,
+    }
+
+
+def execute_record(
+    repo_root: Path,
+    record: Mapping[str, Any],
+    *,
+    expected_source_commit: str | None = None,
+) -> dict[str, Any]:
+    """Execute one validated manifest record and return artifact evidence.
+
+    Preconditions: the record is source-bound, available, and already schema
+    validated. Postconditions: exit code and every changed file match the record.
+    """
+    root = repo_root.resolve()
+    if record["availability"]["state"] != "available":
+        raise WorkflowExecutionError(f"workflow is unavailable: {record['id']}")
+    if (
+        expected_source_commit is not None
+        and record["source_commit"] != expected_source_commit
+    ):
+        raise WorkflowExecutionError(
+            f"workflow source commit does not match executor authority: {record['id']}"
+        )
+    declared_paths = {artifact["path"] for artifact in record["expected_artifacts"]}
+    for raw in declared_paths:
+        path = _artifact_path(root, raw)
+        if path.exists():
+            if not path.is_file():
+                raise WorkflowExecutionError(f"declared artifact is not a file: {raw}")
+            path.unlink()
+    scan_root = _execution_scope(root, declared_paths)
+    before = _snapshot_files(scan_root, repo_root=root)
+    environment = {
+        key: os.environ[key]
+        for key in record["environment"]["inherit"]
+        if key in os.environ
+    }
+    environment.update(record["environment"]["fixed"])
+    python_paths = record["environment"]["python_paths"]
+    if python_paths:
+        environment["PYTHONPATH"] = os.pathsep.join(python_paths)
+    cwd = root if record["cwd"] == "." else root / record["cwd"]
+    command = [sys.executable, "-m", *record["argv"]]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=environment,
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorkflowExecutionError(
+            f"workflow {record['id']} exceeded the 120-second execution limit"
+        ) from exc
+    if completed.returncode != record["expected_exit_code"]:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise WorkflowExecutionError(
+            f"workflow {record['id']} exit code {completed.returncode} != "
+            f"{record['expected_exit_code']}: {detail}"
+        )
+    after = _snapshot_files(scan_root, repo_root=root)
+    changed = {
+        path for path in set(before) | set(after) if before.get(path) != after.get(path)
+    }
+    undeclared = changed - declared_paths
+    if undeclared:
+        raise WorkflowExecutionError(
+            f"workflow {record['id']} produced undeclared outputs: {sorted(undeclared)}"
+        )
+    evidence = [
+        item
+        for artifact in record["expected_artifacts"]
+        if (item := _verify_artifact(root, artifact)) is not None
+    ]
+    return {
+        "workflow_id": record["id"],
+        "kind": record["kind"],
+        "expected_exit_code": record["expected_exit_code"],
+        "actual_exit_code": completed.returncode,
+        "executor": record["executor"],
+        "argv": list(record["argv"]),
+        "cwd": record["cwd"],
+        "artifacts": evidence,
+    }
+
+
+def execute_all(
+    repo_root: Path,
+    *,
+    report_path: Path = DEFAULT_REPORT,
+    require_clean: bool = True,
+) -> dict[str, Any]:
+    """Execute every available record and write canonical aggregate evidence."""
+    from scripts import companion_catalog
+
+    root = repo_root.resolve()
+    catalog = companion_catalog.build_catalog(root, require_clean=require_clean)
+    schema = json.loads(
+        (root / "docs/api/contracts/upstreamdrift-companion-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    jsonschema.Draft202012Validator(schema).validate(catalog)
+    records = catalog["workflows"]
+    source_commit = catalog["source"]["commit"]
+    development_skipped = ["companion-export"] if not require_clean else []
+    executions = [
+        execute_record(root, record, expected_source_commit=source_commit)
+        for record in records
+        if record["availability"]["state"] == "available"
+        and record["id"] not in development_skipped
+    ]
+    registry_input = next(
+        item
+        for item in catalog["source"]["inputs"]
+        if item["path"] == REGISTRY_PATH.as_posix()
+    )
+    report = {
+        "report_version": "1.0.0",
+        "source_commit": source_commit,
+        "registry_path": REGISTRY_PATH.as_posix(),
+        "registry_sha256": registry_input["sha256"],
+        "executed_workflow_ids": [row["workflow_id"] for row in executions],
+        "failure_fixture_ids": [
+            row["workflow_id"] for row in executions if row["kind"] == "failure-fixture"
+        ],
+        "unavailable_workflow_ids": [
+            record["id"]
+            for record in records
+            if record["availability"]["state"] == "unavailable"
+        ],
+        "development_skipped_workflow_ids": development_skipped,
+        "executions": executions,
+    }
+    if require_clean and report_path.is_absolute():
+        raise WorkflowExecutionError("authoritative report path must be repo-relative")
+    destination = report_path if report_path.is_absolute() else root / report_path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    execute_all_parser = subparsers.add_parser("execute-all")
+    execute_all_parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    execute_parser = subparsers.add_parser("execute")
+    execute_parser.add_argument("--workflow-id", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the public fail-closed workflow executor."""
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "execute-all":
+            report = execute_all(args.repo_root, report_path=args.report)
+            sys.stdout.write(json.dumps(report, sort_keys=True) + "\n")
+            return 0
+        from scripts import companion_catalog
+
+        root = args.repo_root.resolve()
+        catalog = companion_catalog.build_catalog(root)
+        record = next(
+            (row for row in catalog["workflows"] if row["id"] == args.workflow_id),
+            None,
+        )
+        if record is None:
+            raise WorkflowContractError(f"unknown workflow ID: {args.workflow_id}")
+        evidence = execute_record(
+            root, record, expected_source_commit=catalog["source"]["commit"]
+        )
+        sys.stdout.write(json.dumps(evidence, sort_keys=True) + "\n")
+        return 0
+    except (
+        WorkflowContractError,
+        WorkflowExecutionError,
+        jsonschema.ValidationError,
+    ) as exc:
+        sys.stderr.write(f"companion workflow execution refused: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/config/companion_workflows.v1.json
+++ b/scripts/config/companion_workflows.v1.json
@@ -1,0 +1,1070 @@
+{
+  "registry_id": "upstreamdrift-companion-workflows",
+  "version": "1.0.0",
+  "workflows": [
+    {
+      "id": "companion-export",
+      "title": "Export the Exact-Revision Companion Manifest",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_catalog",
+        "--output",
+        "dist/companion-workflows/artifacts/companion-export/upstreamdrift-companion.v1.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/companion-export/upstreamdrift-companion.v1.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        },
+        {
+          "path": "dist/companion-workflows/artifacts/companion-export/upstreamdrift-companion.v1.json.sha256",
+          "type": "sha256",
+          "required": true,
+          "verification": {
+            "method": "sha256-sidecar",
+            "minimum_bytes": 70
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/adr/0043-companion-manifest-provider-authority.md",
+        "docs/operations/companion-publication.md"
+      ],
+      "program_ids": ["project_map"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "repository",
+        "fixture_paths": [
+          "docs/api/contracts/upstreamdrift-companion-v1.schema.json"
+        ],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The manifest exports software facts and does not qualify calculations, engines, or biomechanics claims."
+      ]
+    },
+    {
+      "id": "installation-verification",
+      "title": "Verify the Core Provider Installation Contract",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "installation-verification",
+        "--output",
+        "dist/companion-workflows/artifacts/installation-verification/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/installation-verification/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/user_guide/installation.md",
+        "docs/troubleshooting/installation.md"
+      ],
+      "program_ids": ["project_map"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "This CI record checks the Python floor and provider-authority imports; optional GUI and engine extras remain outside its scope."
+      ]
+    },
+    {
+      "id": "model-launch-resolution",
+      "title": "Resolve a Registered Model Launch",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "model-launch-resolution",
+        "--output",
+        "dist/companion-workflows/artifacts/model-launch-resolution/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/model-launch-resolution/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": ["docs/model_explorer/attachment-manifests.md"],
+      "program_ids": ["model_explorer"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "repository",
+        "fixture_paths": ["src/config/models.yaml"],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "Provider CI resolves the launch command headlessly and does not claim that a graphical window was visually inspected."
+      ]
+    },
+    {
+      "id": "reference-double-pendulum-simulation",
+      "title": "Run a Reference Double-Pendulum Simulation",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "reference-simulation",
+        "--output",
+        "dist/companion-workflows/artifacts/reference-double-pendulum-simulation/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/reference-double-pendulum-simulation/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": ["docs/engines/pendulum.md"],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 1e-9,
+        "relative_tolerance": 1e-9
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The short synthetic trajectory is a deterministic software example, not a fitted or validated golfer motion."
+      ]
+    },
+    {
+      "id": "reference-double-pendulum-analysis",
+      "title": "Analyze a Reference Double-Pendulum Trace",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "reference-analysis",
+        "--output",
+        "dist/companion-workflows/artifacts/reference-double-pendulum-analysis/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/reference-double-pendulum-analysis/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": ["docs/engines/pendulum.md"],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 1e-9,
+        "relative_tolerance": 1e-9
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "Tip speed and mechanical-energy change are model outputs, not independent measurements or causal evidence."
+      ]
+    },
+    {
+      "id": "launch-monitor-import-export",
+      "title": "Import and Export Canonical Launch-Monitor Data",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "launch-monitor-roundtrip",
+        "--output",
+        "dist/companion-workflows/artifacts/launch-monitor-import-export/result.json",
+        "--csv-output",
+        "dist/companion-workflows/artifacts/launch-monitor-import-export/canonical-shots.csv"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/launch-monitor-import-export/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        },
+        {
+          "path": "dist/companion-workflows/artifacts/launch-monitor-import-export/canonical-shots.csv",
+          "type": "csv",
+          "required": true,
+          "verification": {
+            "method": "csv-header",
+            "minimum_bytes": 20,
+            "required_columns": [
+              "shot_id",
+              "club_speed",
+              "ball_speed",
+              "launch_angle",
+              "spin_rate",
+              "carry_distance"
+            ]
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/user_guide/launch_monitor_analytics.md",
+        "docs/adr/0031-launch-monitor-canonical-shot-schema.md"
+      ],
+      "program_ids": ["launch_monitor_analytics"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "repository",
+        "fixture_paths": ["tests/fixtures/launch_monitor/trackman.csv"],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The two-row synthetic fixture verifies mapping and round-trip mechanics; it is not monitor calibration or population evidence."
+      ]
+    },
+    {
+      "id": "program-catalog-export",
+      "title": "Export a Program Catalog Slice",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "program-catalog-export",
+        "--output",
+        "dist/companion-workflows/artifacts/program-catalog-export/programs.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/program-catalog-export/programs.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/adr/0043-companion-manifest-provider-authority.md"
+      ],
+      "program_ids": ["project_map"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "This is a software-discovery projection and does not qualify the listed programs or their scientific outputs."
+      ]
+    },
+    {
+      "id": "zero-torque-counterfactual",
+      "title": "Evaluate the Instantaneous Zero-Torque Counterfactual",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "zero-torque-counterfactual",
+        "--output",
+        "dist/companion-workflows/artifacts/zero-torque-counterfactual/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/zero-torque-counterfactual/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/research/proximal_distal_energy_transfer/chapters/_ch04_counterfactuals.qmd",
+        "docs/engines/pendulum.md"
+      ],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 1e-9,
+        "relative_tolerance": 1e-9
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "This is an instantaneous model intervention at a fixed state, not an experimentally observed no-torque swing or a full alternative trajectory."
+      ]
+    },
+    {
+      "id": "reference-simulation-report",
+      "title": "Generate a Reference Simulation Report",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "reference-report",
+        "--output",
+        "dist/companion-workflows/artifacts/reference-simulation-report/report.md"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/reference-simulation-report/report.md",
+          "type": "markdown",
+          "required": true,
+          "verification": {
+            "method": "non-empty",
+            "minimum_bytes": 80
+          }
+        }
+      ],
+      "documentation_paths": ["docs/engines/pendulum.md"],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 1e-9,
+        "relative_tolerance": 1e-9
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The generated Markdown reports only the governed synthetic fixture and is not a scientific publication or design authority."
+      ]
+    },
+    {
+      "id": "reference-simulation-plot",
+      "title": "Generate a Reference Simulation Plot",
+      "kind": "workflow",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "reference-plot",
+        "--output",
+        "dist/companion-workflows/artifacts/reference-simulation-plot/tip-speed.png"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 0,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/reference-simulation-plot/tip-speed.png",
+          "type": "png",
+          "required": true,
+          "verification": {
+            "method": "png-signature",
+            "minimum_bytes": 1000
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/engines/pendulum.md",
+        "docs/adr/0011-plot-style-toolkit.md"
+      ],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Matplotlib with the headless Agg backend",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 1e-9,
+        "relative_tolerance": 1e-9
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The plot is a deterministic software illustration of a synthetic trace and has no subject-level inferential authority."
+      ]
+    },
+    {
+      "id": "failure-unsupported-dependency",
+      "title": "Reject an Unsupported Dependency",
+      "kind": "failure-fixture",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "unsupported-dependency",
+        "--output",
+        "dist/companion-workflows/artifacts/failure-unsupported-dependency/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 20,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/failure-unsupported-dependency/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/user_guide/installing_optional_features.md"
+      ],
+      "program_ids": ["opensim_golf"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The reserved missing package is a deterministic conformance fixture and does not report the installation state of any real optional dependency."
+      ],
+      "failure_class": "unsupported-dependency"
+    },
+    {
+      "id": "failure-bad-input",
+      "title": "Reject Invalid Pendulum Parameters",
+      "kind": "failure-fixture",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "bad-input",
+        "--output",
+        "dist/companion-workflows/artifacts/failure-bad-input/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 21,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/failure-bad-input/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": ["docs/engines/pendulum.md"],
+      "program_ids": ["pendulum_simulator"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The fixture verifies a precondition failure only and does not bound all invalid physical inputs."
+      ],
+      "failure_class": "bad-input"
+    },
+    {
+      "id": "failure-unavailable-engine",
+      "title": "Reject an Unavailable Engine Fixture",
+      "kind": "failure-fixture",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "unavailable-engine",
+        "--output",
+        "dist/companion-workflows/artifacts/failure-unavailable-engine/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 22,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/failure-unavailable-engine/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": [
+        "docs/user_guide/installing_optional_features.md"
+      ],
+      "program_ids": ["opensim_golf"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "inline",
+        "fixture_paths": [],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The reserved engine identifier is a deterministic fail-closed fixture and does not assert that a named production engine is unavailable."
+      ],
+      "failure_class": "unavailable-engine"
+    },
+    {
+      "id": "failure-stale-version",
+      "title": "Reject a Stale Companion Compatibility Version",
+      "kind": "failure-fixture",
+      "executor": "python-module",
+      "argv": [
+        "scripts.companion_workflow_tasks",
+        "stale-version",
+        "--output",
+        "dist/companion-workflows/artifacts/failure-stale-version/result.json"
+      ],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": 23,
+      "expected_artifacts": [
+        {
+          "path": "dist/companion-workflows/artifacts/failure-stale-version/result.json",
+          "type": "json",
+          "required": true,
+          "verification": {
+            "method": "json-object",
+            "minimum_bytes": 3
+          }
+        }
+      ],
+      "documentation_paths": ["docs/operations/companion-publication.md"],
+      "program_ids": ["project_map"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "supported",
+      "availability": {
+        "state": "available",
+        "reason": null
+      },
+      "determinism": {
+        "fixture_kind": "repository",
+        "fixture_paths": [
+          "docs/api/contracts/upstreamdrift-companion-compatibility-v1.json"
+        ],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "The fixture proves compatibility-policy refusal and does not declare a real historical schema version."
+      ],
+      "failure_class": "stale-version"
+    },
+    {
+      "id": "opensim-native-gui-launch",
+      "title": "Launch the Native OpenSim GUI",
+      "kind": "workflow",
+      "executor": null,
+      "argv": [],
+      "cwd": ".",
+      "environment": {
+        "inherit": [
+          "COMSPEC",
+          "HOME",
+          "LANG",
+          "LC_ALL",
+          "PATH",
+          "PATHEXT",
+          "SYSTEMROOT",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+          "WINDIR"
+        ],
+        "fixed": {
+          "MPLBACKEND": "Agg",
+          "PYTHONHASHSEED": "0",
+          "PYTHONDONTWRITEBYTECODE": "1",
+          "PYTHONUTF8": "1"
+        },
+        "python_paths": [".", "src", "src/shared/python"]
+      },
+      "expected_exit_code": null,
+      "expected_artifacts": [],
+      "documentation_paths": [
+        "docs/user_guide/installing_optional_features.md"
+      ],
+      "program_ids": ["opensim_golf"],
+      "prerequisites": [
+        "Python 3.11 or 3.12",
+        "Repository checkout at the declared source commit"
+      ],
+      "support_tier": "experimental",
+      "availability": {
+        "state": "unavailable",
+        "reason": "Core provider CI does not install or visually qualify the optional native OpenSim GUI runtime."
+      },
+      "determinism": {
+        "fixture_kind": "repository",
+        "fixture_paths": ["src/config/models.yaml"],
+        "absolute_tolerance": 0,
+        "relative_tolerance": 0
+      },
+      "verification_method": "Exact exit code plus declared artifact type, size, and SHA-256 evidence",
+      "scientific_limitations": [
+        "This record is deliberately non-executable until a separately qualified optional-runtime workflow and visual evidence authority exist."
+      ]
+    }
+  ]
+}

--- a/tests/ci/test_ci_infrastructure.py
+++ b/tests/ci/test_ci_infrastructure.py
@@ -854,6 +854,7 @@ class TestCIEnvironmentCompatibility:
             "pick-runner",
             "changed-paths",
             "code-quality",
+            "companion-workflows",
             "security-scans",
             "repo-structure-gates",
             "tests",

--- a/tests/companion/test_companion_catalog.py
+++ b/tests/companion/test_companion_catalog.py
@@ -52,6 +52,8 @@ def test_catalog_reconciles_current_registries_without_schema_count_constants(
         "program_records": 70,
         "feature_records": 41,
         "feature_surface_paths": 79,
+        "workflow_records": 15,
+        "executable_workflow_records": 14,
     }
     assert len({record["id"] for record in catalog["programs"]}) == 70
     assert len({record["id"] for record in catalog["features"]}) == 41
@@ -202,10 +204,14 @@ def test_catalog_pins_exact_provider_and_input_provenance() -> None:
     assert tools["pinned_commit"] == "cc883cbaf63157b58c71cba385a683df2762b0cb"
     assert tools["vendor_path"] == "vendor/ud-tools"
     assert {item["path"] for item in source["inputs"]} == {
+        "docs/api/contracts/upstreamdrift-companion-compatibility-v1.json",
+        "docs/api/contracts/upstreamdrift-companion-v1.schema.json",
         "pyproject.toml",
+        "scripts/config/companion_workflows.v1.json",
         "src/config/feature_parity.json",
         "src/config/launcher_manifest.json",
         "src/config/models.yaml",
+        "tests/fixtures/launch_monitor/trackman.csv",
     }
     assert all(len(item["sha256"]) == 64 for item in source["inputs"])
 

--- a/tests/companion/test_companion_workflows.py
+++ b/tests/companion/test_companion_workflows.py
@@ -1,0 +1,359 @@
+"""Governed provider-workflow contracts for companion consumers (#9190)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "docs/api/contracts/upstreamdrift-companion-v1.schema.json"
+REGISTRY_PATH = REPO_ROOT / "scripts/config/companion_workflows.v1.json"
+pytestmark = pytest.mark.unit
+
+
+def _catalog_module():
+    from scripts import companion_catalog
+
+    return companion_catalog
+
+
+def _workflow_module():
+    from scripts import companion_workflows
+
+    return companion_workflows
+
+
+def _minimal_record() -> dict[str, Any]:
+    return {
+        "id": "fixture-success",
+        "title": "Fixture Success",
+        "kind": "workflow",
+        "executor": "python-module",
+        "argv": ["scripts.companion_workflow_tasks"],
+        "cwd": ".",
+        "environment": {
+            "inherit": ["PATH"],
+            "fixed": {"PYTHONHASHSEED": "0"},
+            "python_paths": [],
+        },
+        "expected_exit_code": 0,
+        "expected_artifacts": [
+            {
+                "path": "dist/companion-workflows/artifacts/fixture-success.json",
+                "type": "json",
+                "required": True,
+                "verification": {
+                    "method": "json-object",
+                    "minimum_bytes": 3,
+                },
+            }
+        ],
+        "documentation_paths": ["docs/operations/companion-publication.md"],
+        "program_ids": ["model_explorer"],
+        "prerequisites": ["Python 3.11 or 3.12"],
+        "support_tier": "supported",
+        "availability": {"state": "available", "reason": None},
+        "determinism": {
+            "fixture_kind": "inline",
+            "fixture_paths": [],
+            "absolute_tolerance": 0.0,
+            "relative_tolerance": 0.0,
+        },
+        "verification_method": "Exact exit code and declared-artifact contract",
+        "scientific_limitations": [
+            "This workflow exercises software behavior, not scientific qualification."
+        ],
+        "source_commit": "a" * 40,
+    }
+
+
+def _registry_payload(*records: dict[str, Any]) -> bytes:
+    raw_records = []
+    for record in records:
+        raw = deepcopy(record)
+        raw.pop("source_commit", None)
+        raw_records.append(raw)
+    return json.dumps(
+        {
+            "registry_id": "upstreamdrift-companion-workflows",
+            "version": "1.0.0",
+            "workflows": raw_records,
+        }
+    ).encode()
+
+
+def test_catalog_exports_complete_governed_workflow_inventory() -> None:
+    catalog = _catalog_module().build_catalog(REPO_ROOT, require_clean=False)
+    workflows = catalog["workflows"]
+
+    available = [
+        row for row in workflows if row["availability"]["state"] == "available"
+    ]
+    successes = [row for row in available if row["kind"] == "workflow"]
+    failures = [row for row in available if row["kind"] == "failure-fixture"]
+    unavailable = [
+        row for row in workflows if row["availability"]["state"] == "unavailable"
+    ]
+
+    assert len(successes) >= 10
+    assert len(failures) == 4
+    assert {row["failure_class"] for row in failures} == {
+        "bad-input",
+        "stale-version",
+        "unavailable-engine",
+        "unsupported-dependency",
+    }
+    assert unavailable
+    assert [row["id"] for row in workflows] == sorted(row["id"] for row in workflows)
+    assert all(row["source_commit"] == catalog["source"]["commit"] for row in workflows)
+    assert all(row["scientific_limitations"] for row in workflows)
+    assert all(row["documentation_paths"] for row in workflows)
+    assert all(row["program_ids"] for row in workflows)
+
+
+def test_registry_is_an_exact_hashed_catalog_input() -> None:
+    catalog = _catalog_module().build_catalog(REPO_ROOT, require_clean=False)
+    inputs = {row["path"]: row["sha256"] for row in catalog["source"]["inputs"]}
+
+    assert REGISTRY_PATH.relative_to(REPO_ROOT).as_posix() in inputs
+    assert len(inputs[REGISTRY_PATH.relative_to(REPO_ROOT).as_posix()]) == 64
+    assert catalog["summary"]["workflow_records"] == len(catalog["workflows"])
+    assert catalog["summary"]["executable_workflow_records"] >= 14
+
+
+def test_extended_workflow_schema_is_strict_and_validates_catalog() -> None:
+    catalog = _catalog_module().build_catalog(REPO_ROOT, require_clean=False)
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.Draft202012Validator(schema).validate(catalog)
+    workflow_schema = schema["$defs"]["workflow"]
+    assert workflow_schema["additionalProperties"] is False
+    assert {
+        "executor",
+        "argv",
+        "cwd",
+        "environment",
+        "expected_artifacts",
+        "source_commit",
+        "determinism",
+        "scientific_limitations",
+    } <= set(workflow_schema["required"])
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (("executor", "shell"), "executor"),
+        (
+            ("argv", ["scripts.companion_workflow_tasks", "; rm -rf output"]),
+            "metacharacter",
+        ),
+        (
+            ("argv", ["scripts.companion_workflow_tasks", "../outside"]),
+            "traversal",
+        ),
+        (
+            ("argv", ["scripts.companion_workflow_tasks", "https://example.test/main"]),
+            "mutable external reference",
+        ),
+        (("argv", ["json.tool"]), "approved workflow boundary"),
+        (("cwd", "../outside"), "repo-relative"),
+        (
+            (
+                "expected_artifacts",
+                [
+                    {
+                        "path": "C:/outside.json",
+                        "type": "json",
+                        "required": True,
+                        "verification": {
+                            "method": "json-object",
+                            "minimum_bytes": 1,
+                        },
+                    }
+                ],
+            ),
+            "repo-relative",
+        ),
+        (("program_ids", ["dangling-program"]), "program"),
+    ],
+)
+def test_registry_rejects_unsafe_or_dangling_records(
+    mutation: tuple[str, Any], message: str
+) -> None:
+    module = _workflow_module()
+    record = _minimal_record()
+    key, value = mutation
+    record[key] = value
+    payload = _registry_payload(record)
+
+    with pytest.raises(module.WorkflowContractError, match=message):
+        module.parse_registry(
+            payload,
+            repo_root=REPO_ROOT,
+            source_commit="a" * 40,
+            program_ids={"model_explorer"},
+        )
+
+
+def test_registry_rejects_duplicate_ids_and_environment_overlap() -> None:
+    module = _workflow_module()
+    record = _minimal_record()
+    duplicate = deepcopy(record)
+    duplicate["environment"]["inherit"].append("PYTHONHASHSEED")
+    payload = _registry_payload(record, duplicate)
+
+    with pytest.raises(module.WorkflowContractError, match="environment|duplicate"):
+        module.parse_registry(
+            payload,
+            repo_root=REPO_ROOT,
+            source_commit="a" * 40,
+            program_ids={"model_explorer"},
+        )
+
+    undeclared = _minimal_record()
+    undeclared["environment"]["fixed"]["SECRET_NOT_DECLARED"] = "unsafe"
+    with pytest.raises(module.WorkflowContractError, match="environment keys"):
+        module.parse_registry(
+            _registry_payload(undeclared),
+            repo_root=REPO_ROOT,
+            source_commit="a" * 40,
+            program_ids={"model_explorer"},
+        )
+
+
+def test_executor_uses_shell_false_and_only_declared_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _workflow_module()
+    record = _minimal_record()
+    record["cwd"] = "work"
+    record["expected_artifacts"][0]["path"] = "work/result.json"
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setenv("PATH", "declared-path")
+    monkeypatch.setenv("SECRET_NOT_DECLARED", "must-not-leak")
+    observed: dict[str, Any] = {}
+
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed["command"] = command
+        observed.update(kwargs)
+        (tmp_path / "work/result.json").write_text("{}\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "ok", "")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    evidence = module.execute_record(tmp_path, record)
+
+    assert observed["shell"] is False
+    assert observed["command"] == [
+        sys.executable,
+        "-m",
+        "scripts.companion_workflow_tasks",
+    ]
+    assert observed["env"] == {"PATH": "declared-path", "PYTHONHASHSEED": "0"}
+    assert evidence["workflow_id"] == "fixture-success"
+    assert len(evidence["artifacts"][0]["sha256"]) == 64
+
+
+def test_executor_rejects_missing_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _workflow_module()
+    record = _minimal_record()
+    record["expected_artifacts"][0]["path"] = "missing.json"
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+    )
+
+    with pytest.raises(module.WorkflowExecutionError, match="missing"):
+        module.execute_record(tmp_path, record)
+
+
+def test_executor_rejects_unexpected_exit_and_undeclared_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _workflow_module()
+    record = _minimal_record()
+    record["expected_artifacts"][0]["path"] = "result.json"
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 7, "", "bad"),
+    )
+    with pytest.raises(module.WorkflowExecutionError, match="exit code"):
+        module.execute_record(tmp_path, record)
+
+    def create_extra(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        (tmp_path / "result.json").write_text("{}\n", encoding="utf-8")
+        (tmp_path / "extra.txt").write_text("undeclared\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(module.subprocess, "run", create_extra)
+    with pytest.raises(module.WorkflowExecutionError, match="undeclared"):
+        module.execute_record(tmp_path, record)
+
+
+def test_executor_refuses_unavailable_and_stale_source_records(tmp_path: Path) -> None:
+    module = _workflow_module()
+    unavailable = _minimal_record()
+    unavailable["availability"] = {
+        "state": "unavailable",
+        "reason": "Optional engine is absent",
+    }
+    unavailable["expected_exit_code"] = None
+    unavailable["expected_artifacts"] = []
+    with pytest.raises(module.WorkflowExecutionError, match="unavailable"):
+        module.execute_record(tmp_path, unavailable)
+
+    stale = _minimal_record()
+    stale["source_commit"] = "0" * 40
+    with pytest.raises(module.WorkflowExecutionError, match="source commit"):
+        module.execute_record(tmp_path, stale, expected_source_commit="a" * 40)
+
+
+def test_provider_workflows_execute_and_emit_complete_evidence(tmp_path: Path) -> None:
+    module = _workflow_module()
+    report_path = tmp_path / "execution-report.v1.json"
+
+    report = module.execute_all(REPO_ROOT, report_path=report_path, require_clean=False)
+
+    assert report_path.is_file()
+    assert (
+        report["source_commit"]
+        == _catalog_module().build_catalog(REPO_ROOT, require_clean=False)["source"][
+            "commit"
+        ]
+    )
+    assert len(report["registry_sha256"]) == 64
+    assert len(report["executed_workflow_ids"]) >= 13
+    assert len(report["failure_fixture_ids"]) == 4
+    assert report["unavailable_workflow_ids"]
+    assert report["development_skipped_workflow_ids"] == ["companion-export"]
+    assert all(row["artifacts"] for row in report["executions"])
+
+
+def test_provider_ci_executes_and_aggregates_governed_workflows() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/ci-standard.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "companion-workflows:" in workflow
+    assert "pydantic==2.12.5" in workflow
+    assert "python3 -m scripts.companion_workflows" in workflow
+    assert "--report dist/companion-workflows/execution-report.v1.json" in workflow
+    assert "upstreamdrift-companion-workflows-${{ github.sha }}" in workflow
+    quality_gate = workflow.split("  quality-gate:", maxsplit=1)[1]
+    assert "companion-workflows," in quality_gate
+    assert "needs.companion-workflows.result" in quality_gate

--- a/tests/fixtures/companion/current-v1.0.0.json
+++ b/tests/fixtures/companion/current-v1.0.0.json
@@ -43,6 +43,8 @@
     "local_model_records": 0,
     "program_records": 0,
     "feature_records": 0,
-    "feature_surface_paths": 0
+    "feature_surface_paths": 0,
+    "workflow_records": 0,
+    "executable_workflow_records": 0
   }
 }


### PR DESCRIPTION
## Summary
- define a strict, hashed 15-record companion workflow registry at exact source revisions
- execute all 14 available success and governed-failure workflows through one public shell=False executor in PR and protected-main CI
- keep the native OpenSim GUI record explicitly unavailable and separate workflow execution evidence from scientific qualification
- extend the provider schema, catalog, ADR, publication runbook, SPEC, handoff, fixtures, and contract tests

## Contract and authority boundary
- 10 successful workflows cover installation verification, launch resolution, simulation/analysis, import/export, catalog export, counterfactual behavior, report output, and plotting
- 4 deterministic nonzero-exit fixtures cover unsupported dependency, bad input, unavailable engine, and stale version
- 1 native OpenSim GUI path is non-executable until the optional runtime and capability/screenshot authority exist
- registry SHA-256: ef78695030635fbe476912ecb7f59c8cdfd303cf0c187de0d24d63e22fd6be35
- this PR supplies execution evidence only; it does not qualify calculations, engines, screenshots, or scientific claims

## Verification
- tests/companion: 57 passed
- tests/ci/test_ci_infrastructure.py: 84 passed, 1 skipped
- exact-head public CLI executed all 14 available records and produced exact-commit evidence
- local pre-push Ruff, formatting, Prettier, Bandit, pytest, title, and governance gates passed

## Supersession
This clean replacement branch is rooted directly on current protected origin/main (5c16d33764a9c11e4a0c08e902e3a64d7a58aaeb) and supersedes conflicting PR #9307.

Closes #9190