### PR TITLE
fix(launchers): make skeleton card pulse animate and stop cleanly

### DIFF
--- a/src/launchers/model_card.py
+++ b/src/launchers/model_card.py
@@ -15,6 +15,7 @@ from PyQt6.QtCore import (
     QMimeData,
     QPoint,
     QPropertyAnimation,
+    QSequentialAnimationGroup,
     Qt,
 )
 from PyQt6.QtGui import (
@@ -30,6 +31,7 @@ from PyQt6.QtWidgets import (
     QApplication,
     QFrame,
     QGraphicsDropShadowEffect,
+    QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -131,16 +133,31 @@ class SkeletonCard(QFrame):
             }
         """)
 
-        self.effect = QGraphicsDropShadowEffect(self)
-        self.effect.setBlurRadius(20)
-        self.effect.setColor(QColor(0, 0, 0, 80))
+        # Qt only allows one QGraphicsEffect per widget, and a real pulse
+        # needs a QGraphicsOpacityEffect (setWindowOpacity() is a no-op on
+        # a non top-level widget -- issue #8906), so the opacity effect
+        # replaces the drop shadow as the card's active effect.
+        self.effect = QGraphicsOpacityEffect(self)
+        self.effect.setOpacity(0.35)
         self.setGraphicsEffect(self.effect)
 
-        self._pulse_opacity: float = 0.3
-        self._anim = QPropertyAnimation(self, b"pulseOpacity")
-        self._anim.setDuration(1000)
-        self._anim.setStartValue(0.3)
-        self._anim.setEndValue(0.3)
+        self._pulse_opacity: float = 0.35
+
+        pulse_up = QPropertyAnimation(self, b"pulseOpacity")
+        pulse_up.setDuration(1000)
+        pulse_up.setStartValue(0.35)
+        pulse_up.setEndValue(0.85)
+        pulse_up.setEasingCurve(QEasingCurve.Type.InOutSine)
+
+        pulse_down = QPropertyAnimation(self, b"pulseOpacity")
+        pulse_down.setDuration(1000)
+        pulse_down.setStartValue(0.85)
+        pulse_down.setEndValue(0.35)
+        pulse_down.setEasingCurve(QEasingCurve.Type.InOutSine)
+
+        self._anim = QSequentialAnimationGroup(self)
+        self._anim.addAnimation(pulse_up)
+        self._anim.addAnimation(pulse_down)
         self._anim.setLoopCount(-1)
         self._anim.start()
 
@@ -151,7 +168,17 @@ class SkeletonCard(QFrame):
     @pulseOpacity.setter  # type: ignore[no-redef]
     def pulseOpacity(self, value: float) -> None:
         self._pulse_opacity = value
-        self.setWindowOpacity(value)
+        self.effect.setOpacity(value)
+
+    def hideEvent(self, event: QEvent | None) -> None:
+        """Stop the pulse animation once the skeleton is hidden.
+
+        Without this, `_anim`'s loop-forever animation keeps running after
+        the card is torn down (e.g. by `_rebuild_grid`'s grid-teardown
+        loop), leaking a timer for the lifetime of the process (#8906).
+        """
+        self._anim.stop()
+        super().hideEvent(event)
 
 
 class DraggableModelCard(QFrame):

--- a/src/launchers/upstream_drift_launcher.py
+++ b/src/launchers/upstream_drift_launcher.py
@@ -557,6 +557,10 @@ class UpstreamDriftLauncher(QMainWindow):
                 item = self.grid_layout.takeAt(0)
                 widget = item.widget() if item is not None else None
                 if widget is not None:
+                    # Hide before deleteLater() so widgets that stop
+                    # per-widget resources in hideEvent (e.g. SkeletonCard's
+                    # pulse animation, #8906) actually get a chance to.
+                    widget.hide()
                     widget.deleteLater()
 
             _SkeletonCard: Any = None

--- a/tests/unit/launchers/test_model_card_skeleton.py
+++ b/tests/unit/launchers/test_model_card_skeleton.py
@@ -1,6 +1,10 @@
+import pytest
+from PyQt6.QtWidgets import QGraphicsOpacityEffect
+
 from src.launchers.model_card import SkeletonCard
 
 
+@pytest.mark.unit
 def test_skeleton_card_initialization(qapp) -> None:
     """Test that SkeletonCard initializes with correct dimensions and effects."""
     card = SkeletonCard()
@@ -8,13 +12,63 @@ def test_skeleton_card_initialization(qapp) -> None:
     assert card.objectName() == "SkeletonCard"
     assert card.minimumSize().width() == 180
     assert card.minimumSize().height() == 240
-    assert card.graphicsEffect() is not None
 
-    # Check Animation
+    # The pulse must be driven by a QGraphicsOpacityEffect installed on the
+    # frame itself -- setWindowOpacity() is a no-op on a non top-level
+    # widget (issue #8906).
+    effect = card.graphicsEffect()
+    assert isinstance(effect, QGraphicsOpacityEffect)
+
+
+@pytest.mark.unit
+def test_skeleton_card_animation_has_distinct_endpoints(qapp) -> None:
+    """The pulse animation must actually move between two opacity values.
+
+    Regression test for issue #8906: the original animation set both
+    ``startValue`` and ``endValue`` to 0.3, making the "pulse" a
+    mathematical no-op.
+    """
+    card = SkeletonCard()
+
     assert hasattr(card, "_anim")
     anim = card._anim
-    assert anim.propertyName() == b"pulseOpacity"
-    assert anim.duration() == 1000
-    assert anim.startValue() == 0.3
-    assert anim.endValue() == 0.3
     assert anim.loopCount() == -1
+
+    # Ping-ponging animation group: one leg growing, one leg shrinking,
+    # with distinct, non-equal endpoints.
+    assert anim.animationCount() == 2
+    forward = anim.animationAt(0)
+    backward = anim.animationAt(1)
+
+    assert forward.propertyName() == b"pulseOpacity"
+    assert backward.propertyName() == b"pulseOpacity"
+    assert forward.startValue() != forward.endValue()
+    assert forward.startValue() == pytest.approx(backward.endValue())
+    assert forward.endValue() == pytest.approx(backward.startValue())
+
+
+@pytest.mark.unit
+def test_skeleton_card_pulse_opacity_setter_updates_effect(qapp) -> None:
+    """The pulseOpacity property setter must write through to the
+    QGraphicsOpacityEffect instead of calling the no-op setWindowOpacity().
+    """
+    card = SkeletonCard()
+
+    card.pulseOpacity = 0.6
+
+    assert card.pulseOpacity == pytest.approx(0.6)
+    assert card.graphicsEffect().opacity() == pytest.approx(0.6)
+
+
+@pytest.mark.unit
+def test_skeleton_card_stops_animation_on_hide(qapp) -> None:
+    """Hiding a skeleton card must stop its animation so it doesn't leak a
+    forever-running timer once the card is torn down (issue #8906).
+    """
+    card = SkeletonCard()
+    card.show()
+    assert card._anim.state() == card._anim.State.Running
+
+    card.hide()
+
+    assert card._anim.state() == card._anim.State.Stopped


### PR DESCRIPTION
## Summary
- `SkeletonCard`'s loading-state pulse animated between identical start/end opacity values (0.3 -> 0.3), a mathematical no-op, and drove the value through `setWindowOpacity()`, which Qt only applies to top-level windows -- silently discarded on this child widget.
- The animation also looped forever with no teardown path, leaking a running timer for every skeleton card once the real grid loaded.

## Fix
- Replace the drop-shadow effect with a `QGraphicsOpacityEffect` (Qt allows only one `QGraphicsEffect` per widget) and drive it from the `pulseOpacity` property setter instead of the no-op `setWindowOpacity()`.
- Ping-pong between distinct opacity endpoints (0.35 <-> 0.85) via a `QSequentialAnimationGroup` instead of a single degenerate animation.
- Stop the animation in `hideEvent`, and hide grid-teardown widgets before `deleteLater()` in `_rebuild_grid` so `hideEvent` actually fires before the widget is destroyed.

Fixes #8906

## Test plan
- [x] `tests/unit/launchers/test_model_card_skeleton.py` (updated + 3 new regression tests: distinct animation endpoints, setter writes through to the effect, animation stops on hide)
- [x] `python -m pytest tests/launchers/test_model_card.py tests/launchers/test_model_card_status.py tests/launchers/test_model_card_tile_scale.py` (38 passed, 1 pre-existing unrelated failure deselected and confirmed to also fail on main)
- [x] `ruff check` / `ruff format --check` on changed files