### PR TITLE
fix(tests): correct stale wall_clock_s assertion in OpenSim SimOut test

### DIFF
--- a/tests/test_opensim_simulate.py
+++ b/tests/test_opensim_simulate.py
@@ -216,7 +216,7 @@ class TestSimulateWithCoefficients:
         assert out.clubhead.shape == (n_samples, 3)
         assert out.club_quat.shape == (n_samples, 4)
         assert isinstance(out.solver_status, str)
-        assert out.wall_clock_s >= 0.0
+        assert out.duration_s >= 0.0
 
     def test_solver_status_success_for_nominal_inputs(
         self,


### PR DESCRIPTION
## Summary
- `test_zero_theta_returns_canonical_simout` asserted `out.wall_clock_s`, a field that has never existed on `SimOut`
- `SimOut`'s wall-clock timing field is `duration_s` (see its docstring and `TestSimOutSchema._make_simout`, which Drake's parity tests also use)
- Same copy-paste-stale-assertion pattern as the one fixed in `tests/motion_matching/mujoco_mjcf/test_simulate.py` (#9366)

## Test plan
- [x] `python3 -m ruff check tests/test_opensim_simulate.py` — passes
- [x] `python3 -m ruff format --check tests/test_opensim_simulate.py` — passes
- [x] `python3 -m pytest tests/test_opensim_simulate.py -v` — 13 passed, 6 skipped (OpenSim bindings not installed locally; these were skipping before this change too)
- [x] Confirmed via `SimOut.__dataclass_fields__` that `wall_clock_s` was never a valid attribute, only `duration_s`
- [x] Local pre-push hooks (ruff, mypy, bandit, pytest-unit) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)