### PR TITLE
docs(launcher, ADR-0045 F3): cross-link the putting tiles

### DIFF
--- a/src/config/launcher_manifest.json
+++ b/src/config/launcher_manifest.json
@@ -176,7 +176,7 @@
     {
       "id": "putting_green",
       "name": "Putting Green",
-      "description": "Realistic putting green simulation with ball rolling physics",
+      "description": "Author and practice on realistic greens: surface presets, terrain import, wind, and ball-roll physics (ud-legacy-roll/1). Greens export to the Impact Explorer's putting analytics via the shared green-surface wire.",
       "category": "simulation",
       "type": "putting_green",
       "path": "src/engines/physics_engines/putting_green/python/simulator.py",
@@ -351,7 +351,7 @@
     {
       "id": "rate_of_closure",
       "name": "Rate of Closure Impact Explorer",
-      "description": "Quantifies how a rotating clubhead's impact-point delivery differs from the tracked reference point (COM or geometric center)",
+      "description": "Quantifies how a rotating clubhead's impact-point delivery differs from the tracked reference point (COM or geometric center). Putting analytics accepts greens authored in Putting Green.",
       "category": "biomechanics",
       "type": "special_app",
       "path": "src/rate_of_closure/launch_pyqt6.py",


### PR DESCRIPTION
## Summary
- Updates putting_green tile description to document green authoring, practice mode, and export to Impact Explorer analytics
- Appends to rate_of_closure tile description: "Putting analytics accepts greens authored in Putting Green."

## Tile Descriptions Updated

**putting_green:**
"Author and practice on realistic greens: surface presets, terrain import, wind, and ball-roll physics (ud-legacy-roll/1). Greens export to the Impact Explorer's putting analytics via the shared green-surface wire."

**rate_of_closure:**
"Quantifies how a rotating clubhead's impact-point delivery differs from the tracked reference point (COM or geometric center). Putting analytics accepts greens authored in Putting Green."

## Test Results
- launcher_manifest: 9 test suites (47 tests)
- feature_parity: 1 test suite (1 test)
- **Total: 121 tests passed in 12.62s**

Closes #9345