### PR TITLE
docs(adr): propose the three consolidation decisions from the launcher review (Phase B)

### DIFF
--- a/docs/adr/0045-putting-integration-one-experience-two-preserved-stacks.md
+++ b/docs/adr/0045-putting-integration-one-experience-two-preserved-stacks.md
@@ -1,0 +1,98 @@
+# ADR-0045: Putting Integration — One Experience, Two Preserved Physics Stacks
+
+- Status: Proposed
+- Date: 2026-08-30
+- Decision Makers: repo owner (approval required before any implementation)
+- Related Issues/PRs: #9143, Tools#4800 (P2/P9), Tools#4816, Tools#4819, launcher tiles `putting_green` and `rate_of_closure`
+
+## Context
+
+UpstreamDrift now carries two complete putting simulators, and a user who
+putts in both gets different answers with no explanation:
+
+| Capability    | UD `putting_green` engine                                                                | Tools putting (vendored, Impact Explorer tab)                                                                        |
+| ------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Surface model | Topography presets, grid `_surface_io` JSON, `.npy`/GeoTIFF loaders, scattered-point RBF | Parametric heightfield + grid wire `swing_sim.green_surface/1` (bilinear)                                            |
+| Roll physics  | `ball_roll_physics` — µ ≈ `0.196/stimp` × height-of-cut/condition/grain factors          | `putting/roll.py` — µ ≈ `0.559/stimp` (USGA stimpmeter geometry, 1.83 m/s release)                                   |
+| Hole capture  | Radius test + 1.5 m/s lip-out heuristic                                                  | Holmes (1991)/Penner (2002) speed-dependent effective radius                                                         |
+| Impact/stroke | None — launch state is an input                                                          | Full 2-D impact solve (aim/face/path/attack/offsets), mesh-derived putter MOI, stroke import from engines            |
+| Extras        | Practice mode, wind physics, checkpoints, API route, web page + `puttingPlayback.ts`     | Dispersion Monte Carlo, putter-fitting counterfactuals, `putting_result/2` wire, 3D playback on the shared transport |
+
+The two stacks were already bridged at the data level by Tools#4819 (P9): a
+runtime-free adapter converts UD topographies to/from the
+`swing_sim.green_surface/1` wire, refuses the non-conservative weighted-slope
+field rather than approximating it, and **gate-pins the roll-out divergence at
+a constant ratio ≈ 2.854** (the two µ-laws share the `1/stimp` form but assume
+different stimpmeter release speeds). The divergence is physics, not a bug —
+each model is internally consistent.
+
+Constraint set by the owner: **no functionality may be deleted or limited.**
+Consolidation means integration, not deprecation.
+
+## Decision
+
+Adopt a layered ownership model in which each capability has exactly one home
+and every surface reaches it through the existing wires:
+
+1. **Green authoring and terrain stay with UD `putting_green`.** Its surface
+   presets, importers (grid/`.npy`/GeoTIFF/RBF), practice mode, and wind
+   remain the authoring experience. Nothing moves out of it.
+2. **Stroke, impact, and analytics stay with Tools putting.** Impact solve,
+   putter MOI, dispersion, counterfactuals, `putting_result/2`, and 3D
+   playback remain the analytics authority. Nothing moves out of it.
+3. **The P9 wire is the only bridge.** A green authored in `putting_green`
+   (any importer) exports through the adapter into the Tools simulator; a
+   `green_surface/1` document loads into `putting_green`. Neither stack
+   imports the other's runtime.
+4. **The physics divergence becomes a user-visible, named choice instead of a
+   silent fork.** Both roll models are preserved and exposed as named,
+   provenance-carrying options — `ud-legacy-roll/1` (agronomic factors:
+   height-of-cut, condition, grain) and `usga-stimp-roll/1` (stimpmeter
+   geometry + Holmes/Penner capture) — selectable wherever a putt is
+   integrated, with the active model recorded in every result document.
+   Results from different models are never numerically compared without the
+   model names attached. Neither model is removed; the ≈2.854 gate keeps the
+   documented relationship honest.
+5. **Launcher/tile presentation:** both tiles remain. `putting_green`'s
+   description gains "green authoring, practice" framing; the Impact
+   Explorer's putting tab gains an "Import green from Putting Green…" action
+   (the adapter already exists). A later phase may add cross-links between
+   the two surfaces; neither tile is removed.
+
+## Alternatives Considered
+
+1. **Retire UD `putting_green`, keep only Tools putting.** Rejected: deletes
+   practice mode, wind, GeoTIFF/RBF import, and the web page — violates the
+   no-deletion constraint, and the authoring UX is genuinely good.
+2. **Retire Tools putting tab inside UD, keep `putting_green`.** Rejected:
+   deletes the impact solve, MOI fitting, dispersion, counterfactuals — the
+   scientific core the epics just built.
+3. **Force one µ-law.** Rejected for now: both models are defensible under
+   different assumptions; silently rewriting one would change every archived
+   result. Naming the models preserves both and makes the choice explicit.
+   A future calibration study may promote one to default — that is a
+   physics decision with its own evidence, not an architecture decision.
+4. **Merge the codebases.** Rejected: cross-repo runtime imports invert the
+   Tools-is-a-leaf dependency rule; the wire boundary is the architecture.
+
+## Consequences
+
+- Positive: zero capability loss; one bridge to maintain (already tested);
+  divergence becomes informative instead of confusing; each stack keeps its
+  release cadence.
+- Negative: two roll models remain to maintain; the model-selection surface
+  adds one concept for users ("which physics?") — mitigated by a sensible
+  default per surface (authoring surfaces default to `ud-legacy-roll/1`,
+  analytics surfaces to `usga-stimp-roll/1`, both switchable).
+- Follow-ups (each its own issue, sized after approval):
+  F1 model-name plumbing into `putting_green` results; F2 "Import green"
+  action in the Impact Explorer putting tab (both runtimes); F3 cross-links
+  between the two tiles; F4 the UD-side consumer test from #9143.
+
+## Validation
+
+- The existing P9 cross-engine gates (ratio pin, sign/monotonicity parity)
+  stay mandatory; a change in either µ-law fails them.
+- New gate with F1: every putt result document names its roll model; a
+  result without a model name is refused by the fail-closed readers.
+- No test that exists today is deleted or weakened by this ADR.

--- a/docs/adr/0046-launch-monitor-analytics-single-model-layer.md
+++ b/docs/adr/0046-launch-monitor-analytics-single-model-layer.md
@@ -1,0 +1,94 @@
+# ADR-0046: Launch-Monitor Analytics — Two Workbenches, One Model Layer
+
+- Status: Proposed
+- Date: 2026-08-30
+- Decision Makers: repo owner (approval required before any implementation)
+- Related Issues/PRs: launcher tiles `launch_monitor_analytics` and `rate_of_closure`; Tools launch-monitor epic (#4583 line); UD `src/shared/python/launch_monitor/`
+
+## Context
+
+This is the deepest duplication in the platform: two **independent,
+full-depth launch-monitor analytics stacks**, developed in parallel, with no
+shared code and no shared wire.
+
+|                      | UD stack                                                                                                                                                                                                                                                                                                                                                                                               | Tools stack (vendored)                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Model layer          | `src/shared/python/launch_monitor/` — **30 modules**: corpus, importer, schema, treatment, relationships, multivariate, modeling, comparison, dispersion, trends, longitudinal(+statistics/types), strokes_gained(+types), player_covariation(+core/types), profiles, project, outcome_proxy, conformance_bundle, dataset_reference(+contract/operations/verification), flexible_analysis, contract_v2 | `rate_of_closure/launch_monitor_*` (~12 Python modules + full TS twins): analysis(+statistics/types), canonical_v2 (+pinned golden), import, linked_scatter, longitudinal, numeric, performance, private_corpus, strokes_gained(+baseline) |
+| GUI                  | Standalone 9-tab workbench (`src/tools/launch_monitor_analytics`, 1.7k LOC): Sessions, Data Treatment, Relationships, Flexible Analysis, Models, Monitor Comparison, Dispersion, Trends, Reports                                                                                                                                                                                                       | Launch Monitor Analytics tab inside the Impact Explorer, in **both** runtimes (PyQt + React), with source-backed strokes-gained v2, dispersion, session trends, longitudinal inference                                                     |
+| Distinctives         | Monitor **comparison**, data **treatment** pipeline, flexible analysis, player covariation, dataset-reference verification                                                                                                                                                                                                                                                                             | **Cross-runtime parity with pinned goldens**, canonical v2 wire, explicit-identity projects, private-corpus boundary (no private rows in project files), linked scatter into the impact model's context                                    |
+| Verified independent | `strokes_gained.py` heads differ in structure, imports, and helpers; Tools has **no** `shared/python/launch_monitor` package; UD's tab imports only its own layer                                                                                                                                                                                                                                      |                                                                                                                                                                                                                                            |
+
+Both are good. Neither is a subset of the other. The duplication cost is
+real: a metric defined twice (strokes gained, dispersion) can silently
+diverge exactly like the putting µ-laws did, but here there is _no adapter
+and no gate_ — nothing would even reveal it.
+
+Constraint set by the owner: **no functionality may be deleted or limited.**
+
+## Decision
+
+Converge on **one model layer, two preserved workbenches**, in three
+non-destructive stages. Both GUIs survive throughout; users lose nothing at
+any stage.
+
+1. **Stage 0 — the drift gate (immediately, before any migration).**
+   Define the overlap set (strokes gained, dispersion, longitudinal trend
+   statistics) and add cross-stack consistency gates: identical synthetic
+   session in → numerically compared out, with any _legitimate_
+   methodological difference documented and pinned, exactly as the putting
+   ratio gate does. This makes the current divergence measurable before
+   anything moves.
+2. **Stage 1 — canonical model layer in Tools.** Tools is the fleet's DRY
+   leaf (UD vendors it; Gasification_Model consumes it), so the canonical
+   layer grows there, in shared code (not inside `rate_of_closure`).
+   Capabilities that exist only in UD's layer (comparison, treatment,
+   player covariation, dataset-reference verification, flexible analysis)
+   are **ported up** to the canonical layer with their tests — ported, not
+   reimplemented; UD's implementations are the reference and its authors'
+   attribution is retained. Capabilities that exist only in Tools' layer
+   (canonical v2 wire, private-corpus boundary, cross-runtime goldens)
+   are already home.
+3. **Stage 2 — both workbenches consume the canonical layer.** The UD 9-tab
+   workbench keeps its exact UI and tab set, re-pointed module-by-module at
+   the vendored canonical layer, retiring its private copy only when each
+   module's consumers are on the canonical one **and its tests pass against
+   it**. The Impact Explorer tab likewise. The UD workbench remains the
+   "deep desk" surface; the Impact Explorer tab remains the in-context
+   surface; the launcher keeps both tiles with descriptions that state the
+   relationship ("the same analytics engine").
+
+## Alternatives Considered
+
+1. **Retire the UD workbench.** Rejected: deletes monitor comparison, data
+   treatment, flexible analysis, player covariation — capabilities the
+   Tools tab does not have; violates the constraint.
+2. **Retire the Tools tab.** Rejected: deletes cross-runtime web analytics
+   entirely (the UD workbench is desktop-only), plus the private-corpus
+   boundary and pinned parity.
+3. **Keep both stacks, add only gates (stop at Stage 0).** Viable minimum,
+   and Stage 0 is valuable alone — but it locks in double maintenance of
+   30+12 modules forever. Kept as the fallback if Stage 1 stalls.
+4. **Canonical layer in UD instead of Tools.** Rejected: inverts the fleet
+   dependency direction; Gasification_Model and the web twins could not
+   reach it.
+
+## Consequences
+
+- Positive: one definition of every metric; UD-only capabilities become
+  available to the web runtime for the first time (they arrive in the
+  canonical layer's TS twins); both UIs keep their identity.
+- Negative: Stage 1 is real porting work with review load; during the
+  transition the drift gates are the safety net; vendored-pin bumps become
+  load-bearing for the UD workbench.
+- Follow-ups (own issues, sized after approval): G0 gates; G1 port plan
+  per module (an inventory table of the 30 UD modules with
+  keep-port-already-home classification); G2 re-pointing PRs per tab.
+
+## Validation
+
+- Stage 0 gates run in both repos' CI from day one.
+- Every Stage 2 re-point PR must show the tab's existing tests passing
+  against the canonical layer before the private module is removed —
+  removal of a private module with failing or skipped tab tests is the
+  explicit non-goal.
+- The launcher-manifest parity contract keeps both tiles' claims honest.

--- a/docs/adr/0047-trajectory-visualization-shared-wire-preserved-viewers.md
+++ b/docs/adr/0047-trajectory-visualization-shared-wire-preserved-viewers.md
@@ -1,0 +1,93 @@
+# ADR-0047: Trajectory Visualization — Shared Wire, Preserved Viewers
+
+- Status: Proposed
+- Date: 2026-08-30
+- Decision Makers: repo owner (approval required before any implementation)
+- Related Issues/PRs: launcher tiles `shot_tracer`, `rate_of_closure`; `ui/src/pages/BallFlight.tsx`; `src/api/routes/ball_flight.py`; Tools#4800 P8 (#4820/#4852)
+
+## Context
+
+Ball-flight trajectories are visualized in three places, powered by **two
+independent flight-model families**:
+
+| Surface                                                            | Runtime               | Physics behind it                                                                                                                                                           |
+| ------------------------------------------------------------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shot Tracer tile (`_shot_tracer_gui.py`, pyqtgraph/OpenGL)         | Qt                    | UD `shared/python/physics/flight_models.py` — Waterloo-Penner, MacDonald-Hanzely, unified launch conditions, aero-coefficient registry                                      |
+| BallFlight web page (`/ball-flight`) + `api/routes/ball_flight.py` | React                 | same UD family, via the API's model enumeration                                                                                                                             |
+| Impact Explorer Flight Explorer + 3D playback                      | Qt + React (vendored) | Tools `swing_sim.flight` — aerodynamics, capability evaluator, ground transfer, Rust fast path — plus the P8 shared playback transport (golden-pinned sample→frame mapping) |
+
+The two model families are _both legitimate research assets_: UD's implements
+named published models for comparison; Tools' is the simulation-suite
+authority wired into impact, ground, and putting. Unlike putting (P9) there
+is **no interchange wire between them** — a Shot Tracer trajectory cannot be
+replayed in the Impact Explorer's 3D playback, and an Impact Explorer flight
+cannot be overlaid against the Waterloo-Penner curve in Shot Tracer, even
+though comparing models is Shot Tracer's stated purpose.
+
+Constraint set by the owner: **no functionality may be deleted or limited.**
+
+## Decision
+
+Integrate at the **trajectory-record level**, not the viewer level. All
+three surfaces survive unchanged in identity; what they gain is the ability
+to read each other's output.
+
+1. **One trajectory interchange record.** Tools already ships the versioned,
+   fail-closed `swing_sim.delivery_trajectory/1` posture and the P8 playback
+   transport consumes retained samples. Define
+   `ball_flight_trajectory/1` in the same idiom (time-stamped samples,
+   declared frame, model provenance, byte-deterministic) as the _export
+   format of every flight producer_:
+   - UD `flight_models.FlightResult` gains `to_trajectory_record()` /
+     adapter (runtime-free, like P9's).
+   - Tools `swing_sim.flight` results likewise (largely already true —
+     retained samples drive P8 playback today).
+2. **Every viewer learns to read the record.** Shot Tracer's multi-model
+   comparison accepts imported records alongside its native models (its
+   purpose — comparison — finally spans both families); the BallFlight page
+   likewise via the API; the Impact Explorer's 3D playback replays any
+   record through the P8 transport (deterministic frames from samples is
+   already its contract).
+3. **No viewer is merged into another.** Shot Tracer stays the quick
+   compare-models tool; BallFlight stays the web-native page; the Impact
+   Explorer stays the full-suite context. Their tile descriptions state the
+   relationship. Consolidating the _rendering components_ (e.g., one Qt 3D
+   trajectory widget) is desirable engineering but explicitly deferred —
+   it is refactoring behind stable surfaces and needs no decision here.
+4. **Model families stay separate and named.** As in ADR-0045, provenance
+   travels in the record; a Waterloo-Penner curve and a `swing_sim` capability
+   flight can sit on the same axes because each is labeled, never because
+   they were forced through one implementation.
+
+## Alternatives Considered
+
+1. **Retire Shot Tracer into the Impact Explorer.** Rejected: deletes the
+   lightweight compare-published-models workflow and its OpenGL view;
+   violates the constraint.
+2. **Port UD's named models into `swing_sim.flight`.** Attractive later
+   (one registry), but it is a physics-porting project with validation
+   burden; the record-level integration delivers the user value (cross
+   viewing/comparison) without it. Revisit after the record exists.
+3. **Do nothing.** Rejected: three viewers that cannot share data is the
+   navigation-level confusion the launcher review flagged; users reasonably
+   expect a trajectory to be portable between tiles of the same app.
+
+## Consequences
+
+- Positive: cross-family comparison becomes possible for the first time;
+  every producer gains replay in the best viewer (P8 playback); adapters are
+  runtime-free and testable exactly like P9's.
+- Negative: one more versioned wire to maintain; three import surfaces to
+  wire up (each small).
+- Follow-ups (own issues, sized after approval): H1 the record + UD adapter
+  with cross-family gates (analytic: identical launch conditions produce
+  same-order carry; provenance mandatory); H2 Shot Tracer import; H3
+  BallFlight page import; H4 Impact Explorer playback import.
+
+## Validation
+
+- H1's gates mirror P9's posture: byte-deterministic round trip, refusal of
+  unknown fields, documented (not reconciled) model differences.
+- A record produced by each family must replay in all three viewers in CI
+  (headless probe for Qt surfaces, vitest for web).
+- No existing viewer test is deleted or weakened.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,44 +11,47 @@ This directory tracks architecture-impacting decisions for UpstreamDrift.
 
 ## Index
 
-| ADR                                                           | Title                                                                             | Status   | Date       |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- | ---------- |
-| [0001](0001-fastapi-local-first-api.md)                       | FastAPI for Local-First API Design                                                | Accepted | 2026-02-18 |
-| [0002](0002-physics-engine-plugin-architecture.md)            | Physics Engine Plugin Architecture                                                | Accepted | 2026-02-18 |
-| [0003](0003-websocket-realtime-simulation.md)                 | WebSocket Protocol for Real-Time Simulation                                       | Accepted | 2026-02-18 |
-| [0004](0004-launcher-provider-migration.md)                   | Launcher Provider Migration Modes and Legacy Deprecation Policy                   | Accepted | 2026-04-08 |
-| [0005](0005-rust-tools-core-git-dependency.md)                | Pin `tools-core` as a Git Dependency                                              | Accepted | 2026-04-23 |
-| [0006](0006-multi-source-motion-targets.md)                   | Multi-Source Motion Targets                                                       | Accepted | 2026-05-08 |
-| [0007](0007-motion-pipeline-architecture.md)                  | Motion Pipeline Architecture (CIR)                                                | Proposed | 2026-05-08 |
-| [0012](0012-canonical-pose-interchange.md)                    | Canonical Pose Interchange                                                        | Accepted | 2026-05-09 |
-| [0013](0013-launcher-composability.md)                        | Launcher Composability — Embeddable-tool contract and IPC layer                   | Accepted | 2026-05-09 |
-| [0017](0017-sidekick-agentic-action-layer.md)                 | Sidekick agentic action layer                                                     | Accepted | 2026-05-22 |
-| [0018](0018-standalone-sidekick.md)                           | Standalone Sidekick Application                                                   | Accepted | 2026-05-23 |
-| [0019](0019-mission-drift-calculators.md)                     | Mission-Drift Calculators                                                         | Accepted | 2026-04-25 |
-| [0020](0020-canonical-urdf-subsystem.md)                      | Canonical URDF subsystem                                                          | Accepted | 2026-05-08 |
-| [0021](0021-container-strategy.md)                            | Container Strategy — Three-Dockerfile Policy                                      | Accepted | 2026-05-25 |
-| [0022](0022-chat-sidekick-boundary.md)                        | Chat Sidekick Boundary                                                            | Accepted | 2026-06-12 |
-| [0023](0023-mujoco-warp-backend.md)                           | MuJoCo Warp GPU + MuJoCo CPU backends behind one Protocol                         | Accepted | 2026-05-29 |
-| [0024](0024-differentiable-backend.md)                        | Differentiable backend — MJX (JAX) vs custom Warp kernels                         | Accepted | 2026-05-29 |
-| [0025](0025-jaxsim-backend-home.md)                           | JaxSim Backend Home                                                               | Accepted | 2026-05-30 |
-| [0026](0026-canonical-dynamic-state-v2.md)                    | Canonical Dynamic State v2                                                        | Accepted | 2026-05-31 |
-| [0027](0027-canonical-viewport-backend.md)                    | Canonical 3D Viewport Backend (Rerun export follow-up executed 2026-08-08, #8405) | Accepted | 2026-05-31 |
-| [0028](0028-react-tauri-launcher-parity.md)                   | React/Tauri launcher parity model                                                 | Accepted | 2026-06-10 |
-| [0030](0030-c3d-viewer-renderer-backend.md)                   | C3D Viewer Renderer Backend                                                       | Accepted | 2026-06-10 |
-| [0031](0031-launch-monitor-canonical-shot-schema.md)          | Canonical Launch Monitor Shot Schema                                              | Accepted | 2026-08-04 |
-| [0032](0032-bunkershot3d-club-design-architecture.md)         | BunkerShot3D as a Multi-Fidelity Club-Design Tool                                 | Accepted | 2026-08-13 |
-| [0033](0033-bunkershot3d-sand-field-tier.md)                  | Sand-Field Visualization Tier for BunkerShot3D                                    | Proposed | 2026-08-16 |
-| [0034](0034-launch-monitor-analysis-contract-v2.md)           | Launch Monitor Analysis Contract V2                                               | Accepted | 2026-08-19 |
-| [0035](0035-source-backed-strokes-gained-contract.md)         | Source-Backed Strokes-Gained Contract                                             | Accepted | 2026-08-20 |
-| [0036](0036-launch-monitor-identity-boundaries.md)            | Launch Monitor Player, Session, and Order Identity Boundaries                     | Accepted | 2026-08-20 |
-| [0037](0037-immutable-launch-monitor-dataset-jobs.md)         | Immutable Launch-Monitor Dataset Jobs                                             | Accepted | 2026-08-20 |
-| [0038](0038-launch-monitor-player-covariation-contract.md)    | Canonical Launch Monitor Player Covariation Contract                              | Accepted | 2026-08-20 |
-| [0039](0039-attested-launch-monitor-longitudinal-sessions.md) | Attested Launch Monitor Longitudinal Sessions                                     | Accepted | 2026-08-20 |
-| [0040](0040-data-free-launch-monitor-conformance-bundle.md)   | Data-Free Launch-Monitor Conformance Bundle                                       | Accepted | 2026-08-21 |
-| [0041](0041-markerless-mocap-consumer-authority.md)           | Markerless Mocap Consumer Authority                                               | Accepted | 2026-08-25 |
-| [0042](0042-engineering-design-manual-authority.md)           | Engineering Design Manual Authority and Release Boundary                          | Accepted | 2026-08-25 |
-| [0043](0043-companion-manifest-provider-authority.md)         | Companion Manifest Provider Authority                                             | Accepted | 2026-08-28 |
-| [0044](0044-out-of-plane-fidelity-for-bunkershot3d.md)        | Out-of-Plane Fidelity for BunkerShot3D                                            | Proposed | 2026-08-29 |
+| ADR                                                                     | Title                                                                             | Status   | Date       |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- | ---------- |
+| [0001](0001-fastapi-local-first-api.md)                                 | FastAPI for Local-First API Design                                                | Accepted | 2026-02-18 |
+| [0002](0002-physics-engine-plugin-architecture.md)                      | Physics Engine Plugin Architecture                                                | Accepted | 2026-02-18 |
+| [0003](0003-websocket-realtime-simulation.md)                           | WebSocket Protocol for Real-Time Simulation                                       | Accepted | 2026-02-18 |
+| [0004](0004-launcher-provider-migration.md)                             | Launcher Provider Migration Modes and Legacy Deprecation Policy                   | Accepted | 2026-04-08 |
+| [0005](0005-rust-tools-core-git-dependency.md)                          | Pin `tools-core` as a Git Dependency                                              | Accepted | 2026-04-23 |
+| [0006](0006-multi-source-motion-targets.md)                             | Multi-Source Motion Targets                                                       | Accepted | 2026-05-08 |
+| [0007](0007-motion-pipeline-architecture.md)                            | Motion Pipeline Architecture (CIR)                                                | Proposed | 2026-05-08 |
+| [0012](0012-canonical-pose-interchange.md)                              | Canonical Pose Interchange                                                        | Accepted | 2026-05-09 |
+| [0013](0013-launcher-composability.md)                                  | Launcher Composability — Embeddable-tool contract and IPC layer                   | Accepted | 2026-05-09 |
+| [0017](0017-sidekick-agentic-action-layer.md)                           | Sidekick agentic action layer                                                     | Accepted | 2026-05-22 |
+| [0018](0018-standalone-sidekick.md)                                     | Standalone Sidekick Application                                                   | Accepted | 2026-05-23 |
+| [0019](0019-mission-drift-calculators.md)                               | Mission-Drift Calculators                                                         | Accepted | 2026-04-25 |
+| [0020](0020-canonical-urdf-subsystem.md)                                | Canonical URDF subsystem                                                          | Accepted | 2026-05-08 |
+| [0021](0021-container-strategy.md)                                      | Container Strategy — Three-Dockerfile Policy                                      | Accepted | 2026-05-25 |
+| [0022](0022-chat-sidekick-boundary.md)                                  | Chat Sidekick Boundary                                                            | Accepted | 2026-06-12 |
+| [0023](0023-mujoco-warp-backend.md)                                     | MuJoCo Warp GPU + MuJoCo CPU backends behind one Protocol                         | Accepted | 2026-05-29 |
+| [0024](0024-differentiable-backend.md)                                  | Differentiable backend — MJX (JAX) vs custom Warp kernels                         | Accepted | 2026-05-29 |
+| [0025](0025-jaxsim-backend-home.md)                                     | JaxSim Backend Home                                                               | Accepted | 2026-05-30 |
+| [0026](0026-canonical-dynamic-state-v2.md)                              | Canonical Dynamic State v2                                                        | Accepted | 2026-05-31 |
+| [0027](0027-canonical-viewport-backend.md)                              | Canonical 3D Viewport Backend (Rerun export follow-up executed 2026-08-08, #8405) | Accepted | 2026-05-31 |
+| [0028](0028-react-tauri-launcher-parity.md)                             | React/Tauri launcher parity model                                                 | Accepted | 2026-06-10 |
+| [0030](0030-c3d-viewer-renderer-backend.md)                             | C3D Viewer Renderer Backend                                                       | Accepted | 2026-06-10 |
+| [0031](0031-launch-monitor-canonical-shot-schema.md)                    | Canonical Launch Monitor Shot Schema                                              | Accepted | 2026-08-04 |
+| [0032](0032-bunkershot3d-club-design-architecture.md)                   | BunkerShot3D as a Multi-Fidelity Club-Design Tool                                 | Accepted | 2026-08-13 |
+| [0033](0033-bunkershot3d-sand-field-tier.md)                            | Sand-Field Visualization Tier for BunkerShot3D                                    | Proposed | 2026-08-16 |
+| [0034](0034-launch-monitor-analysis-contract-v2.md)                     | Launch Monitor Analysis Contract V2                                               | Accepted | 2026-08-19 |
+| [0035](0035-source-backed-strokes-gained-contract.md)                   | Source-Backed Strokes-Gained Contract                                             | Accepted | 2026-08-20 |
+| [0036](0036-launch-monitor-identity-boundaries.md)                      | Launch Monitor Player, Session, and Order Identity Boundaries                     | Accepted | 2026-08-20 |
+| [0037](0037-immutable-launch-monitor-dataset-jobs.md)                   | Immutable Launch-Monitor Dataset Jobs                                             | Accepted | 2026-08-20 |
+| [0038](0038-launch-monitor-player-covariation-contract.md)              | Canonical Launch Monitor Player Covariation Contract                              | Accepted | 2026-08-20 |
+| [0039](0039-attested-launch-monitor-longitudinal-sessions.md)           | Attested Launch Monitor Longitudinal Sessions                                     | Accepted | 2026-08-20 |
+| [0040](0040-data-free-launch-monitor-conformance-bundle.md)             | Data-Free Launch-Monitor Conformance Bundle                                       | Accepted | 2026-08-21 |
+| [0041](0041-markerless-mocap-consumer-authority.md)                     | Markerless Mocap Consumer Authority                                               | Accepted | 2026-08-25 |
+| [0042](0042-engineering-design-manual-authority.md)                     | Engineering Design Manual Authority and Release Boundary                          | Accepted | 2026-08-25 |
+| [0043](0043-companion-manifest-provider-authority.md)                   | Companion Manifest Provider Authority                                             | Accepted | 2026-08-28 |
+| [0044](0044-out-of-plane-fidelity-for-bunkershot3d.md)                  | Out-of-Plane Fidelity for BunkerShot3D                                            | Proposed | 2026-08-29 |
+| [0045](0045-putting-integration-one-experience-two-preserved-stacks.md) | Putting Integration — One Experience, Two Preserved Physics Stacks                | Proposed | 2026-08-30 |
+| [0046](0046-launch-monitor-analytics-single-model-layer.md)             | Launch-Monitor Analytics — Two Workbenches, One Model Layer                       | Proposed | 2026-08-30 |
+| [0047](0047-trajectory-visualization-shared-wire-preserved-viewers.md)  | Trajectory Visualization — Shared Wire, Preserved Viewers                         | Proposed | 2026-08-30 |
 
 Note: ADR 0013 was amended on 2026-05-31 to document the CC-32
 canonical-core app-shell registry reuse of the embeddable-tool contract.


### PR DESCRIPTION
Phase B of the user-approved launcher review. Three ADRs, all **Status: Proposed** — no implementation until the owner accepts each. Governing constraint, stated in every doc: **no functionality is deleted or limited**; every redundancy resolves by integration.

| ADR | Area | Shape of the decision |
|---|---|---|
| [0045](docs/adr/0045-putting-integration-one-experience-two-preserved-stacks.md) | Two putting simulators | Green authoring stays with `putting_green`; stroke/impact/analytics with the vendored Tools stack; the tested P9 wire is the only bridge; **both roll models survive as named, provenance-carrying choices** (`ud-legacy-roll/1` vs `usga-stimp-roll/1`) instead of a silent ×2.854 fork |
| [0046](docs/adr/0046-launch-monitor-analytics-single-model-layer.md) | Two launch-monitor stacks (30 UD modules + 12 Tools modules, zero shared code — the deepest duplication found) | **Stage 0: drift gates first**, making today's divergence measurable before anything moves; then one canonical model layer in Tools with UD-only capabilities **ported up** (comparison, treatment, covariation, flexible analysis); both workbenches preserved and re-pointed module-by-module, each removal gated on its consumer's tests passing against the canonical layer |
| [0047](docs/adr/0047-trajectory-visualization-shared-wire-preserved-viewers.md) | Two flight-model families, three viewers, no interchange | Integrate at the **record level**: `ball_flight_trajectory/1` in the P9 idiom, every producer exports it, every viewer reads it — cross-family comparison becomes possible for the first time; no viewer is merged away |

Evidence in each ADR is measured, not assumed: the module inventories, the tab sets, the verified-independent `strokes_gained` implementations, the µ-law ratio pin from #4819, and the flight-model class rosters.

Merging this PR records the proposals; **accepting each ADR is a separate owner decision**, after which its follow-ups get sized as individual issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)