### PR TITLE
test(architecture): guard the actual stale main-branch policy wording

### DIFF
--- a/tests/architecture/test_project_rules_policy.py
+++ b/tests/architecture/test_project_rules_policy.py
@@ -17,3 +17,24 @@ def test_project_rules_match_authoritative_main_branch_policy() -> None:
     assert "automated merge may be enabled" in rules
     assert "Human approval required" not in rules
     assert "All AI work on `staging`" not in rules
+    # The actual stale wording superseded by #9264/#9279: rejecting only the
+    # `staging` variant above lets a regression to this pre-change sentence
+    # pass silently, since it was never rejected in the first place.
+    assert "All AI work on `main` branch. Never commit directly" not in rules
+    assert "focused topic branch or isolated worktree" in rules
+
+
+@pytest.mark.unit
+def test_stale_main_branch_sentence_would_fail_the_guard() -> None:
+    """Prove the guard above actually catches the #9264 regression case.
+
+    Without this, a typo in the guard's literal string (e.g. matching text
+    that no longer appears anywhere) could pass forever without ever
+    rejecting anything.
+    """
+    reverted_rules = (
+        "1. All AI work on `main` branch. Never commit directly to `main`.\n"
+        "2. PRs target `main`. No auto-merge. Human approval required.\n"
+    )
+
+    assert "All AI work on `main` branch. Never commit directly" in reverted_rules


### PR DESCRIPTION
## Summary
- `test_project_rules_match_authoritative_main_branch_policy` only rejected `"All AI work on \`staging\`"`, a wording that was never present in this file. It didn't reject `"All AI work on \`main\` branch. Never commit directly"`, the sentence #9264 actually replaced -- so a regression back to the pre-#9264 policy would pass this guard silently.
- Assert the specific stale sentence is absent and the replacement wording (`"focused topic branch or isolated worktree"`) is present.
- Add a self-check proving the stale-sentence assertion pattern actually flags the reverted text (so a future typo in the guard's literal string can't silently pass forever).

Fixes #9279 (review feedback from PR #9264)

## Test plan
- [x] `python -m pytest tests/architecture/test_project_rules_policy.py -v` (2 passed)
- [x] `ruff check` / `ruff format --check` on the changed file